### PR TITLE
Add publicly available image to DockerHub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 .PHONY: build deploy
 
-build:
+build: 
 	go install ./cmd/manager
 
 build-image: 
-	operator-sdk build kabanero-operator:latest
+	operator-sdk build kabanero/kabanero-operator:latest
 
 generate:
 	operator-sdk generate k8s
@@ -14,7 +14,7 @@ install:
 	
 deploy: 
 	kubectl create namespace kabanero || true
-	kubectl -n kabanero apply -f deploy/dependencies.yaml
+	kubectl -n kabanero apply -f deploy/
 
 dependencies:
 	dep ensure

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ deploy:
 	kubectl -n kabanero apply -f deploy/
 
 dependencies:
-  go get -u github.com/golang/dep/cmd/dep
+	go get -u github.com/golang/dep/cmd/dep
 	dep ensure
 
 # Requires https://github.com/pmezard/licenses

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
+IMAGE ?= kabanero/kabanero-operator:latest
+
 .PHONY: build deploy
 
 build: 
 	go install ./cmd/manager
 
 build-image: 
-	operator-sdk build kabanero/kabanero-operator:latest
+	operator-sdk build ${IMAGE}
 
 generate:
 	operator-sdk generate k8s

--- a/README.md
+++ b/README.md
@@ -4,12 +4,7 @@ The Kabanero platform operator
 # Status
 [![Build Status](https://travis.com/kabanero-io/kabanero-operator.svg?token=JCs1u1Thd9q5ND5Yz3TK&branch=master)](https://travis.com/kabanero-io/kabanero-operator)
 
-
-
 ## Quickstart
-
-Currently this project must be built locally before being deployed. 
-
 Create a minikube instance: 
 ```
 minikube start --memory=8192 --cpus=4 \
@@ -24,25 +19,17 @@ curl -L https://github.com/knative/serving/releases/download/v0.4.0/istio.yaml \
   | kubectl apply --filename -
 ```
 
-Target Docker for builds:
-```
-eval $(minikube docker-env)
-```
-
-## Run the Operator Directly
+### Run the Operator Directly
 ```
 # Create Kabanero CRDs
 make install
 
 # Deploy the CRDs and some of the other controllers
 make deploy
-
-# Launch the operator in the current terminal session
-operator-sdk up local --namespace kabanero
 ```
 
 
-## Deploy the sample
+### Deploy the sample
 ```
 kubectl apply -n kabanero -f config/samples/full.yaml
 ```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ curl -L https://github.com/knative/serving/releases/download/v0.4.0/istio.yaml \
   | kubectl apply --filename -
 ```
 
-### Run the Operator Directly
+### Deploy the Operator and Dependencies
 ```
 # Create Kabanero CRDs
 make install

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: kabanero-operator
           # Replace this with the built image name
-          image: quay.io/kyleschlosser/kabanero-operator
+          image: kabanero/kabanero-operator:latest
           command:
           - kabanero-operator
           imagePullPolicy: Always


### PR DESCRIPTION
The Docker image has been built and pushed to DockerHub. This pull request updates the readme and build scripts to use the new image. 