### PR TITLE
update components, patch clusterrole, workaround no such file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+# This is a workaround until manfistival can interact with the virtual file system
+
+FROM kabanero-operator:latest
+
+COPY config /config

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ build-image:
 	go get -u github.com/golang/dep/cmd/dep
 	dep ensure
 	operator-sdk build kabanero-operator:latest
+	# This is a workaround until manfistival can interact with the virtual file system
+	docker build -t kabanero-operator:latest .
 
 generate:
 	operator-sdk generate k8s

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ build:
 	go install ./cmd/manager
 
 build-image: 
+	go get -u github.com/golang/dep/cmd/dep
+	dep ensure
 	operator-sdk build kabanero-operator:latest
 
 generate:

--- a/contrib/get_dependencies.sh
+++ b/contrib/get_dependencies.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+set -Eeuox pipefail
+
 $(dirname $0)/get_knative_eventing_operator.sh
 $(dirname $0)/get_knative_serving_operator.sh
 $(dirname $0)/get_tekton_operator.sh
@@ -8,3 +11,49 @@ cat knative-serving.yaml >> $DEST; echo "---" >> $DEST
 cat tekton.yaml >> $DEST; echo "---" >> $DEST
 
 rm knative-eventing.yaml knative-serving.yaml tekton.yaml
+
+
+
+#Errata to knative ClusterRoles for OKD 3.11.0
+cat << EOF >> $DEST
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-serving-operator
+rules:
+- apiGroups:
+  - '*'
+  attributeRestrictions: null
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups: null
+  attributeRestrictions: null
+  nonResourceURLs:
+  - '*'
+  resources: []
+  verbs:
+  - '*'
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-eventing-operator
+rules:
+- apiGroups:
+  - '*'
+  attributeRestrictions: null
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups: null
+  attributeRestrictions: null
+  nonResourceURLs:
+  - '*'
+  resources: []
+  verbs:
+  - '*'
+---
+EOF

--- a/contrib/get_knative_eventing_operator.sh
+++ b/contrib/get_knative_eventing_operator.sh
@@ -1,10 +1,11 @@
 DEST=knative-eventing.yaml
 
-BASEURL=https://raw.githubusercontent.com/openshift-knative/knative-eventing-operator/master/deploy
+BASEURL=https://raw.githubusercontent.com/openshift-knative/knative-eventing-operator/v0.7.0/deploy
 $(dirname $0)/get_operator_config.sh $BASEURL $DEST
 
 curl $BASEURL/crds/eventing_v1alpha1_knativeeventing_crd.yaml -o eventing_v1alpha1_knativeeventing_crd.yaml
 cat eventing_v1alpha1_knativeeventing_crd.yaml >> $DEST; echo "---" >> $DEST
 rm eventing_v1alpha1_knativeeventing_crd.yaml
 
-sed -i '' 's/namespace: default/namespace: kabanero/' $DEST
+sed -i.bak 's/namespace: default/namespace: kabanero/g' $DEST
+rm $DEST.bak

--- a/contrib/get_knative_serving_operator.sh
+++ b/contrib/get_knative_serving_operator.sh
@@ -1,10 +1,16 @@
 DEST=knative-serving.yaml
 
-BASEURL=https://raw.githubusercontent.com/openshift-knative/knative-serving-operator/master/deploy
+BASEURL=https://raw.githubusercontent.com/knative/serving-operator/master/config/
 $(dirname $0)/get_operator_config.sh $BASEURL $DEST
 
 curl $BASEURL/crds/serving_v1alpha1_knativeserving_crd.yaml -o serving_v1alpha1_knativeserving_crd.yaml
 cat serving_v1alpha1_knativeserving_crd.yaml >> $DEST; echo "---" >> $DEST
 rm serving_v1alpha1_knativeserving_crd.yaml
 
-sed -i '' 's/namespace: default/namespace: kabanero/' $DEST
+sed -i.bak 's/namespace: default/namespace: kabanero/g' $DEST
+rm $DEST.bak
+
+
+# Use openshift-knative image until upstream image is available
+sed -i.bak 's|image: github.com/knative/serving-operator/cmd/manager|image: quay.io/openshift-knative/knative-serving-operator:v0.7.0|g' $DEST
+rm $DEST.bak

--- a/contrib/get_tekton_operator.sh
+++ b/contrib/get_tekton_operator.sh
@@ -7,4 +7,5 @@ curl $BASEURL/crds/openshift-pipelines-operator-tekton_v1alpha1_install_crd.yaml
 cat openshift-pipelines-operator-tekton_v1alpha1_install_crd.yaml >> $DEST; echo "---" >> $DEST
 rm openshift-pipelines-operator-tekton_v1alpha1_install_crd.yaml
 
-sed -i '' 's/namespace: openshift-pipelines-operator/namespace: kabanero/' $DEST
+sed -i.bak 's/namespace: openshift-pipelines-operator/namespace: kabanero/g' $DEST
+rm $DEST.bak

--- a/deploy/dependencies.yaml
+++ b/deploy/dependencies.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: knative-eventing-operator
           # Replace this with the built image name
-          image: quay.io/openshift-knative/knative-eventing-operator:v0.6.0
+          image: quay.io/openshift-knative/knative-eventing-operator:v0.7.0
           command:
           - knative-eventing-operator
           imagePullPolicy: Always
@@ -222,10 +222,8 @@ spec:
       serviceAccountName: knative-serving-operator
       containers:
         - name: knative-serving-operator
-          image: quay.io/openshift-knative/knative-serving-operator:v0.6.0
-          command:
-          - knative-serving-operator
-          imagePullPolicy: Always
+          image: quay.io/openshift-knative/knative-serving-operator:v0.7.0
+          imagePullPolicy: IfNotPresent
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -449,13 +447,15 @@ spec:
       serviceAccountName: openshift-pipelines-operator
       containers:
         - name: openshift-pipelines-operator
-          image: quay.io/openshift-pipeline/openshift-pipelines-operator:v0.3.1-2
+          image: quay.io/openshift-pipeline/openshift-pipelines-operator:v0.4.0-1
           command:
           - openshift-pipelines-operator
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE
-              value: ""
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -479,6 +479,7 @@ rules:
   - events
   - configmaps
   - secrets
+  - pods/log
   verbs:
   - '*'
 - apiGroups:
@@ -688,4 +689,44 @@ spec:
     served: true
     storage: true
 ---
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-serving-operator
+rules:
+- apiGroups:
+  - '*'
+  attributeRestrictions: null
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups: null
+  attributeRestrictions: null
+  nonResourceURLs:
+  - '*'
+  resources: []
+  verbs:
+  - '*'
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-eventing-operator
+rules:
+- apiGroups:
+  - '*'
+  attributeRestrictions: null
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups: null
+  attributeRestrictions: null
+  nonResourceURLs:
+  - '*'
+  resources: []
+  verbs:
+  - '*'
 ---


### PR DESCRIPTION
Add additional Dockerfile, using the operator-sdk build container image as an intermediate. This works around issue
https://github.com/kabanero-io/kabanero-operator/issues/23


Update the dependent operators
https://github.com/kabanero-io/kabanero-operator/issues/20


knative-eventing 0.7.0 release
knative-serving operator moved upstream, but does not have an updated published container image in the manifest, use the openshift one
tekton does not have a new tagged release, but a new operator image is published


Update the sed such that it should work on GNU sed and MacOS


Update the ClusterRole for knative eventing & serving so they function on OKD 3.11.0
As is, the operator will fail, requesting cluster-admin clusterrole
