### PR TITLE
Update role.yaml to reflect permissions for OKD 3.x

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -8,23 +8,25 @@ rules:
   - ""
   resources:
   - pods
-  - services
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - configmaps
-  - secrets
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - services
+  verbs:
+  - get
+  - create
 - apiGroups:
   - apps
   resources:
   - deployments
-  - daemonsets
   - replicasets
-  - statefulsets
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - monitoring.coreos.com
   resources:
@@ -46,4 +48,26 @@ rules:
   - '*'
   verbs:
   - '*'
+- apiGroups:
+  - tekton.dev
+  resources:
+  - installs
+  verbs:
+  - get
+  - create
+  - delete
+- apiGroups:
+  - eventing.knative.dev
+  resources:
+  - knativeeventings
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - serving.knative.dev
+  resources:
+  - knativeservings
+  verbs:
+  - get
+  - create
 ---


### PR DESCRIPTION
This is a partial implementation of issue #1.  The code annotations are not updated to generate these roles.  The roles were tested on OKD 3.11.