### PR TITLE
Activate all collections in listed repositories by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ deploy:
 
 ifeq "$(IMAGE)" "kabanero-operator:latest"
 	# No image pull policy for local image
-	sed -i '' '/imagePullPolicy/d' deploy/operator.yaml
+	sed -i '' -e 's!imagePullPolicy: Always!imagePullPolicy: Never!' deploy/operator.yaml
 else
 	# Substitute current image name
 	sed -i '' -e 's!image: kabanero-operator:latest!image: ${IMAGE}!' deploy/operator.yaml

--- a/config/samples/full.yaml
+++ b/config/samples/full.yaml
@@ -14,4 +14,4 @@ spec:
     # A list of those repositories which are searched for collections
     repositories: 
     - name: experimental
-      url: https://github.com/kabanero-io/kabanero-collection/blob/master/experimental
+      url: https://raw.githubusercontent.com/kabanero-io/kabanero-collection/master/experimental/index.yaml

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -51,11 +51,9 @@ rules:
 - apiGroups:
   - tekton.dev
   resources:
-  - installs
+  - '*'
   verbs:
-  - get
-  - create
-  - delete
+  - '*'
 - apiGroups:
   - eventing.knative.dev
   resources:

--- a/pkg/controller/collection/collection.go
+++ b/pkg/controller/collection/collection.go
@@ -6,6 +6,18 @@ type CollectionV1Index struct {
 	Collections map[string][]IndexedCollectionV1 `yaml:"projects,omitempty"`
 }
 
+// Convenience function which iterates over the complex Collections structure
+func (c *CollectionV1Index) ListCollections() []IndexedCollectionV1 {
+	all := make([]IndexedCollectionV1, 0)
+	for _, v := range c.Collections {
+		for _, colRef := range v {
+			all = append(all, colRef)
+		}
+	}
+
+	return all
+}
+
 type IndexedCollectionV1 struct {
 	Created        string   `yaml:"created,omitempty"`
 	Description    string   `yaml:"description,omitempty"`

--- a/pkg/controller/collection/resolver.go
+++ b/pkg/controller/collection/resolver.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 )
 
-func resolveIndex(url string) (*CollectionV1Index, error) {
+func ResolveIndex(url string) (*CollectionV1Index, error) {
 	if !strings.HasSuffix(url, "/index.yaml") {
 		url = url + "/index.yaml"
 	}
@@ -38,7 +38,31 @@ func resolveIndex(url string) (*CollectionV1Index, error) {
 	return &index, nil
 }
 
-func resolveCollection(urls ...string) (*CollectionV1, error) {
+func SearchCollection(collectionName string, index *CollectionV1Index) (*CollectionV1, error) {
+	//Locate the desired collection in the index
+	var collectionRef *IndexedCollectionV1
+	for _, collectionList := range index.Collections {
+		for _, _collectionRef := range collectionList {
+			if _collectionRef.Name == collectionName {
+				collectionRef = &_collectionRef
+			}
+		}
+	}
+
+	if collectionRef == nil {
+		//The collection referenced in the Collection resource has no match in the index
+		return nil, nil
+	}
+
+	collection, err := ResolveCollection(collectionRef.CollectionUrls...)
+	if err != nil {
+		return nil, err
+	}
+
+	return collection, nil
+}
+
+func ResolveCollection(urls ...string) (*CollectionV1, error) {
 	for _, url := range urls {
 		if strings.HasSuffix(url, "tar.gz") {
 			panic("No implementation for collection archives")

--- a/pkg/controller/kabaneroplatform/featured_collections.go
+++ b/pkg/controller/kabaneroplatform/featured_collections.go
@@ -1,0 +1,75 @@
+package kabaneroplatform
+
+import (
+	"context"
+	_ "fmt"
+	kabanerov1alpha1 "github.com/kabanero-io/kabanero-operator/pkg/apis/kabanero/v1alpha1"
+	"github.com/kabanero-io/kabanero-operator/pkg/controller/collection"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func reconcileFeaturedCollections(ctx context.Context, k *kabanerov1alpha1.Kabanero, cl client.Client) error {
+	//Resolve the collections which are currently featured across the various indexes
+	featured, err := featuredCollections(k)
+	if err != nil {
+		return err
+	}
+
+	for _, c := range featured {
+		//For each collection, assure that a corresponding resource exists
+		name := types.NamespacedName{
+			Name:      c.Manifest.Name,
+			Namespace: k.GetNamespace(),
+		}
+
+		collectionResource := &kabanerov1alpha1.Collection{}
+		err := cl.Get(ctx, name, collectionResource)
+		if errors.IsNotFound(err) {
+			//Not found, so create
+			collectionResource = &kabanerov1alpha1.Collection{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      c.Manifest.Name,
+					Namespace: k.GetNamespace(),
+				},
+				Spec: kabanerov1alpha1.CollectionSpec{
+					Name:    c.Manifest.Name,
+					Version: c.Manifest.Version,
+				},
+			}
+			err := cl.Create(ctx, collectionResource)
+			return err
+		} else {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Resolves all featured collections for the given Kabanero instance
+func featuredCollections(k *kabanerov1alpha1.Kabanero) ([]*collection.CollectionV1, error) {
+	var collections []*collection.CollectionV1
+
+	if k.Spec.Collections.EnableFeatured {
+		for _, r := range k.Spec.Collections.Repositories {
+			index, err := collection.ResolveIndex(r.Url)
+			if err != nil {
+				return nil, err
+			}
+
+			for _, c := range index.ListCollections() {
+				c, err := collection.ResolveCollection(c.CollectionUrls...)
+				if err != nil {
+					return nil, err
+				}
+
+				collections = append(collections, c)
+			}
+		}
+	}
+
+	return collections, nil
+}

--- a/pkg/controller/kabaneroplatform/featured_collections_test.go
+++ b/pkg/controller/kabaneroplatform/featured_collections_test.go
@@ -1,0 +1,109 @@
+// +build integration
+
+package kabaneroplatform
+
+import (
+	"context"
+	kabanerov1alpha1 "github.com/kabanero-io/kabanero-operator/pkg/apis/kabanero/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"testing"
+)
+
+func destroyCollection(ctx context.Context, cl client.Client, name string, namespace string) error {
+	//Cleanup any prior test
+	collectionResource := &kabanerov1alpha1.Collection{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	err := cl.Delete(ctx, collectionResource)
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+
+	return nil
+}
+
+func TestReconcileFeaturedCollections(t *testing.T) {
+	ctx := context.Background()
+
+	scheme, _ := kabanerov1alpha1.SchemeBuilder.Build()
+	cl, err := client.New(config.GetConfigOrDie(), client.Options{Scheme: scheme})
+	if err != nil {
+		t.Fatal("Could not create a client", err)
+	}
+
+	//Cleanup any prior run
+	err = destroyCollection(ctx, cl, "java-microprofile", "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	//Cleanup after run
+	defer destroyCollection(ctx, cl, "java-microprofile", "default")
+
+	collection_index_url := "https://raw.githubusercontent.com/kabanero-io/kabanero-collection/master/experimental/index.yaml"
+
+	k := &kabanerov1alpha1.Kabanero{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+		},
+		Spec: kabanerov1alpha1.KabaneroSpec{
+			Collections: kabanerov1alpha1.InstanceCollectionConfig{
+				EnableFeatured: true,
+				Repositories: []kabanerov1alpha1.RepositoryConfig{
+					kabanerov1alpha1.RepositoryConfig{
+						Name: "default",
+						Url:  collection_index_url,
+					},
+				},
+			},
+		},
+	}
+
+	err = reconcileFeaturedCollections(context.Background(), k, cl)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	//Verify the collection was created
+	collectionResource := &kabanerov1alpha1.Collection{}
+	err = cl.Get(ctx, types.NamespacedName{Name: "java-microprofile", Namespace: "default"}, collectionResource)
+	if err != nil {
+		t.Fatal("Could not resolve the automatically created collection", err)
+	}
+}
+
+// Attempts to resolve the featured collections from the default repository
+// Note that this test is fragile since it relies on connectivity to the central example index
+// and the presence of specific collections
+func TestResolveFeaturedCollections(t *testing.T) {
+	collection_index_url := "https://raw.githubusercontent.com/kabanero-io/kabanero-collection/master/experimental/index.yaml"
+
+	k := &kabanerov1alpha1.Kabanero{
+		Spec: kabanerov1alpha1.KabaneroSpec{
+			Collections: kabanerov1alpha1.InstanceCollectionConfig{
+				EnableFeatured: true,
+				Repositories: []kabanerov1alpha1.RepositoryConfig{
+					kabanerov1alpha1.RepositoryConfig{
+						Name: "default",
+						Url:  collection_index_url,
+					},
+				},
+			},
+		},
+	}
+
+	collections, err := featuredCollections(k)
+	if err != nil {
+		t.Fatal("Could not resolve the featured collections from the default index", err)
+	}
+
+	if len(collections) < 1 {
+		t.Fatal("Was expecting at least one collection to be found in the default repository: ", collection_index_url)
+	}
+}

--- a/pkg/controller/kabaneroplatform/kabaneroplatform_controller.go
+++ b/pkg/controller/kabaneroplatform/kabaneroplatform_controller.go
@@ -95,6 +95,12 @@ func (r *ReconcileKabanero) Reconcile(request reconcile.Request) (reconcile.Resu
 		return reconcile.Result{}, err
 	}
 
+	err = reconcileFeaturedCollections(ctx, instance, r.client)
+	if err != nil {
+		fmt.Println("Error in reconcile featured collections: ", err)
+		return reconcile.Result{}, err
+	}
+
 	err = reconcile_tekton(ctx, instance, r.client)
 	if err != nil {
 		fmt.Println("Error in reconcile tekton: ", err)


### PR DESCRIPTION
This implementation will install all featured collections by default since the repository model does not currently have a notation for which collections are featured. We will need to follow on with another code update to the controller after the collections repository has been updated. 