### PR TITLE
update prepare release script to update repository tag

### DIFF
--- a/.travis/prepare_release.sh
+++ b/.travis/prepare_release.sh
@@ -2,6 +2,13 @@
 BASEPATH=$(dirname $(dirname $0))
 DEST=$BASEPATH/deploy/kabanero-operators.yaml
 
+# Find we are running on MAC.
+MAC_EXEC=false
+macos=Darwin
+if [ "$(uname)" == "Darwin" ]; then
+   MAC_EXEC=true
+fi
+
 # Prepare operator deployment file
 cat << EOF >> $DEST
 apiVersion: v1
@@ -16,3 +23,12 @@ cat $BASEPATH/deploy/operator.yaml >> $DEST; echo "---" >> $DEST
 cat $BASEPATH/deploy/role.yaml >> $DEST; echo "---" >> $DEST
 cat $BASEPATH/deploy/role_binding.yaml >> $DEST; echo "---" >> $DEST
 cat $BASEPATH/deploy/service_account.yaml >> $DEST; echo "---" >> $DEST
+
+# Update the operator deployment image entry if TRAVIS_TAG is set
+if [ ! -z "$TRAVIS_TAG" ]; then
+   if [[ $MAC_EXEC == true ]]; then
+      sed -i '' -e "s!image: kabanero-operator:latest!image: kabanero-operator:$TRAVIS_TAG!g" $DEST
+   else
+      sed -i "s!image: kabanero-operator:latest!image: kabanero-operator:$TRAVIS_TAG!g" $DEST
+   fi
+fi


### PR DESCRIPTION
The prepare release script was not putting the correct container image name in the generated yaml.  The container image should contain the tag for the release, not `latest`.