### PR TITLE
add eventing-contrib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ generate:
 	operator-sdk generate openapi
 
 install:
+	kubectl config set-context $$(kubectl config current-context) --namespace=kabanero
 	kubectl apply -f deploy/crds/
 	
 deploy: 
@@ -45,13 +46,14 @@ deploy:
 
 ifeq "$(IMAGE)" "kabanero-operator:latest"
 	# No image pull policy for local image
-	sed -i '' -e 's!imagePullPolicy: Always!imagePullPolicy: Never!' deploy/operator.yaml
+	sed -i.bak -e 's!imagePullPolicy: Always!imagePullPolicy: Never!' deploy/operator.yaml
 else
 	# Substitute current image name
-	sed -i '' -e 's!image: kabanero-operator:latest!image: ${IMAGE}!' deploy/operator.yaml
+	sed -i.bak -e 's!image: kabanero-operator:latest!image: ${IMAGE}!' deploy/operator.yaml
 endif
-
-	kubectl -n kabanero apply -f deploy/
+	rm deploy/operator.yaml.bak
+	kubectl config set-context $$(kubectl config current-context) --namespace=kabanero
+	kubectl apply -f deploy/
 
 dependencies: 
 ifeq (, $(shell which dep))

--- a/contrib/get_dependencies.sh
+++ b/contrib/get_dependencies.sh
@@ -3,14 +3,16 @@ set -Eeuox pipefail
 
 $(dirname $0)/get_knative_eventing_operator.sh
 $(dirname $0)/get_knative_serving_operator.sh
+$(dirname $0)/get_knative_contrib_operator.sh
 $(dirname $0)/get_tekton_operator.sh
 
 DEST=dependencies.yaml
 cat knative-eventing.yaml >> $DEST; echo "---" >> $DEST
 cat knative-serving.yaml >> $DEST; echo "---" >> $DEST
+cat knative-contrib.yaml >> $DEST; echo "---" >> $DEST
 cat tekton.yaml >> $DEST; echo "---" >> $DEST
 
-rm knative-eventing.yaml knative-serving.yaml tekton.yaml
+rm knative-eventing.yaml knative-serving.yaml knative-contrib.yaml tekton.yaml
 
 
 

--- a/contrib/get_knative_contrib_operator.sh
+++ b/contrib/get_knative_contrib_operator.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -Eeuox pipefail
+
+DEST=knative-contrib.yaml
+
+RELEASE=v0.6.0
+GITHUB_SOURCE=eventing-sources.yaml
+
+#RELEASE=v0.7.1
+#GITHUB_SOURCE=github.yaml
+
+#v0.7.2+ is needed to fix
+#https://github.com/knative/eventing-contrib/issues/481
+
+BASEURL=https://github.com/knative/eventing-contrib/releases/download/${RELEASE}
+
+curl -f -L $BASEURL/${GITHUB_SOURCE} -o ${GITHUB_SOURCE}
+cat ${GITHUB_SOURCE} >> $DEST; echo "---" >> $DEST
+rm ${GITHUB_SOURCE}

--- a/contrib/get_knative_eventing_operator.sh
+++ b/contrib/get_knative_eventing_operator.sh
@@ -1,9 +1,14 @@
+#!/bin/bash
+set -Eeuox pipefail
+
 DEST=knative-eventing.yaml
 
-BASEURL=https://raw.githubusercontent.com/openshift-knative/knative-eventing-operator/v0.7.0/deploy
+RELEASE=v0.6.0
+
+BASEURL=https://raw.githubusercontent.com/openshift-knative/knative-eventing-operator/${RELEASE}/deploy
 $(dirname $0)/get_operator_config.sh $BASEURL $DEST
 
-curl $BASEURL/crds/eventing_v1alpha1_knativeeventing_crd.yaml -o eventing_v1alpha1_knativeeventing_crd.yaml
+curl -f $BASEURL/crds/eventing_v1alpha1_knativeeventing_crd.yaml -o eventing_v1alpha1_knativeeventing_crd.yaml
 cat eventing_v1alpha1_knativeeventing_crd.yaml >> $DEST; echo "---" >> $DEST
 rm eventing_v1alpha1_knativeeventing_crd.yaml
 

--- a/contrib/get_knative_serving_operator.sh
+++ b/contrib/get_knative_serving_operator.sh
@@ -1,16 +1,16 @@
+#!/bin/bash
+set -Eeuox pipefail
+
 DEST=knative-serving.yaml
 
-BASEURL=https://raw.githubusercontent.com/knative/serving-operator/master/config/
+RELEASE=v0.6.0
+
+BASEURL=https://raw.githubusercontent.com/openshift-knative/knative-serving-operator/${RELEASE}/deploy
 $(dirname $0)/get_operator_config.sh $BASEURL $DEST
 
-curl $BASEURL/crds/serving_v1alpha1_knativeserving_crd.yaml -o serving_v1alpha1_knativeserving_crd.yaml
+curl -f $BASEURL/crds/serving_v1alpha1_knativeserving_crd.yaml -o serving_v1alpha1_knativeserving_crd.yaml
 cat serving_v1alpha1_knativeserving_crd.yaml >> $DEST; echo "---" >> $DEST
 rm serving_v1alpha1_knativeserving_crd.yaml
 
 sed -i.bak 's/namespace: default/namespace: kabanero/g' $DEST
-rm $DEST.bak
-
-
-# Use openshift-knative image until upstream image is available
-sed -i.bak 's|image: github.com/knative/serving-operator/cmd/manager|image: quay.io/openshift-knative/knative-serving-operator:v0.7.0|g' $DEST
 rm $DEST.bak

--- a/contrib/get_operator_config.sh
+++ b/contrib/get_operator_config.sh
@@ -1,4 +1,6 @@
-set -x
+#!/bin/bash
+set -Eeuox pipefail
+
 
 BASEURL=$1
 DEST=$2
@@ -13,12 +15,12 @@ if [ -z ${DEST} ]; then
     exit -1
 fi
 
-curl $BASEURL/operator.yaml -o operator.yaml
-curl $BASEURL/role.yaml -o role.yaml
-curl $BASEURL/role_binding.yaml -o role_binding.yaml
-curl $BASEURL/service_account.yaml -o service_account.yaml
+curl -f $BASEURL/operator.yaml -o operator.yaml
+curl -f $BASEURL/role.yaml -o role.yaml
+curl -f $BASEURL/role_binding.yaml -o role_binding.yaml
+curl -f $BASEURL/service_account.yaml -o service_account.yaml
 
-rm $DEST
+rm -f $DEST
 for f in operator.yaml role.yaml role_binding.yaml service_account.yaml; do
   cat $f >> $DEST; echo "---" >> $DEST
 done

--- a/contrib/get_tekton_operator.sh
+++ b/contrib/get_tekton_operator.sh
@@ -3,9 +3,13 @@ DEST=tekton.yaml
 BASEURL=https://raw.githubusercontent.com/openshift/tektoncd-pipeline-operator/master/deploy
 $(dirname $0)/get_operator_config.sh $BASEURL $DEST
 
-curl $BASEURL/crds/openshift-pipelines-operator-tekton_v1alpha1_install_crd.yaml -o openshift-pipelines-operator-tekton_v1alpha1_install_crd.yaml
-cat openshift-pipelines-operator-tekton_v1alpha1_install_crd.yaml >> $DEST; echo "---" >> $DEST
-rm openshift-pipelines-operator-tekton_v1alpha1_install_crd.yaml
+curl -f $BASEURL/crds/operator_v1alpha1_config_crd.yaml -o operator_v1alpha1_config_crd.yaml
+cat operator_v1alpha1_config_crd.yaml >> $DEST; echo "---" >> $DEST
+rm operator_v1alpha1_config_crd.yaml
 
-sed -i.bak 's/namespace: openshift-pipelines-operator/namespace: kabanero/g' $DEST
+curl -f $BASEURL/crds/operator_v1alpha1_config_cr.yaml -o operator_v1alpha1_config_cr.yaml
+cat operator_v1alpha1_config_cr.yaml >> $DEST; echo "---" >> $DEST
+rm operator_v1alpha1_config_cr.yaml
+
+sed -i.bak 's/namespace: openshift-operators/namespace: kabanero/g' $DEST
 rm $DEST.bak

--- a/deploy/dependencies.yaml
+++ b/deploy/dependencies.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: knative-eventing-operator
           # Replace this with the built image name
-          image: quay.io/openshift-knative/knative-eventing-operator:v0.7.0
+          image: quay.io/openshift-knative/knative-eventing-operator:v0.6.0
           command:
           - knative-eventing-operator
           imagePullPolicy: Always
@@ -222,8 +222,10 @@ spec:
       serviceAccountName: knative-serving-operator
       containers:
         - name: knative-serving-operator
-          image: quay.io/openshift-knative/knative-serving-operator:v0.7.0
-          imagePullPolicy: IfNotPresent
+          image: quay.io/openshift-knative/knative-serving-operator:v0.6.0
+          command:
+          - knative-serving-operator
+          imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -429,6 +431,329 @@ spec:
     storage: true
 ---
 ---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: knative-sources
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: controller-manager
+  namespace: knative-sources
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: eventing-sources-controller
+rules:
+- apiGroups:
+  - sources.eventing.knative.dev
+  resources:
+  - githubsources
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - sources.eventing.knative.dev
+  resources:
+  - containersources
+  - containersources/status
+  - containersources/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - sources.eventing.knative.dev
+  resources:
+  - githubsources/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - sources.eventing.knative.dev
+  resources:
+  - githubsources/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - serving.knative.dev
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - eventing.knative.dev
+  resources:
+  - eventtypes
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: eventing-sources-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: eventing-sources-controller
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: knative-sources
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: eventing-sources-addressable-resolver
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: addressable-resolver
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: knative-sources
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    eventing.knative.dev/source: "true"
+    knative.dev/crd-install: "true"
+  name: githubsources.sources.eventing.knative.dev
+spec:
+  group: sources.eventing.knative.dev
+  names:
+    categories:
+    - all
+    - knative
+    - eventing
+    - sources
+    kind: GitHubSource
+    plural: githubsources
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            accessToken:
+              properties:
+                secretKeyRef:
+                  type: object
+              type: object
+            eventTypes:
+              items:
+                enum:
+                - check_suite
+                - commit_comment
+                - create
+                - delete
+                - deployment
+                - deployment_status
+                - fork
+                - gollum
+                - installation
+                - integration_installation
+                - issue_comment
+                - issues
+                - label
+                - member
+                - membership
+                - milestone
+                - organization
+                - org_block
+                - page_build
+                - ping
+                - project_card
+                - project_column
+                - project
+                - public
+                - pull_request
+                - pull_request_review
+                - pull_request_review_comment
+                - push
+                - release
+                - repository
+                - status
+                - team
+                - team_add
+                - watch
+                type: string
+              minItems: 1
+              type: array
+            ownerAndRepository:
+              minLength: 1
+              type: string
+            secretToken:
+              properties:
+                secretKeyRef:
+                  type: object
+              type: object
+            serviceAccountName:
+              type: string
+            sink:
+              type: object
+          required:
+          - ownerAndRepository
+          - eventTypes
+          - accessToken
+          - secretToken
+          type: object
+        status:
+          properties:
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  severity:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            sinkUri:
+              type: string
+            webhookIDKey:
+              type: string
+          type: object
+  version: v1alpha1
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: controller
+  namespace: knative-sources
+spec:
+  ports:
+  - port: 443
+  selector:
+    control-plane: controller-manager
+
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: controller-manager
+  namespace: knative-sources
+spec:
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  serviceName: controller-manager
+  template:
+    metadata:
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+      - env:
+        - name: GH_RA_IMAGE
+          value: gcr.io/knative-releases/github.com/knative/eventing-sources/cmd/github_receive_adapter@sha256:b5d6e12d16d16c6c42ae3d4325a1ef3a8a129dfc97740aa28000c0867edfc4ff
+        image: gcr.io/knative-releases/github.com/knative/eventing-sources/cmd/manager@sha256:99cf1f559f74ae97f271632697ed6e78a3fdd88a155632a57341b0dd6eab6581
+        name: manager
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 1000Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+      serviceAccountName: controller-manager
+      terminationGracePeriodSeconds: 10
+
+---
+---
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -446,20 +771,20 @@ spec:
     spec:
       serviceAccountName: openshift-pipelines-operator
       containers:
-        - name: openshift-pipelines-operator
-          image: quay.io/openshift-pipeline/openshift-pipelines-operator:v0.4.0-1
-          command:
-          - openshift-pipelines-operator
-          imagePullPolicy: Always
-          env:
-            - name: WATCH_NAMESPACE
-              value: ""
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "openshift-pipelines-operator"
+      - name: openshift-pipelines-operator
+        image: quay.io/openshift-pipeline/openshift-pipelines-operator:v0.5.0
+        command:
+        - openshift-pipelines-operator
+        imagePullPolicy: Always
+        env:
+        - name: WATCH_NAMESPACE
+          value: ""
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: OPERATOR_NAME
+          value: "openshift-pipelines-operator"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -510,13 +835,6 @@ rules:
   - get
   - create
   - delete
-- apiGroups:
-  - tekton.dev
-  resources:
-  - '*'
-  - installs
-  verbs:
-  - '*'
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
@@ -616,6 +934,18 @@ rules:
   - update
   - delete
   - use
+- apiGroups:
+  - operator.tekton.dev
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - tekton.dev
+  resources:
+  - '*'
+  verbs:
+  - '*'
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -640,52 +970,71 @@ metadata:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: installs.tekton.dev
+  name: config.operator.tekton.dev
 spec:
-  group: tekton.dev
+  group: operator.tekton.dev
   names:
-    kind: Install
-    listKind: InstallList
-    plural: installs
-    singular: install
-  scope: Namespaced
+    kind: Config
+    listKind: ConfigList
+    plural: config
+    singular: config
+  scope: Cluster
   subresources:
     status: {}
   validation:
     openAPIV3Schema:
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
         spec:
+          properties:
+            targetNamespace:
+              description: namespace where OpenShift pipelines will be installed
+              type: string
+          required:
+          - targetNamespace
           type: object
         status:
           properties:
-            resources:
-              description: The resources applied
+            conditions:
+              description: installation status sorted in reverse chronological order
               items:
-                type: string
+                properties:
+                  code:
+                    description: Code indicates the status of installation of pipeline resources.
+                    type: string
+                  details:
+                    description: Additional details about the Code
+                    type: string
+                  version:
+                    description: The version of tekton pipelines
+                    type: string
+                required:
+                - code
+                - version
+                type: object
               type: array
-            version:
-              type: string
-          required:
-          - resources
-          - version
           type: object
+  additionalPrinterColumns:
+  - JSONPath: ".status.conditions[0].code"
+    name: status
+    type: string
   version: v1alpha1
   versions:
   - name: v1alpha1
     served: true
     storage: true
+---
+apiVersion: operator.tekton.dev/v1alpha1
+kind: Config
+metadata:
+  name: cluster
+spec:
+  targetNamespace: openshift-pipelines
 ---
 ---
 kind: ClusterRole


### PR DESCRIPTION
Use a set-context approach in the Makefile to be able to apply namespaced and non-namespaced objects simulatenously
Update sed to a compatible approach for both MacOS and GNU

Add knative-contrib fetch to the overall get_dependencies

Pull the knative-contrib release v0.6.0. v0.7.x github releases are currently broken.

As such, change knative eventing and serving back to v0.6.0 releases for compatibility

Hardening, stop at failures
Add curl -f
set -Eeuox pipefail

