### PR TITLE
Detect upgrade versions of collections.  Process version changes.

### DIFF
--- a/3RD_PARTY
+++ b/3RD_PARTY
@@ -3,9 +3,9 @@ github.com/PuerkitoBio/purell                            BSD 3-clause "New" or "
 github.com/PuerkitoBio/urlesc                            BSD 3-clause "New" or "Revised" License (96%)
 github.com/appscode/jsonpatch                            Apache License 2.0
 github.com/beorn7/perks/quantile                         MIT License (98%)
+github.com/blang/semver                                  MIT License
 github.com/davecgh/go-spew/spew                          ISC License (98%)
 github.com/emicklei/go-restful/log                       MIT License
-github.com/evanphx/json-patch                            BSD 3-clause "New" or "Revised" License (97%)
 github.com/go-logr/logr                                  Apache License 2.0
 github.com/go-logr/zapr                                  Apache License 2.0
 github.com/go-openapi/jsonpointer                        Apache License 2.0
@@ -21,7 +21,6 @@ github.com/google/uuid                                   BSD 3-clause "New" or "
 github.com/googleapis/gnostic                            Apache License 2.0
 github.com/gregjones/httpcache/diskcache                 MIT License (98%)
 github.com/hashicorp/golang-lru/simplelru                Mozilla Public License 2.0
-github.com/imdario/mergo                                 BSD 3-clause "New" or "Revised" License (96%)
 github.com/jcrossley3/manifestival                       Apache License 2.0
 github.com/json-iterator/go                              MIT License
 github.com/mailru/easyjson                               MIT License (98%)
@@ -30,12 +29,10 @@ github.com/modern-go/concurrent                          Apache License 2.0
 github.com/modern-go/reflect2                            Apache License 2.0
 github.com/pborman/uuid                                  BSD 3-clause "New" or "Revised" License (96%)
 github.com/peterbourgon/diskv                            MIT License (98%)
-github.com/pkg/errors                                    BSD 2-clause "Simplified" License
 github.com/prometheus/client_golang/prometheus           Apache License 2.0
 github.com/prometheus/client_model/go                    Apache License 2.0
 github.com/prometheus/common                             Apache License 2.0
 github.com/prometheus/procfs/internal/fs                 Apache License 2.0
-github.com/spf13/pflag                                   BSD 3-clause "New" or "Revised" License (96%)
 go.uber.org/atomic                                       MIT License (98%)
 go.uber.org/multierr                                     MIT License (98%)
 go.uber.org/zap                                          MIT License (98%)

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -65,6 +65,14 @@
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:dafc9bfdb2d9816587ca63844a722b36525183e14423b1f356fd9a8a805b6230"
+  name = "github.com/blang/semver"
+  packages = ["."]
+  pruneopts = "NT"
+  revision = "ba2c2ddd89069b46a7011d4106f6868f17ee1705"
+  version = "v3.6.1"
+
+[[projects]]
   digest = "1:13af3d205c774ec0bbda45fee1a4089f3cd9a55c5367b527698b34550ec15e71"
   name = "github.com/census-instrumentation/opencensus-proto"
   packages = [
@@ -1109,6 +1117,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/blang/semver",
     "github.com/go-openapi/spec",
     "github.com/jcrossley3/manifestival",
     "github.com/operator-framework/operator-sdk/pkg/k8sutil",
@@ -1126,6 +1135,7 @@
     "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
     "k8s.io/apimachinery/pkg/runtime",
     "k8s.io/apimachinery/pkg/runtime/schema",
+    "k8s.io/apimachinery/pkg/types",
     "k8s.io/client-go/plugin/pkg/client/auth",
     "k8s.io/code-generator/cmd/client-gen",
     "k8s.io/code-generator/cmd/conversion-gen",

--- a/deploy/crds/kabanero_v1alpha1_collection_crd.yaml
+++ b/deploy/crds/kabanero_v1alpha1_collection_crd.yaml
@@ -57,6 +57,12 @@ spec:
               type: string
             activeVersion:
               type: string
+            availableLocation:
+              type: string
+            availableVersion:
+              type: string
+            statusMessage:
+              type: string
           type: object
   version: v1alpha1
   versions:

--- a/pkg/apis/kabanero/v1alpha1/collection_types.go
+++ b/pkg/apis/kabanero/v1alpha1/collection_types.go
@@ -31,6 +31,9 @@ type CollectionStatus struct {
 	ActiveVersion string `json:"activeVersion,omitempty"`
 	ActiveDigest  string `json:"activeDigest,omitempty"`
 	ActiveAssets []RepositoryAssetStatus `json:"activeAssets,omitempty"`
+	AvailableVersion string `json:"availableVersion,omitempty"`
+	AvailableLocation string `json:"availableLocation,omitempty"`
+	StatusMessage string `json:"statusMessage,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/kabanero/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/kabanero/v1alpha1/zz_generated.openapi.go
@@ -126,6 +126,24 @@ func schema_pkg_apis_kabanero_v1alpha1_CollectionStatus(ref common.ReferenceCall
 							},
 						},
 					},
+					"availableVersion": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"availableLocation": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"statusMessage": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/controller/collection/collection_controller.go
+++ b/pkg/controller/collection/collection_controller.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/blang/semver"
 	mf "github.com/jcrossley3/manifestival"
 	kabanerov1alpha1 "github.com/kabanero-io/kabanero-operator/pkg/apis/kabanero/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -102,6 +103,8 @@ func (r *ReconcileCollection) Reconcile(request reconcile.Request) (reconcile.Re
 	}
 
 	// Resolve the kabanero instance
+	// TODO: issue #92, when repo is added to the Collection, there will be no need for the Kabanero
+	//       object here.
 	var k *kabanerov1alpha1.Kabanero
 	l := kabanerov1alpha1.KabaneroList{}
 	err = r.client.List(context.Background(), &client.ListOptions{}, &l)
@@ -142,8 +145,42 @@ func failedAssets(status kabanerov1alpha1.CollectionStatus) bool {
 	return false
 }
 
+// Finds the collection with the highest semver.  Caller has validated that resolvedCollection
+// contains at least one collection.
+func findMaxVersionCollection(collections []resolvedCollection) *resolvedCollection {
+	log.Info(fmt.Sprintf("findMaxVersionCollection: processing %v collections", len(collections)))
+
+	var maxCollection *resolvedCollection = nil
+	maxVersion, _ := semver.Make("0.0.0")
+
+	for i, _ := range collections {
+		curVersion, err := semver.ParseTolerant(collections[i].collection.Manifest.Version)
+		if err == nil {
+			if curVersion.Compare(maxVersion) > 0 {
+				maxCollection = &collections[i]
+				maxVersion = curVersion
+			}
+		} else {
+			log.Info(fmt.Sprintf("findMaxVersionCollection: invalid semver " + collections[i].collection.Manifest.Version))
+		}
+	}
+
+	// It's possible we didn't find a valid semver, in which case we'd return nil.
+	return maxCollection
+}
+
+
+// Used internally by ReconcileCollection to store matching collections
+type resolvedCollection struct {
+	collection CollectionV1
+	repositoryUrl string
+}
+
 func (r *ReconcileCollection) ReconcileCollection(c *kabanerov1alpha1.Collection, k *kabanerov1alpha1.Kabanero) (reconcile.Result, error) {
 	r_log := log.WithValues("Request.Namespace", c.GetNamespace()).WithValues("Request.Name", c.GetName())
+
+	// Clear the status message, we'll generate a new one if necessary
+	c.Status.StatusMessage = ""
 
 	//The collection name can be either the spec.name or the resource name. The
 	//spec.name has precedence
@@ -155,52 +192,88 @@ func (r *ReconcileCollection) ReconcileCollection(c *kabanerov1alpha1.Collection
 	}
 	r_log = r_log.WithValues("Collection.Name", collectionName)
 
-	//Retreive the remote index
-	var collection *CollectionV1
-	if k.Spec.Collections.Repositories != nil && len(k.Spec.Collections.Repositories) > 0 {
-		for _, repo := range k.Spec.Collections.Repositories {
-			index, err := r.indexResolver(repo.Url)
-			if err != nil {
-				return reconcile.Result{Requeue: true, RequeueAfter: 60 * time.Second}, err
-			}
+	// Retreive all matching collection names from all remote indexes.  If none were specified,
+	// use the default.
+	var matchingCollections []resolvedCollection
+	repositories := k.Spec.Collections.Repositories
+	if len(repositories) == 0 {
+		default_url := "https://raw.githubusercontent.com/kabanero-io/kabanero-collection/master/experimental/index.yaml"
+		repositories = append(repositories, kabanerov1alpha1.RepositoryConfig{Name: "default", Url: default_url})
+	}
+	
+	for _, repo := range repositories {
+		index, err := r.indexResolver(repo.Url)
+		if err != nil {
+			// TODO: Issue #92, should just search the repository where the colleciton was loaded initially.
+			return reconcile.Result{Requeue: true, RequeueAfter: 60 * time.Second}, err
+		}
 
-			_collection, err := SearchCollection(collectionName, index)
-			if err != nil {
-				r_log.Error(err, "Could not search the provided index")
+		// Search for all versions of the collection in this repository index.
+		_collections, err := SearchCollection(collectionName, index)
+		if err != nil {
+			r_log.Error(err, "Could not search the provided index")
+		}
+
+		// Build out the list of all collections across all repository indexes
+		for _, collection := range _collections {
+			matchingCollections = append(matchingCollections, resolvedCollection{collection: collection, repositoryUrl: repo.Url})
+		}
+	}
+
+	// We have a list of all collections that match the name.  We'll use this list to see
+	// if we have one at the requested version, as well as find the one at the highest level
+	// to inform the user if an upgrade is available.
+	if len(matchingCollections) > 0 {
+		specVersion, semverErr := semver.ParseTolerant(c.Spec.Version)
+		if (semverErr == nil) {
+			// Search for the highest version.  Update the Status field if one is found that
+			// is higher than the requested version.  This will only work if the Spec.Version adheres
+			// to the semver standard.
+			upgradeCollection := findMaxVersionCollection(matchingCollections)
+			if upgradeCollection != nil {
+				// The upgrade collection semver is valid, we tested it in findMaxVersionCollection
+				upgradeVersion, _ := semver.ParseTolerant(upgradeCollection.collection.Manifest.Version)
+				if upgradeVersion.Compare(specVersion) > 0 {
+					c.Status.AvailableVersion = upgradeCollection.collection.Manifest.Version
+					c.Status.AvailableLocation = upgradeCollection.repositoryUrl
+				} else {
+					// The spec version is the same or higher than the collection versions
+					c.Status.AvailableVersion = ""
+					c.Status.AvailableLocation = ""
+				}
+			} else {
+				// None of the collections versions adher to semver standards
+				c.Status.AvailableVersion = ""
+				c.Status.AvailableLocation = ""
 			}
-			if _collection != nil {
-				collection = _collection
+		} else {
+			r_log.Error(semverErr, "Could not determine upgrade availability for collection " + collectionName)
+		}
+		
+		// Search for the correct version.  The list may have duplicates, we're just searching for
+		// the first match.
+		for _, matchingCollection := range matchingCollections {
+			if matchingCollection.collection.Manifest.Version == c.Spec.Version {
+				err := activate(c, &matchingCollection.collection, r.client)
+				if err != nil {
+					return reconcile.Result{Requeue: true, RequeueAfter: 60 * time.Second}, err
+				}
+				return reconcile.Result{}, nil
 			}
 		}
-                if collection != nil {
-                        err := activate(c, collection, r.client)
-                        if err != nil {
-                                return reconcile.Result{Requeue: true, RequeueAfter: 60 * time.Second}, err
-                        }
-                        return reconcile.Result{}, nil
-                }
+
+		// No collection with a matching version could be found. Update the status
+		// message so the user understands that the version they want is not available.
+		c.Status.StatusMessage = "The requested version of the collection (" + c.Spec.Version + ") is not available."
+
+		return reconcile.Result{}, nil
 	}
 
-	//If not found, search the default
-	//TODO: incorporate this default into a webhook
-	default_url := "https://raw.githubusercontent.com/kabanero-io/kabanero-collection/master/experimental/index.yaml"
-	index, err := r.indexResolver(default_url)
-	if err != nil {
-		return reconcile.Result{Requeue: true, RequeueAfter: 60 * time.Second}, err
+	// No version of the collection could be found.  If there is no active version, update
+	// the status message so the user knows that something needs to be done.
+	if c.Status.ActiveVersion == "" {
+		c.Status.StatusMessage = "No version of the collection is available."
 	}
-	collection, err = SearchCollection(collectionName, index)
-	if err != nil {
-		return reconcile.Result{Requeue: true, RequeueAfter: 60 * time.Second}, err
-	}
-	if collection == nil {
-		return reconcile.Result{Requeue: true, RequeueAfter: 60 * time.Second}, fmt.Errorf("Collection could not be found")
-	}
-
-	err = activate(c, collection, r.client)
-	if err != nil {
-		return reconcile.Result{Requeue: true, RequeueAfter: 60 * time.Second}, err
-	}
-
 	return reconcile.Result{}, nil
 }
 
@@ -246,7 +319,62 @@ func updateAssetStatus(status *kabanerov1alpha1.CollectionStatus, asset AssetMan
 
 func activate(collectionResource *kabanerov1alpha1.Collection, collection *CollectionV1, c client.Client) error {
 	manifest := collection.Manifest
-	
+
+	// Detect if the version is changing from the active version.  If it is, we need to clean up the
+	// assets from the previous version.
+	if (collectionResource.Status.ActiveVersion != "") && (collectionResource.Status.ActiveVersion != manifest.Version) {
+		// Our version change strategy is going to be as follows:
+		// 1) Attempt to load all of the known artifacts.  Any failure, status message and punt.
+		// 2) Delete the artifacts.  If something goes wrong here, the state of the collection is unknown.
+		type transformedRemoteManifest struct {
+			m mf.Manifest
+			assetUrl string
+		}
+		
+		var transformedManifests []transformedRemoteManifest
+		errorMessage := "Error during version change from " + collectionResource.Status.ActiveVersion + " to " + manifest.Version
+		
+		for _, asset := range collectionResource.Status.ActiveAssets {
+			log.Info(fmt.Sprintf("Preparing to delete asset %v", asset.Url))
+
+			m, err := mf.NewManifest(asset.Url, false, c)
+			if err != nil {
+				log.Error(err, errorMessage, "resource", asset.Url)
+				collectionResource.Status.StatusMessage = errorMessage + ": " + err.Error()
+				return nil // Forces status to be updated
+			}
+
+			log.Info(fmt.Sprintf("Resources: %v", m.Resources))
+
+			err = m.Transform(func(u *unstructured.Unstructured) error {
+				u.SetNamespace(collectionResource.GetNamespace())
+				return nil
+			})
+			if err != nil {
+				log.Error(err, errorMessage, "resource", asset.Url)
+				collectionResource.Status.StatusMessage = errorMessage + ": " + err.Error()
+				return nil // Forces status to be updated
+			}
+
+			// Queue the resolved manifest to be deleted in the next step.
+			transformedManifests = append(transformedManifests, transformedRemoteManifest{m, asset.Url})
+		}
+
+		// Now delete the manifests
+		for _, transformedManifest := range transformedManifests {
+		  err := transformedManifest.m.DeleteAll()
+			if err != nil {
+				// It's hard to know what the state of things is now... log the error.
+				log.Error(err, "Error deleting the resource", "resource", transformedManifest.assetUrl)
+			}
+		}
+
+		// Indicate there is not currently an active version of this collection.
+		collectionResource.Status.ActiveVersion = ""
+		collectionResource.Status.ActiveAssets = nil
+	}
+
+	// Now apply the new version
 	for _, asset := range manifest.Assets {
 		if asset.Type == "kubernetes-resource" {
 			// If the asset has a digest, see if the digest has changed.  Don't bother updating anything
@@ -297,6 +425,6 @@ func activate(collectionResource *kabanerov1alpha1.Collection, collection *Colle
 
 	// Update the status of the Collection object to reflect the version we applied.
 	collectionResource.Status.ActiveVersion = manifest.Version;
-
+	
 	return nil
 }

--- a/vendor/github.com/blang/semver/LICENSE
+++ b/vendor/github.com/blang/semver/LICENSE
@@ -1,0 +1,22 @@
+The MIT License
+
+Copyright (c) 2014 Benedikt Lang <github at benediktlang.de>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+

--- a/vendor/github.com/blang/semver/examples/main.go
+++ b/vendor/github.com/blang/semver/examples/main.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/blang/semver"
+)
+
+func main() {
+	v, err := semver.Parse("0.0.1-alpha.preview.222+123.github")
+	if err != nil {
+		fmt.Printf("Error while parsing (not valid): %q", err)
+	}
+	fmt.Printf("Version to string: %q\n", v)
+
+	fmt.Printf("Major: %d\n", v.Major)
+	fmt.Printf("Minor: %d\n", v.Minor)
+	fmt.Printf("Patch: %d\n", v.Patch)
+
+	// Prerelease versions
+	if len(v.Pre) > 0 {
+		fmt.Println("Prerelease versions:")
+		for i, pre := range v.Pre {
+			fmt.Printf("%d: %q\n", i, pre)
+		}
+	}
+
+	// Build meta data
+	if len(v.Build) > 0 {
+		fmt.Println("Build meta data:")
+		for i, build := range v.Build {
+			fmt.Printf("%d: %q\n", i, build)
+		}
+	}
+
+	// Make == Parse (Value), New for Pointer
+	v001, _ := semver.Make("0.0.1")
+
+	fmt.Println("\nUse Version.Compare for comparisons (-1, 0, 1):")
+	fmt.Printf("%q is greater than %q: Compare == %d\n", v001, v, v001.Compare(v))
+	fmt.Printf("%q is less than %q: Compare == %d\n", v, v001, v.Compare(v001))
+	fmt.Printf("%q is equal to %q: Compare == %d\n", v, v, v.Compare(v))
+
+	fmt.Println("\nUse comparison helpers returning booleans:")
+	fmt.Printf("%q is greater than %q: %t\n", v001, v, v001.GT(v))
+	fmt.Printf("%q is greater than equal %q: %t\n", v001, v, v001.GTE(v))
+	fmt.Printf("%q is greater than equal %q: %t\n", v, v, v.GTE(v))
+	fmt.Printf("%q is less than %q: %t\n", v, v001, v.LT(v001))
+	fmt.Printf("%q is less than equal %q: %t\n", v, v001, v.LTE(v001))
+	fmt.Printf("%q is less than equal %q: %t\n", v, v, v.LTE(v))
+
+	fmt.Println("\nManipulate Version in place:")
+	v.Pre[0], err = semver.NewPRVersion("beta")
+	if err != nil {
+		fmt.Printf("Error parsing pre release version: %q", err)
+	}
+	fmt.Printf("Version to string: %q\n", v)
+
+	fmt.Println("\nCompare Prerelease versions:")
+	pre1, _ := semver.NewPRVersion("123")
+	pre2, _ := semver.NewPRVersion("alpha")
+	pre3, _ := semver.NewPRVersion("124")
+	fmt.Printf("%q is less than %q: Compare == %d\n", pre1, pre2, pre1.Compare(pre2))
+	fmt.Printf("%q is greater than %q: Compare == %d\n", pre3, pre1, pre3.Compare(pre1))
+	fmt.Printf("%q is equal to %q: Compare == %d\n", pre1, pre1, pre1.Compare(pre1))
+
+	fmt.Println("\nValidate versions:")
+	v.Build[0] = "?"
+
+	err = v.Validate()
+	if err != nil {
+		fmt.Printf("Validation failed: %s\n", err)
+	}
+
+	fmt.Println("Create valid build meta data:")
+	b1, _ := semver.NewBuildVersion("build123")
+	v.Build[0] = b1
+	fmt.Printf("Version with new build version %q\n", v)
+
+	_, err = semver.NewBuildVersion("build?123")
+	if err != nil {
+		fmt.Printf("Create build version failed: %s\n", err)
+	}
+}

--- a/vendor/github.com/blang/semver/json.go
+++ b/vendor/github.com/blang/semver/json.go
@@ -1,0 +1,23 @@
+package semver
+
+import (
+	"encoding/json"
+)
+
+// MarshalJSON implements the encoding/json.Marshaler interface.
+func (v Version) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.String())
+}
+
+// UnmarshalJSON implements the encoding/json.Unmarshaler interface.
+func (v *Version) UnmarshalJSON(data []byte) (err error) {
+	var versionString string
+
+	if err = json.Unmarshal(data, &versionString); err != nil {
+		return
+	}
+
+	*v, err = Parse(versionString)
+
+	return
+}

--- a/vendor/github.com/blang/semver/range.go
+++ b/vendor/github.com/blang/semver/range.go
@@ -1,0 +1,416 @@
+package semver
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+type wildcardType int
+
+const (
+	noneWildcard  wildcardType = iota
+	majorWildcard wildcardType = 1
+	minorWildcard wildcardType = 2
+	patchWildcard wildcardType = 3
+)
+
+func wildcardTypefromInt(i int) wildcardType {
+	switch i {
+	case 1:
+		return majorWildcard
+	case 2:
+		return minorWildcard
+	case 3:
+		return patchWildcard
+	default:
+		return noneWildcard
+	}
+}
+
+type comparator func(Version, Version) bool
+
+var (
+	compEQ comparator = func(v1 Version, v2 Version) bool {
+		return v1.Compare(v2) == 0
+	}
+	compNE = func(v1 Version, v2 Version) bool {
+		return v1.Compare(v2) != 0
+	}
+	compGT = func(v1 Version, v2 Version) bool {
+		return v1.Compare(v2) == 1
+	}
+	compGE = func(v1 Version, v2 Version) bool {
+		return v1.Compare(v2) >= 0
+	}
+	compLT = func(v1 Version, v2 Version) bool {
+		return v1.Compare(v2) == -1
+	}
+	compLE = func(v1 Version, v2 Version) bool {
+		return v1.Compare(v2) <= 0
+	}
+)
+
+type versionRange struct {
+	v Version
+	c comparator
+}
+
+// rangeFunc creates a Range from the given versionRange.
+func (vr *versionRange) rangeFunc() Range {
+	return Range(func(v Version) bool {
+		return vr.c(v, vr.v)
+	})
+}
+
+// Range represents a range of versions.
+// A Range can be used to check if a Version satisfies it:
+//
+//     range, err := semver.ParseRange(">1.0.0 <2.0.0")
+//     range(semver.MustParse("1.1.1") // returns true
+type Range func(Version) bool
+
+// OR combines the existing Range with another Range using logical OR.
+func (rf Range) OR(f Range) Range {
+	return Range(func(v Version) bool {
+		return rf(v) || f(v)
+	})
+}
+
+// AND combines the existing Range with another Range using logical AND.
+func (rf Range) AND(f Range) Range {
+	return Range(func(v Version) bool {
+		return rf(v) && f(v)
+	})
+}
+
+// ParseRange parses a range and returns a Range.
+// If the range could not be parsed an error is returned.
+//
+// Valid ranges are:
+//   - "<1.0.0"
+//   - "<=1.0.0"
+//   - ">1.0.0"
+//   - ">=1.0.0"
+//   - "1.0.0", "=1.0.0", "==1.0.0"
+//   - "!1.0.0", "!=1.0.0"
+//
+// A Range can consist of multiple ranges separated by space:
+// Ranges can be linked by logical AND:
+//   - ">1.0.0 <2.0.0" would match between both ranges, so "1.1.1" and "1.8.7" but not "1.0.0" or "2.0.0"
+//   - ">1.0.0 <3.0.0 !2.0.3-beta.2" would match every version between 1.0.0 and 3.0.0 except 2.0.3-beta.2
+//
+// Ranges can also be linked by logical OR:
+//   - "<2.0.0 || >=3.0.0" would match "1.x.x" and "3.x.x" but not "2.x.x"
+//
+// AND has a higher precedence than OR. It's not possible to use brackets.
+//
+// Ranges can be combined by both AND and OR
+//
+//  - `>1.0.0 <2.0.0 || >3.0.0 !4.2.1` would match `1.2.3`, `1.9.9`, `3.1.1`, but not `4.2.1`, `2.1.1`
+func ParseRange(s string) (Range, error) {
+	parts := splitAndTrim(s)
+	orParts, err := splitORParts(parts)
+	if err != nil {
+		return nil, err
+	}
+	expandedParts, err := expandWildcardVersion(orParts)
+	if err != nil {
+		return nil, err
+	}
+	var orFn Range
+	for _, p := range expandedParts {
+		var andFn Range
+		for _, ap := range p {
+			opStr, vStr, err := splitComparatorVersion(ap)
+			if err != nil {
+				return nil, err
+			}
+			vr, err := buildVersionRange(opStr, vStr)
+			if err != nil {
+				return nil, fmt.Errorf("Could not parse Range %q: %s", ap, err)
+			}
+			rf := vr.rangeFunc()
+
+			// Set function
+			if andFn == nil {
+				andFn = rf
+			} else { // Combine with existing function
+				andFn = andFn.AND(rf)
+			}
+		}
+		if orFn == nil {
+			orFn = andFn
+		} else {
+			orFn = orFn.OR(andFn)
+		}
+
+	}
+	return orFn, nil
+}
+
+// splitORParts splits the already cleaned parts by '||'.
+// Checks for invalid positions of the operator and returns an
+// error if found.
+func splitORParts(parts []string) ([][]string, error) {
+	var ORparts [][]string
+	last := 0
+	for i, p := range parts {
+		if p == "||" {
+			if i == 0 {
+				return nil, fmt.Errorf("First element in range is '||'")
+			}
+			ORparts = append(ORparts, parts[last:i])
+			last = i + 1
+		}
+	}
+	if last == len(parts) {
+		return nil, fmt.Errorf("Last element in range is '||'")
+	}
+	ORparts = append(ORparts, parts[last:])
+	return ORparts, nil
+}
+
+// buildVersionRange takes a slice of 2: operator and version
+// and builds a versionRange, otherwise an error.
+func buildVersionRange(opStr, vStr string) (*versionRange, error) {
+	c := parseComparator(opStr)
+	if c == nil {
+		return nil, fmt.Errorf("Could not parse comparator %q in %q", opStr, strings.Join([]string{opStr, vStr}, ""))
+	}
+	v, err := Parse(vStr)
+	if err != nil {
+		return nil, fmt.Errorf("Could not parse version %q in %q: %s", vStr, strings.Join([]string{opStr, vStr}, ""), err)
+	}
+
+	return &versionRange{
+		v: v,
+		c: c,
+	}, nil
+
+}
+
+// inArray checks if a byte is contained in an array of bytes
+func inArray(s byte, list []byte) bool {
+	for _, el := range list {
+		if el == s {
+			return true
+		}
+	}
+	return false
+}
+
+// splitAndTrim splits a range string by spaces and cleans whitespaces
+func splitAndTrim(s string) (result []string) {
+	last := 0
+	var lastChar byte
+	excludeFromSplit := []byte{'>', '<', '='}
+	for i := 0; i < len(s); i++ {
+		if s[i] == ' ' && !inArray(lastChar, excludeFromSplit) {
+			if last < i-1 {
+				result = append(result, s[last:i])
+			}
+			last = i + 1
+		} else if s[i] != ' ' {
+			lastChar = s[i]
+		}
+	}
+	if last < len(s)-1 {
+		result = append(result, s[last:])
+	}
+
+	for i, v := range result {
+		result[i] = strings.Replace(v, " ", "", -1)
+	}
+
+	// parts := strings.Split(s, " ")
+	// for _, x := range parts {
+	// 	if s := strings.TrimSpace(x); len(s) != 0 {
+	// 		result = append(result, s)
+	// 	}
+	// }
+	return
+}
+
+// splitComparatorVersion splits the comparator from the version.
+// Input must be free of leading or trailing spaces.
+func splitComparatorVersion(s string) (string, string, error) {
+	i := strings.IndexFunc(s, unicode.IsDigit)
+	if i == -1 {
+		return "", "", fmt.Errorf("Could not get version from string: %q", s)
+	}
+	return strings.TrimSpace(s[0:i]), s[i:], nil
+}
+
+// getWildcardType will return the type of wildcard that the
+// passed version contains
+func getWildcardType(vStr string) wildcardType {
+	parts := strings.Split(vStr, ".")
+	nparts := len(parts)
+	wildcard := parts[nparts-1]
+
+	possibleWildcardType := wildcardTypefromInt(nparts)
+	if wildcard == "x" {
+		return possibleWildcardType
+	}
+
+	return noneWildcard
+}
+
+// createVersionFromWildcard will convert a wildcard version
+// into a regular version, replacing 'x's with '0's, handling
+// special cases like '1.x.x' and '1.x'
+func createVersionFromWildcard(vStr string) string {
+	// handle 1.x.x
+	vStr2 := strings.Replace(vStr, ".x.x", ".x", 1)
+	vStr2 = strings.Replace(vStr2, ".x", ".0", 1)
+	parts := strings.Split(vStr2, ".")
+
+	// handle 1.x
+	if len(parts) == 2 {
+		return vStr2 + ".0"
+	}
+
+	return vStr2
+}
+
+// incrementMajorVersion will increment the major version
+// of the passed version
+func incrementMajorVersion(vStr string) (string, error) {
+	parts := strings.Split(vStr, ".")
+	i, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return "", err
+	}
+	parts[0] = strconv.Itoa(i + 1)
+
+	return strings.Join(parts, "."), nil
+}
+
+// incrementMajorVersion will increment the minor version
+// of the passed version
+func incrementMinorVersion(vStr string) (string, error) {
+	parts := strings.Split(vStr, ".")
+	i, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return "", err
+	}
+	parts[1] = strconv.Itoa(i + 1)
+
+	return strings.Join(parts, "."), nil
+}
+
+// expandWildcardVersion will expand wildcards inside versions
+// following these rules:
+//
+// * when dealing with patch wildcards:
+// >= 1.2.x    will become    >= 1.2.0
+// <= 1.2.x    will become    <  1.3.0
+// >  1.2.x    will become    >= 1.3.0
+// <  1.2.x    will become    <  1.2.0
+// != 1.2.x    will become    <  1.2.0 >= 1.3.0
+//
+// * when dealing with minor wildcards:
+// >= 1.x      will become    >= 1.0.0
+// <= 1.x      will become    <  2.0.0
+// >  1.x      will become    >= 2.0.0
+// <  1.0      will become    <  1.0.0
+// != 1.x      will become    <  1.0.0 >= 2.0.0
+//
+// * when dealing with wildcards without
+// version operator:
+// 1.2.x       will become    >= 1.2.0 < 1.3.0
+// 1.x         will become    >= 1.0.0 < 2.0.0
+func expandWildcardVersion(parts [][]string) ([][]string, error) {
+	var expandedParts [][]string
+	for _, p := range parts {
+		var newParts []string
+		for _, ap := range p {
+			if strings.Contains(ap, "x") {
+				opStr, vStr, err := splitComparatorVersion(ap)
+				if err != nil {
+					return nil, err
+				}
+
+				versionWildcardType := getWildcardType(vStr)
+				flatVersion := createVersionFromWildcard(vStr)
+
+				var resultOperator string
+				var shouldIncrementVersion bool
+				switch opStr {
+				case ">":
+					resultOperator = ">="
+					shouldIncrementVersion = true
+				case ">=":
+					resultOperator = ">="
+				case "<":
+					resultOperator = "<"
+				case "<=":
+					resultOperator = "<"
+					shouldIncrementVersion = true
+				case "", "=", "==":
+					newParts = append(newParts, ">="+flatVersion)
+					resultOperator = "<"
+					shouldIncrementVersion = true
+				case "!=", "!":
+					newParts = append(newParts, "<"+flatVersion)
+					resultOperator = ">="
+					shouldIncrementVersion = true
+				}
+
+				var resultVersion string
+				if shouldIncrementVersion {
+					switch versionWildcardType {
+					case patchWildcard:
+						resultVersion, _ = incrementMinorVersion(flatVersion)
+					case minorWildcard:
+						resultVersion, _ = incrementMajorVersion(flatVersion)
+					}
+				} else {
+					resultVersion = flatVersion
+				}
+
+				ap = resultOperator + resultVersion
+			}
+			newParts = append(newParts, ap)
+		}
+		expandedParts = append(expandedParts, newParts)
+	}
+
+	return expandedParts, nil
+}
+
+func parseComparator(s string) comparator {
+	switch s {
+	case "==":
+		fallthrough
+	case "":
+		fallthrough
+	case "=":
+		return compEQ
+	case ">":
+		return compGT
+	case ">=":
+		return compGE
+	case "<":
+		return compLT
+	case "<=":
+		return compLE
+	case "!":
+		fallthrough
+	case "!=":
+		return compNE
+	}
+
+	return nil
+}
+
+// MustParseRange is like ParseRange but panics if the range cannot be parsed.
+func MustParseRange(s string) Range {
+	r, err := ParseRange(s)
+	if err != nil {
+		panic(`semver: ParseRange(` + s + `): ` + err.Error())
+	}
+	return r
+}

--- a/vendor/github.com/blang/semver/semver.go
+++ b/vendor/github.com/blang/semver/semver.go
@@ -1,0 +1,455 @@
+package semver
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const (
+	numbers  string = "0123456789"
+	alphas          = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-"
+	alphanum        = alphas + numbers
+)
+
+// SpecVersion is the latest fully supported spec version of semver
+var SpecVersion = Version{
+	Major: 2,
+	Minor: 0,
+	Patch: 0,
+}
+
+// Version represents a semver compatible version
+type Version struct {
+	Major uint64
+	Minor uint64
+	Patch uint64
+	Pre   []PRVersion
+	Build []string //No Precedence
+}
+
+// Version to string
+func (v Version) String() string {
+	b := make([]byte, 0, 5)
+	b = strconv.AppendUint(b, v.Major, 10)
+	b = append(b, '.')
+	b = strconv.AppendUint(b, v.Minor, 10)
+	b = append(b, '.')
+	b = strconv.AppendUint(b, v.Patch, 10)
+
+	if len(v.Pre) > 0 {
+		b = append(b, '-')
+		b = append(b, v.Pre[0].String()...)
+
+		for _, pre := range v.Pre[1:] {
+			b = append(b, '.')
+			b = append(b, pre.String()...)
+		}
+	}
+
+	if len(v.Build) > 0 {
+		b = append(b, '+')
+		b = append(b, v.Build[0]...)
+
+		for _, build := range v.Build[1:] {
+			b = append(b, '.')
+			b = append(b, build...)
+		}
+	}
+
+	return string(b)
+}
+
+// Equals checks if v is equal to o.
+func (v Version) Equals(o Version) bool {
+	return (v.Compare(o) == 0)
+}
+
+// EQ checks if v is equal to o.
+func (v Version) EQ(o Version) bool {
+	return (v.Compare(o) == 0)
+}
+
+// NE checks if v is not equal to o.
+func (v Version) NE(o Version) bool {
+	return (v.Compare(o) != 0)
+}
+
+// GT checks if v is greater than o.
+func (v Version) GT(o Version) bool {
+	return (v.Compare(o) == 1)
+}
+
+// GTE checks if v is greater than or equal to o.
+func (v Version) GTE(o Version) bool {
+	return (v.Compare(o) >= 0)
+}
+
+// GE checks if v is greater than or equal to o.
+func (v Version) GE(o Version) bool {
+	return (v.Compare(o) >= 0)
+}
+
+// LT checks if v is less than o.
+func (v Version) LT(o Version) bool {
+	return (v.Compare(o) == -1)
+}
+
+// LTE checks if v is less than or equal to o.
+func (v Version) LTE(o Version) bool {
+	return (v.Compare(o) <= 0)
+}
+
+// LE checks if v is less than or equal to o.
+func (v Version) LE(o Version) bool {
+	return (v.Compare(o) <= 0)
+}
+
+// Compare compares Versions v to o:
+// -1 == v is less than o
+// 0 == v is equal to o
+// 1 == v is greater than o
+func (v Version) Compare(o Version) int {
+	if v.Major != o.Major {
+		if v.Major > o.Major {
+			return 1
+		}
+		return -1
+	}
+	if v.Minor != o.Minor {
+		if v.Minor > o.Minor {
+			return 1
+		}
+		return -1
+	}
+	if v.Patch != o.Patch {
+		if v.Patch > o.Patch {
+			return 1
+		}
+		return -1
+	}
+
+	// Quick comparison if a version has no prerelease versions
+	if len(v.Pre) == 0 && len(o.Pre) == 0 {
+		return 0
+	} else if len(v.Pre) == 0 && len(o.Pre) > 0 {
+		return 1
+	} else if len(v.Pre) > 0 && len(o.Pre) == 0 {
+		return -1
+	}
+
+	i := 0
+	for ; i < len(v.Pre) && i < len(o.Pre); i++ {
+		if comp := v.Pre[i].Compare(o.Pre[i]); comp == 0 {
+			continue
+		} else if comp == 1 {
+			return 1
+		} else {
+			return -1
+		}
+	}
+
+	// If all pr versions are the equal but one has further prversion, this one greater
+	if i == len(v.Pre) && i == len(o.Pre) {
+		return 0
+	} else if i == len(v.Pre) && i < len(o.Pre) {
+		return -1
+	} else {
+		return 1
+	}
+
+}
+
+// IncrementPatch increments the patch version
+func (v *Version) IncrementPatch() error {
+	if v.Major == 0 {
+		return fmt.Errorf("Patch version can not be incremented for %q", v.String())
+	}
+	v.Patch += 1
+	return nil
+}
+
+// IncrementMinor increments the minor version
+func (v *Version) IncrementMinor() error {
+	if v.Major == 0 {
+		return fmt.Errorf("Minor version can not be incremented for %q", v.String())
+	}
+	v.Minor += 1
+	v.Patch = 0
+	return nil
+}
+
+// IncrementMajor increments the major version
+func (v *Version) IncrementMajor() error {
+	if v.Major == 0 {
+		return fmt.Errorf("Major version can not be incremented for %q", v.String())
+	}
+	v.Major += 1
+	v.Minor = 0
+	v.Patch = 0
+	return nil
+}
+
+// Validate validates v and returns error in case
+func (v Version) Validate() error {
+	// Major, Minor, Patch already validated using uint64
+
+	for _, pre := range v.Pre {
+		if !pre.IsNum { //Numeric prerelease versions already uint64
+			if len(pre.VersionStr) == 0 {
+				return fmt.Errorf("Prerelease can not be empty %q", pre.VersionStr)
+			}
+			if !containsOnly(pre.VersionStr, alphanum) {
+				return fmt.Errorf("Invalid character(s) found in prerelease %q", pre.VersionStr)
+			}
+		}
+	}
+
+	for _, build := range v.Build {
+		if len(build) == 0 {
+			return fmt.Errorf("Build meta data can not be empty %q", build)
+		}
+		if !containsOnly(build, alphanum) {
+			return fmt.Errorf("Invalid character(s) found in build meta data %q", build)
+		}
+	}
+
+	return nil
+}
+
+// New is an alias for Parse and returns a pointer, parses version string and returns a validated Version or error
+func New(s string) (vp *Version, err error) {
+	v, err := Parse(s)
+	vp = &v
+	return
+}
+
+// Make is an alias for Parse, parses version string and returns a validated Version or error
+func Make(s string) (Version, error) {
+	return Parse(s)
+}
+
+// ParseTolerant allows for certain version specifications that do not strictly adhere to semver
+// specs to be parsed by this library. It does so by normalizing versions before passing them to
+// Parse(). It currently trims spaces, removes a "v" prefix, adds a 0 patch number to versions
+// with only major and minor components specified, and removes leading 0s.
+func ParseTolerant(s string) (Version, error) {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "v")
+
+	// Split into major.minor.(patch+pr+meta)
+	parts := strings.SplitN(s, ".", 3)
+	// Remove leading zeros.
+	for i, p := range parts {
+		if len(p) > 1 {
+			parts[i] = strings.TrimPrefix(p, "0")
+		}
+	}
+	// Fill up shortened versions.
+	if len(parts) < 3 {
+		if strings.ContainsAny(parts[len(parts)-1], "+-") {
+			return Version{}, errors.New("Short version cannot contain PreRelease/Build meta data")
+		}
+		for len(parts) < 3 {
+			parts = append(parts, "0")
+		}
+	}
+	s = strings.Join(parts, ".")
+
+	return Parse(s)
+}
+
+// Parse parses version string and returns a validated Version or error
+func Parse(s string) (Version, error) {
+	if len(s) == 0 {
+		return Version{}, errors.New("Version string empty")
+	}
+
+	// Split into major.minor.(patch+pr+meta)
+	parts := strings.SplitN(s, ".", 3)
+	if len(parts) != 3 {
+		return Version{}, errors.New("No Major.Minor.Patch elements found")
+	}
+
+	// Major
+	if !containsOnly(parts[0], numbers) {
+		return Version{}, fmt.Errorf("Invalid character(s) found in major number %q", parts[0])
+	}
+	if hasLeadingZeroes(parts[0]) {
+		return Version{}, fmt.Errorf("Major number must not contain leading zeroes %q", parts[0])
+	}
+	major, err := strconv.ParseUint(parts[0], 10, 64)
+	if err != nil {
+		return Version{}, err
+	}
+
+	// Minor
+	if !containsOnly(parts[1], numbers) {
+		return Version{}, fmt.Errorf("Invalid character(s) found in minor number %q", parts[1])
+	}
+	if hasLeadingZeroes(parts[1]) {
+		return Version{}, fmt.Errorf("Minor number must not contain leading zeroes %q", parts[1])
+	}
+	minor, err := strconv.ParseUint(parts[1], 10, 64)
+	if err != nil {
+		return Version{}, err
+	}
+
+	v := Version{}
+	v.Major = major
+	v.Minor = minor
+
+	var build, prerelease []string
+	patchStr := parts[2]
+
+	if buildIndex := strings.IndexRune(patchStr, '+'); buildIndex != -1 {
+		build = strings.Split(patchStr[buildIndex+1:], ".")
+		patchStr = patchStr[:buildIndex]
+	}
+
+	if preIndex := strings.IndexRune(patchStr, '-'); preIndex != -1 {
+		prerelease = strings.Split(patchStr[preIndex+1:], ".")
+		patchStr = patchStr[:preIndex]
+	}
+
+	if !containsOnly(patchStr, numbers) {
+		return Version{}, fmt.Errorf("Invalid character(s) found in patch number %q", patchStr)
+	}
+	if hasLeadingZeroes(patchStr) {
+		return Version{}, fmt.Errorf("Patch number must not contain leading zeroes %q", patchStr)
+	}
+	patch, err := strconv.ParseUint(patchStr, 10, 64)
+	if err != nil {
+		return Version{}, err
+	}
+
+	v.Patch = patch
+
+	// Prerelease
+	for _, prstr := range prerelease {
+		parsedPR, err := NewPRVersion(prstr)
+		if err != nil {
+			return Version{}, err
+		}
+		v.Pre = append(v.Pre, parsedPR)
+	}
+
+	// Build meta data
+	for _, str := range build {
+		if len(str) == 0 {
+			return Version{}, errors.New("Build meta data is empty")
+		}
+		if !containsOnly(str, alphanum) {
+			return Version{}, fmt.Errorf("Invalid character(s) found in build meta data %q", str)
+		}
+		v.Build = append(v.Build, str)
+	}
+
+	return v, nil
+}
+
+// MustParse is like Parse but panics if the version cannot be parsed.
+func MustParse(s string) Version {
+	v, err := Parse(s)
+	if err != nil {
+		panic(`semver: Parse(` + s + `): ` + err.Error())
+	}
+	return v
+}
+
+// PRVersion represents a PreRelease Version
+type PRVersion struct {
+	VersionStr string
+	VersionNum uint64
+	IsNum      bool
+}
+
+// NewPRVersion creates a new valid prerelease version
+func NewPRVersion(s string) (PRVersion, error) {
+	if len(s) == 0 {
+		return PRVersion{}, errors.New("Prerelease is empty")
+	}
+	v := PRVersion{}
+	if containsOnly(s, numbers) {
+		if hasLeadingZeroes(s) {
+			return PRVersion{}, fmt.Errorf("Numeric PreRelease version must not contain leading zeroes %q", s)
+		}
+		num, err := strconv.ParseUint(s, 10, 64)
+
+		// Might never be hit, but just in case
+		if err != nil {
+			return PRVersion{}, err
+		}
+		v.VersionNum = num
+		v.IsNum = true
+	} else if containsOnly(s, alphanum) {
+		v.VersionStr = s
+		v.IsNum = false
+	} else {
+		return PRVersion{}, fmt.Errorf("Invalid character(s) found in prerelease %q", s)
+	}
+	return v, nil
+}
+
+// IsNumeric checks if prerelease-version is numeric
+func (v PRVersion) IsNumeric() bool {
+	return v.IsNum
+}
+
+// Compare compares two PreRelease Versions v and o:
+// -1 == v is less than o
+// 0 == v is equal to o
+// 1 == v is greater than o
+func (v PRVersion) Compare(o PRVersion) int {
+	if v.IsNum && !o.IsNum {
+		return -1
+	} else if !v.IsNum && o.IsNum {
+		return 1
+	} else if v.IsNum && o.IsNum {
+		if v.VersionNum == o.VersionNum {
+			return 0
+		} else if v.VersionNum > o.VersionNum {
+			return 1
+		} else {
+			return -1
+		}
+	} else { // both are Alphas
+		if v.VersionStr == o.VersionStr {
+			return 0
+		} else if v.VersionStr > o.VersionStr {
+			return 1
+		} else {
+			return -1
+		}
+	}
+}
+
+// PreRelease version to string
+func (v PRVersion) String() string {
+	if v.IsNum {
+		return strconv.FormatUint(v.VersionNum, 10)
+	}
+	return v.VersionStr
+}
+
+func containsOnly(s string, set string) bool {
+	return strings.IndexFunc(s, func(r rune) bool {
+		return !strings.ContainsRune(set, r)
+	}) == -1
+}
+
+func hasLeadingZeroes(s string) bool {
+	return len(s) > 1 && s[0] == '0'
+}
+
+// NewBuildVersion creates a new valid build version
+func NewBuildVersion(s string) (string, error) {
+	if len(s) == 0 {
+		return "", errors.New("Buildversion is empty")
+	}
+	if !containsOnly(s, alphanum) {
+		return "", fmt.Errorf("Invalid character(s) found in build meta data %q", s)
+	}
+	return s, nil
+}

--- a/vendor/github.com/blang/semver/sort.go
+++ b/vendor/github.com/blang/semver/sort.go
@@ -1,0 +1,28 @@
+package semver
+
+import (
+	"sort"
+)
+
+// Versions represents multiple versions.
+type Versions []Version
+
+// Len returns length of version collection
+func (s Versions) Len() int {
+	return len(s)
+}
+
+// Swap swaps two versions inside the collection by its indices
+func (s Versions) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+// Less checks if version at index i is less than version at index j
+func (s Versions) Less(i, j int) bool {
+	return s[i].LT(s[j])
+}
+
+// Sort sorts a slice of versions
+func Sort(versions []Version) {
+	sort.Sort(Versions(versions))
+}

--- a/vendor/github.com/blang/semver/sql.go
+++ b/vendor/github.com/blang/semver/sql.go
@@ -1,0 +1,30 @@
+package semver
+
+import (
+	"database/sql/driver"
+	"fmt"
+)
+
+// Scan implements the database/sql.Scanner interface.
+func (v *Version) Scan(src interface{}) (err error) {
+	var str string
+	switch src := src.(type) {
+	case string:
+		str = src
+	case []byte:
+		str = string(src)
+	default:
+		return fmt.Errorf("version.Scan: cannot convert %T to string", src)
+	}
+
+	if t, err := Parse(str); err == nil {
+		*v = t
+	}
+
+	return
+}
+
+// Value implements the database/sql/driver.Valuer interface.
+func (v Version) Value() (driver.Value, error) {
+	return v.String(), nil
+}


### PR DESCRIPTION
Fixes #61 and #65 
I imported a semver parser to assist in detecting when a repository contains a newer version of a collection than what is currently coded in the collection's `Spec.Version`.  We currently search thru all repositories looking for a newer version, and if we find one, we'll update the `Status` to say where it is and what the version is.  The user can choose to proceed by updating the `Spec.Version` to the new level.

When changing between versions (up or down), the collection controller will first find the requested version.  Once found, we'll attempt to resolve all existing assets using their original URLs.  If they are all found, then we'll proceed to remove them.  Next we'll apply the new version as if it were being applied for the first time.

To test this, I created a new repository using the V1 index format, containing a v0.2.1 and v0.2.2 java microprofile stack (they were essentially both the v0.2.1 stack with some cosmetic changes).  I was able to switch back and forth between the two, and the Kubernetes resources were switched.  If I tried to switch to a version that did not exist, the `Status` was updated with an error message saying so.