### PR TITLE
Build break - unstructured was removed from imports.

### DIFF
--- a/pkg/controller/collection/collection_controller.go
+++ b/pkg/controller/collection/collection_controller.go
@@ -345,10 +345,11 @@ func activate(collectionResource *kabanerov1alpha1.Collection, collection *Colle
 
 			log.Info(fmt.Sprintf("Resources: %v", m.Resources))
 
-			err = m.Transform(func(u *unstructured.Unstructured) error {
-				u.SetNamespace(collectionResource.GetNamespace())
-				return nil
-			})
+			transforms := []mf.Transformer{
+				mf.InjectNamespace(collectionResource.GetNamespace()),
+			}
+
+			err = m.Transform(transforms...)
 			if err != nil {
 				log.Error(err, errorMessage, "resource", asset.Url)
 				collectionResource.Status.StatusMessage = errorMessage + ": " + err.Error()


### PR DESCRIPTION
Conflict between #90 and #93.  The import of `unstructured` was removed.  I modified the code to follow the convention established by #90. 