### PR TITLE
Handle Collection V2 index

### DIFF
--- a/build/bin/dummy.yaml
+++ b/build/bin/dummy.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service
+spec:
+  selector:
+    app: MyApp
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 9376

--- a/config/samples/collection.yaml
+++ b/config/samples/collection.yaml
@@ -3,4 +3,4 @@ kind: Collection
 metadata:
   name: java-microprofile
 spec:
-  version: 1.0.0
+  version: 0.0.2

--- a/config/samples/full.yaml
+++ b/config/samples/full.yaml
@@ -10,7 +10,7 @@ spec:
   collections: 
     # A list of those repositories which are searched for collections
     repositories: 
-    - name: experimental
-      url: https://raw.githubusercontent.com/kabanero-io/kabanero-collection/master/experimental/index.yaml
+    - name: incubator
+      url: https://github.com/kabanero-io/collections/releases/download/v0.0.1/incubator-index.yaml
       # Activates a default set of collections
       activateDefaultCollections: true 

--- a/pkg/controller/collection/archive.go
+++ b/pkg/controller/collection/archive.go
@@ -1,0 +1,83 @@
+package collection
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"archive/tar"
+	"compress/gzip"
+	"bytes"
+	"io"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/yaml"
+)
+
+func DownloadToByte(url string) ([]byte, error) {
+	r, err := http.Get(url)
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("Could not download file: %v", url))
+	}
+	defer r.Body.Close()
+	b, err := ioutil.ReadAll(r.Body)
+	return b, err
+}
+
+
+//Read the manifests from a tar.gz archive
+//It would be better to use the manifest.yaml as the index, and check the signatures
+//For now, ignore manifest.yaml and return all other yaml files from the archive
+func DecodeManifests (archive []byte) ([]unstructured.Unstructured, error) {
+
+	manifests := []unstructured.Unstructured{}
+
+	r := bytes.NewReader(archive)
+	gzReader, err := gzip.NewReader(r)
+		if err != nil {
+			return nil, errors.New(fmt.Sprintf("Could not read manifest gzip"))
+		}
+	tarReader := tar.NewReader(gzReader)
+	
+	decoder := yaml.NewYAMLToJSONDecoder(tarReader)
+	
+	for {
+		header, err := tarReader.Next()
+
+		if err == io.EOF {
+			break
+		}
+
+		if err != nil {
+			return nil, errors.New(fmt.Sprintf("Could not read manifest tar"))
+		}
+
+		//For now skip manifest.yaml, rather than utilizing it as the index of the archive
+		switch {
+		case header.Name == "./manifest.yaml":
+			break
+		case strings.HasSuffix(header.Name, ".yaml"):
+			out := unstructured.Unstructured{}
+			err = decoder.Decode(&out)
+			if err != nil {
+				fmt.Sprintf("Error decoding %v", header.Name)
+			}
+			manifests = append(manifests, out)
+		}
+	}
+	return manifests, nil
+}
+
+
+func GetManifests(url string) ([]unstructured.Unstructured, error) {
+
+	b, err := DownloadToByte(url)
+	if err != nil {
+		return nil, err
+	}
+	manifests, err := DecodeManifests(b)
+	if err != nil {
+		return nil, err
+	}
+	return manifests, err
+}

--- a/pkg/controller/collection/archive_test.go
+++ b/pkg/controller/collection/archive_test.go
@@ -1,0 +1,16 @@
+package collection
+
+import (
+	"testing"
+)
+
+func TestGetManifests(t *testing.T) {
+	manifests, err := GetManifests("https://github.com/kabanero-io/collections/releases/download/v0.0.1/incubator.java-microprofile.pipeline.default.tar.gz")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, manifest := range manifests {
+		t.Log(manifest)
+	}
+}

--- a/pkg/controller/collection/collection_index.go
+++ b/pkg/controller/collection/collection_index.go
@@ -1,0 +1,12 @@
+package collection
+
+type CollectionV1Index struct {
+	ApiVersion  string                           `yaml:"apiVersion,omitempty"`
+	
+	// V1 Collections
+	Generated   string                           `yaml:"generated,omitempty"`
+	Collections map[string][]IndexedCollectionV1 `yaml:"projects,omitempty"`
+	
+	// V2 Collections
+	CollectionsV2 []IndexedCollectionV2 `yaml:"stacks,omitempty"`
+}

--- a/pkg/controller/collection/collection_v1.go
+++ b/pkg/controller/collection/collection_v1.go
@@ -1,10 +1,5 @@
 package collection
 
-type CollectionV1Index struct {
-	ApiVersion  string                           `yaml:"apiVersion,omitempty"`
-	Generated   string                           `yaml:"generated,omitempty"`
-	Collections map[string][]IndexedCollectionV1 `yaml:"projects,omitempty"`
-}
 
 // Convenience function which iterates over the complex Collections structure
 func (c *CollectionV1Index) ListCollections() []IndexedCollectionV1 {

--- a/pkg/controller/collection/collection_v2.go
+++ b/pkg/controller/collection/collection_v2.go
@@ -1,0 +1,61 @@
+package collection
+
+
+// Convenience function which iterates over the complex Collections structure
+//func (c *CollectionV1Index) ListCollectionsV2() []IndexedCollectionV2 {
+//	all := make([]IndexedCollectionV2, 0)
+//	for _, v := range c.CollectionsV2 {
+//		for _, colRef := range v {
+//			all = append(all, colRef)
+//		}
+//	}
+//
+//	return all
+//}
+
+type IndexedCollectionV2 struct {
+	DefaultDashboard   string                   `yaml:"default-dashboard,omitempty"`
+	DefaultImage       string                   `yaml:"default-image,omitempty"`
+	DefaultPipeline    string                   `yaml:"default-pipeline,omitempty"`
+	DefaultTemplate    string                   `yaml:"default-template,omitempty"`
+	Description        string                   `yaml:"description,omitempty"`
+	Id                 string                   `yaml:"id,omitempty"`
+	Images             []IndexedImagesV2        `yaml:"images,omitempty"`
+	License            string                   `yaml:"license,omitempty"`
+	Maintainers        []IndexedMaintainersV2   `yaml:"maintainers,omitempty"`
+	Name               string                   `yaml:"name,omitempty"`
+	Pipelines          []IndexedPipelinesV2     `yaml:"pipelines,omitempty"`
+	Templates          []IndexedTemplatesV2     `yaml:"templates,omitempty"`
+	Version            string                   `yaml:"version,omitempty"`
+}
+
+type IndexedImagesV2 struct {
+	Id                 string                   `yaml:"id,omitempty"`
+	Image              string                   `yaml:"image,omitempty"`
+}
+
+type IndexedMaintainersV2 struct {
+	Email              string                   `yaml:"email,omitempty"`
+	GithubId           string                   `yaml:"github-id,omitempty"`
+	Name               string                   `yaml:"name,omitempty"`
+}
+
+type IndexedPipelinesV2 struct {
+	Id                 string                   `yaml:"id,omitempty"`
+	Sha256             string                   `yaml:"sha256,omitempty"`
+	Url                string                   `yaml:"url,omitempty"`
+}
+
+type IndexedTemplatesV2 struct {
+	Id                 string                   `yaml:"id,omitempty"`
+	Url                string                   `yaml:"url,omitempty"`
+}
+
+type PipelineManifestV2 struct {
+	Contents           []PipelineFilesV2        `yaml:"contents,omitempty"`
+}
+
+type PipelineFilesV2 struct {
+	File               string                   `yaml:"file,omitempty"`
+	Sha256             string                   `yaml:"sha256,omitempty"`
+}

--- a/pkg/controller/collection/resolver.go
+++ b/pkg/controller/collection/resolver.go
@@ -7,10 +7,20 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strings"
+	"regexp"
 )
 
 func ResolveIndex(url string) (*CollectionV1Index, error) {
-	if !strings.HasSuffix(url, "/index.yaml") {
+//	if !strings.HasSuffix(url, "/index.yaml") {
+//		url = url + "/index.yaml"
+//	}
+	
+	// user may specify url to yaml file or directory
+	matched, err := regexp.MatchString(`/([^/]+)[.]yaml$`, url) 
+	if err != nil {
+		return nil, err
+	}
+	if !matched {
 		url = url + "/index.yaml"
 	}
 
@@ -71,6 +81,26 @@ func SearchCollection(collectionName string, index *CollectionV1Index) ([]Collec
 	return collections, nil
 }
 
+
+// Return all resolved collections in the index matching the given name.
+func SearchCollectionV2(collectionName string, index *CollectionV1Index) ([]IndexedCollectionV2, error) {
+	//Locate the desired collection in the index
+	var collectionRefs []IndexedCollectionV2
+	
+	for _, collectionRef := range index.CollectionsV2 {
+		if collectionRef.Id == collectionName {
+			collectionRefs = append(collectionRefs, collectionRef)
+		}
+	}
+
+	if len(collectionRefs) == 0 {
+		//The collection referenced in the Collection resource has no match in the index
+		return nil, nil
+	}
+
+	return collectionRefs, nil
+}
+
 func ResolveCollection(urls ...string) (*CollectionV1, error) {
 	for _, url := range urls {
 		if strings.HasSuffix(url, "tar.gz") {
@@ -110,3 +140,19 @@ func ResolveCollection(urls ...string) (*CollectionV1, error) {
 
 	return nil, nil
 }
+
+
+
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	

--- a/pkg/controller/collection/resolver.go
+++ b/pkg/controller/collection/resolver.go
@@ -140,19 +140,3 @@ func ResolveCollection(urls ...string) (*CollectionV1, error) {
 
 	return nil, nil
 }
-
-
-
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	

--- a/pkg/controller/collection/resolver_test.go
+++ b/pkg/controller/collection/resolver_test.go
@@ -19,6 +19,21 @@ func TestResolveIndex(t *testing.T) {
 	}
 }
 
+func TestResolveIndexV2(t *testing.T) {
+	index, err := ResolveIndex("https://github.com/kabanero-io/collections/releases/download/v0.0.1/incubator-index.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if index == nil {
+		t.Fatal("Returned index was nil")
+	}
+
+	if index.ApiVersion != "v2" {
+		t.Fatal("Expected apiVersion == v2")
+	}
+}
+
 func TestResolveCollection(t *testing.T) {
 	collection, err := ResolveCollection("https://raw.githubusercontent.com/kabanero-io/kabanero-collection/master/experimental/java-microprofile-0.2.1/collection.yaml")
 	if err != nil {

--- a/pkg/controller/kabaneroplatform/kabaneroplatform_controller.go
+++ b/pkg/controller/kabaneroplatform/kabaneroplatform_controller.go
@@ -100,6 +100,12 @@ func (r *ReconcileKabanero) Reconcile(request reconcile.Request) (reconcile.Resu
 		fmt.Println("Error in reconcile featured collections: ", err)
 		return reconcile.Result{}, err
 	}
+	
+	err = reconcileFeaturedCollectionsV2(ctx, instance, r.client)
+	if err != nil {
+		fmt.Println("Error in reconcile featured collections V2: ", err)
+		return reconcile.Result{}, err
+	}
 
 	//Save the status update
 	err = r.client.Status().Update(ctx, instance)


### PR DESCRIPTION
- Add a local dummy.yaml file for Manifestival to construct a Manifest before providing our own unstructured array
- Update reference to collection index, and version
- Archive processes the downloaded pipeline asset tar.gz into unstructured array for Manifestival
- CollectionV1Index is a misnomer, it may now be populated by V1 or V2 
- Add a CollectionV2 struct
- Add necessary V2 funcs to collection_controller

Tested
- Can still install V1
- Can upgrade from V1 to V2 by updating Kabanero repositories and Collection version
- Can install V2

Current Limitation
- Directly deleting the pipeline resources will not auto re-reconcile the resources, since the check is against the archive signature & version
- The archive manifest.yaml is not processed at all, all yaml files excluding manifest are used

