### PR TITLE
Use version 0.1.0 of the Kabanero collections

### DIFF
--- a/config/samples/full.yaml
+++ b/config/samples/full.yaml
@@ -11,6 +11,6 @@ spec:
     # A list of those repositories which are searched for collections
     repositories: 
     - name: incubator
-      url: https://github.com/kabanero-io/collections/releases/download/v0.0.1/incubator-index.yaml
+      url: https://github.com/kabanero-io/collections/releases/download/v0.1.0/kabanero-index.yaml
       # Activates a default set of collections
       activateDefaultCollections: true 

--- a/deploy/olm-catalog/kabanero-operator/0.0.1/kabanero-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kabanero-operator/0.0.1/kabanero-operator.v0.0.1.clusterserviceversion.yaml
@@ -25,8 +25,8 @@ metadata:
             "collections": {
               "repositories": [
                 {
-                  "name": "experimental",
-                  "url": "https://raw.githubusercontent.com/kabanero-io/kabanero-collection/master/experimental/index.yaml",
+                  "name": "incubator",
+                  "url": "https://github.com/kabanero-io/collections/releases/download/v0.1.0/kabanero-index.yaml",
                   "activateDefaultCollections": true
                 }
               ]


### PR DESCRIPTION
The collections team released 0.1.0 and we're updating our samples to use that.