### PR TITLE
92 multiple repository, upgrade

### DIFF
--- a/deploy/crds/kabanero_v1alpha1_collection_crd.yaml
+++ b/deploy/crds/kabanero_v1alpha1_collection_crd.yaml
@@ -55,6 +55,8 @@ spec:
               type: array
             activeDigest:
               type: string
+            activeLocation:
+              type: string
             activeVersion:
               type: string
             availableLocation:

--- a/deploy/crds/kabanero_v1alpha1_kabanero_crd.yaml
+++ b/deploy/crds/kabanero_v1alpha1_kabanero_crd.yaml
@@ -12,19 +12,6 @@ spec:
   scope: Namespaced
   subresources:
     status: {}
-  additionalPrinterColumns:
-    - JSONPath: .metadata.creationTimestamp
-      description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations.
-      name: Age
-      type: date
-    - JSONPath: .status.kabaneroInstance.version
-      description: Kabanero operator instance version.
-      name: Version
-      type: string
-    - JSONPath: .status.kabaneroInstance.ready
-      description: Kabanero operator instance readiness status. The status is directly correlated to the availability of the operator's resources dependencies.
-      name: Ready
-      type: string
   validation:
     openAPIV3Schema:
       properties:

--- a/pkg/apis/kabanero/v1alpha1/collection_types.go
+++ b/pkg/apis/kabanero/v1alpha1/collection_types.go
@@ -29,6 +29,7 @@ type RepositoryAssetStatus struct {
 // +k8s:openapi-gen=true
 type CollectionStatus struct {
 	ActiveVersion string `json:"activeVersion,omitempty"`
+	ActiveLocation string `json:"activeLocation,omitempty"`
 	ActiveDigest  string `json:"activeDigest,omitempty"`
 	ActiveAssets []RepositoryAssetStatus `json:"activeAssets,omitempty"`
 	AvailableVersion string `json:"availableVersion,omitempty"`

--- a/pkg/apis/kabanero/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/kabanero/v1alpha1/zz_generated.openapi.go
@@ -108,6 +108,12 @@ func schema_pkg_apis_kabanero_v1alpha1_CollectionStatus(ref common.ReferenceCall
 							Format: "",
 						},
 					},
+					"activeLocation": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 					"activeDigest": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},

--- a/pkg/controller/collection/collection_index.go
+++ b/pkg/controller/collection/collection_index.go
@@ -1,12 +1,15 @@
 package collection
 
 type CollectionV1Index struct {
-	ApiVersion  string                           `yaml:"apiVersion,omitempty"`
+	ApiVersion      string                              `yaml:"apiVersion,omitempty"`
 	
 	// V1 Collections
-	Generated   string                           `yaml:"generated,omitempty"`
-	Collections map[string][]IndexedCollectionV1 `yaml:"projects,omitempty"`
+	Generated       string                              `yaml:"generated,omitempty"`
+	Collections     map[string][]IndexedCollectionV1    `yaml:"projects,omitempty"`
 	
 	// V2 Collections
-	CollectionsV2 []IndexedCollectionV2 `yaml:"stacks,omitempty"`
+	CollectionsV2   []IndexedCollectionV2               `yaml:"stacks,omitempty"`
+	
+	// Source URL of this index
+	Url              string                             `yaml:"url,omitempty"`
 }

--- a/pkg/controller/collection/resolver.go
+++ b/pkg/controller/collection/resolver.go
@@ -44,6 +44,7 @@ func ResolveIndex(url string) (*CollectionV1Index, error) {
 	if err != nil {
 		return nil, err
 	}
+	index.Url = url
 
 	return &index, nil
 }


### PR DESCRIPTION
- Add activeLocation to the Kabanero Collection Status to track the repository the current collection is installed from
- Set the in-line default index url to the 0.1.0 collection release
- Set the availableLocation, availableVersion to max ver from any index Kabanero knows about, if there is a new version with the same Id
- Fix the upgrade portion of activatev2
- Store the url of the CollectionIndex in its struct (although didn't end up being neccessary for this purpose)


Example/Test

User sets spec to version 0.2.8, and is also notified 0.2.9 is available in another repository

```
apiVersion: kabanero.io/v1alpha1
kind: Collection
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"kabanero.io/v1alpha1","kind":"Collection","metadata":{"annotations":{},"name":"java-microprofile","namespace":"kabanero"},"spec":{"version":"0.2.8"}}
  creationTimestamp: 2019-08-23T19:47:50Z
  generation: 3
  name: java-microprofile
  namespace: kabanero
  ownerReferences:
  - apiVersion: kabanero.io/v1alpha1
    controller: true
    kind: Kabanero
    name: kabanero
    uid: beeee665-c5de-11e9-802b-0016ac101f45
  resourceVersion: "1327215"
  selfLink: /apis/kabanero.io/v1alpha1/namespaces/kabanero/collections/java-microprofile
  uid: e38a0294-c5de-11e9-802b-0016ac101f45
spec:
  version: 0.2.8
status:
  activeAssets:
  - assetDigest: cb84ebba1f43a7767db9dfbc3c071f11e5f8f45d1da50fae6bb2bd4e0fcfce12
    assetName: default
    status: active
    url: https://github.com/kabanero-io/collections/releases/download/v0.0.5/incubator.java-microprofile.v0.2.8.pipeline.default.tar.gz
  activeLocation: https://github.com/kabanero-io/collections/releases/download/v0.0.5/kabanero.yaml
  activeVersion: 0.2.8
  availableLocation: https://github.com/kabanero-io/collections/releases/download/v0.1.0/kabanero-index.yaml
  availableVersion: 0.2.9
```

Changing spec to 0.2.9 will upgrade from the availableLocation, and then show no available upgrades

```
kind: Collection
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"kabanero.io/v1alpha1","kind":"Collection","metadata":{"annotations":{},"name":"java-microprofile","namespace":"kabanero"},"spec":{"version":"0.2.8"}}
  creationTimestamp: 2019-08-23T19:47:50Z
  generation: 4
  name: java-microprofile
  namespace: kabanero
  ownerReferences:
  - apiVersion: kabanero.io/v1alpha1
    controller: true
    kind: Kabanero
    name: kabanero
    uid: beeee665-c5de-11e9-802b-0016ac101f45
  resourceVersion: "1327336"
  selfLink: /apis/kabanero.io/v1alpha1/namespaces/kabanero/collections/java-microprofile
  uid: e38a0294-c5de-11e9-802b-0016ac101f45
spec:
  version: 0.2.9
status:
  activeAssets:
  - assetDigest: 212b31c4b73efa97f720f121b496d46f0bcbae80a4eec2ab861d2f455b1cf8e5
    assetName: default
    status: active
    url: https://github.com/kabanero-io/collections/releases/download/v0.1.0/incubator.java-microprofile.v0.2.9.pipeline.default.tar.gz
  activeLocation: https://github.com/kabanero-io/collections/releases/download/v0.1.0/kabanero-index.yaml
  activeVersion: 0.2.9
```
