### PR TITLE
Update version to 0.1.0 and fix CSV required field.

### DIFF
--- a/config/samples/full.yaml
+++ b/config/samples/full.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   # The platform version determines the desired version for all components, but those
   # can be overriden individually as well
-  version: 0.0.1
+  version: 0.1.0
 
   collections: 
     # A list of those repositories which are searched for collections

--- a/deploy/olm-catalog/kabanero-operator/0.1.0/kabanero-operator-package.yaml
+++ b/deploy/olm-catalog/kabanero-operator/0.1.0/kabanero-operator-package.yaml
@@ -1,6 +1,6 @@
 packageName: kabanero-operator
 channels:
 - name: alpha
-  currentCSV: kabanero-operator.v0.0.1
+  currentCSV: kabanero-operator.v0.1.0
 defaultChannel: alpha
 

--- a/deploy/olm-catalog/kabanero-operator/0.1.0/kabanero-operator.v0.1.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/kabanero-operator/0.1.0/kabanero-operator.v0.1.0.clusterserviceversion.yaml
@@ -1,7 +1,7 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: kabanero-operator.v0.0.1
+  name: kabanero-operator.v0.1.0
   namespace: placeholder
   annotations:
     capabilities: Basic Install
@@ -21,7 +21,7 @@ metadata:
             "name": "kabanero"
           },
           "spec": {
-            "version": "0.0.1",
+            "version": "0.1.0",
             "collections": {
               "repositories": [
                 {
@@ -40,7 +40,7 @@ metadata:
             "name": "java-microprofile"
           },
           "spec": {
-            "version": "1.0.0"
+            "version": "0.0.2"
           }
         }
       ]
@@ -49,7 +49,7 @@ spec:
   minKubeVersion: 1.11.0
   apiservicedefinitions: {}
   maturity: alpha
-  version: 0.0.1
+  version: 0.1.0
   displayName: Kabanero Operator
   description: |
     The Kabanero operator is used to manage Kabanero Foundation instances on your Open Shift or Kubernetes cluster.
@@ -186,9 +186,9 @@ spec:
       kind: KnativeEventing
       displayName: Knative Eventing
       description: Knative Eventing
-    - name: installs.tekton.dev
+    - name: config.operator.tekton.dev
       version: v1alpha1
-      kind: Install
+      kind: Config
       displayName: OpenShift Pipelines Install
       description: OpenShift Pipelines using Tekton
   install:

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "0.0.1"
+	Version = "0.1.0"
 )


### PR DESCRIPTION
This PR updates the kabanero operator version to 0.1.0.
It also fixes tekton related fields in the required section.