### PR TITLE
Converge v1beta1 and v1alpha1 CRDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,8 @@ generate:
 
 install:
 	kubectl config set-context $$(kubectl config current-context) --namespace=kabanero
-	kubectl apply -f deploy/crds/
+	kubectl apply -f deploy/crds/kabanero_kabanero_crd.yaml
+	kubectl apply -f deploy/crds/kabanero_collection_crd.yaml
 	
 deploy: 
 	kubectl create namespace kabanero || true

--- a/contrib/gen_operator_deployment.sh
+++ b/contrib/gen_operator_deployment.sh
@@ -129,8 +129,8 @@ EOF
 
 # Add all needed yaml files.
 cat $DEST_DIR/dependencies.yaml >> $DEST_FILE_TMP; echo "---" >> $DEST_FILE_TMP
-cat $DEST_DIR/crds/kabanero_v1alpha1_kabanero_crd.yaml >> $DEST_FILE_TMP; echo "---" >> $DEST_FILE_TMP
-cat $DEST_DIR/crds/kabanero_v1alpha1_collection_crd.yaml >> $DEST_FILE_TMP; echo "---" >> $DEST_FILE_TMP
+cat $DEST_DIR/crds/kabanero_kabanero_crd.yaml >> $DEST_FILE_TMP; echo "---" >> $DEST_FILE_TMP
+cat $DEST_DIR/crds/kabanero_collection_crd.yaml >> $DEST_FILE_TMP; echo "---" >> $DEST_FILE_TMP
 cat $DEST_DIR/service_account.yaml >> $DEST_FILE_TMP; echo "---" >> $DEST_FILE_TMP
 cat $DEST_DIR/operator.yaml >> $DEST_FILE_TMP; echo "---" >> $DEST_FILE_TMP; echo
 cat $DEST_DIR/role.yaml >> $DEST_FILE_TMP;  echo "---" >> $DEST_FILE_TMP;

--- a/deploy/crds/kabanero_collection_crd.yaml
+++ b/deploy/crds/kabanero_collection_crd.yaml
@@ -1,0 +1,130 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: collections.kabanero.io
+spec:
+  group: kabanero.io
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              name:
+                type: string
+              repositoryUrl:
+                type: string
+              version:
+                type: string
+            type: object
+          status:
+            properties:
+              activeAssets:
+                items:
+                  properties:
+                    assetDigest:
+                      type: string
+                    assetName:
+                      type: string
+                    status:
+                      type: string
+                    statusMessage:
+                      type: string
+                    url:
+                      type: string
+                  type: object
+                type: array
+              activeDigest:
+                type: string
+              activeLocation:
+                type: string
+              activeVersion:
+                type: string
+              availableLocation:
+                type: string
+              availableVersion:
+                type: string
+              statusMessage:
+                type: string
+            type: object
+  - name: v1beta1
+    served: true
+    storage: false
+    schema: 
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              name:
+                type: string
+              repositoryUrl:
+                type: string
+              version:
+                type: string
+            type: object
+          status:
+            properties:
+              activeAssets:
+                items:
+                  properties:
+                    assetDigest:
+                      type: string
+                    assetName:
+                      type: string
+                    status:
+                      type: string
+                    statusMessage:
+                      type: string
+                    url:
+                      type: string
+                  type: object
+                type: array
+              activeDigest:
+                type: string
+              activeVersion:
+                type: string
+              availableLocation:
+                type: string
+              availableVersion:
+                type: string
+              statusMessage:
+                type: string
+            type: object
+  conversion:
+    strategy: None
+  names:
+    kind: Collection
+    listKind: CollectionList
+    plural: collections
+    singular: collection
+  scope: Namespaced
+  subresources:
+    status: {}
+

--- a/deploy/crds/kabanero_kabanero_crd.yaml
+++ b/deploy/crds/kabanero_kabanero_crd.yaml
@@ -1,0 +1,213 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kabaneros.kabanero.io
+spec:
+  group: kabanero.io
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              collections:
+                properties:
+                  repositories:
+                    items:
+                      properties:
+                        activateDefaultCollections:
+                          type: boolean
+                        name:
+                          type: string
+                        url:
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              tekton:
+                properties:
+                  disabled:
+                    type: boolean
+                  version:
+                    type: string
+                type: object
+              version:
+                type: string
+            type: object
+          status:
+            properties:
+              cli:
+                description: CLI readiness status.
+                properties:
+                  errorMessage:
+                    type: string
+                  hostnames:
+                    items:
+                      type: string
+                    type: array
+                type: object
+              kabaneroInstance:
+                description: Kabanero operator instance readiness status. The status
+                  is directly correlated to the availability of resources dependencies.
+                properties:
+                  errorMessage:
+                    type: string
+                  ready:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              knativeEventing:
+                description: Knative eventing instance readiness status.
+                properties:
+                  errorMessage:
+                    type: string
+                  ready:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              knativeServing:
+                description: Knative serving instance readiness status.
+                properties:
+                  errorMessage:
+                    type: string
+                  ready:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              landing:
+                description: Kabanero Landing page readiness status.
+                properties:
+                  errorMessage:
+                    type: string
+                  ready:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              tekton:
+                description: Tekton instance readiness status.
+                properties:
+                  errorMessage:
+                    type: string
+                  ready:
+                    type: string
+                  version:
+                    type: string
+                type: object
+            type: object
+  - name: v1beta1
+    served: true
+    storage: false
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              collections:
+                properties:
+                  repositories:
+                    items:
+                      properties:
+                        activateDefaultCollections:
+                          type: boolean
+                        name:
+                          type: string
+                        url:
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              tekton:
+                properties:
+                  enable:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              version:
+                type: string
+            type: object
+          status:
+            properties:
+              kabaneroInstance:
+                description: Kabanero operator instance readiness status. The status
+                  is directly correlated to the availability of resources dependencies.
+                properties:
+                  errorMessage:
+                    type: string
+                  ready:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              knativeEventing:
+                description: Knative eventing instance readiness status.
+                properties:
+                  errorMessage:
+                    type: string
+                  ready:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              knativeServing:
+                description: Knative serving instance readiness status.
+                properties:
+                  errorMessage:
+                    type: string
+                  ready:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              tekton:
+                description: Tekton instance readiness status.
+                properties:
+                  errorMessage:
+                    type: string
+                  ready:
+                    type: string
+                  version:
+                    type: string
+                type: object
+            type: object
+  conversion:
+    strategy: None
+  names:
+    kind: Kabanero
+    listKind: KabaneroList
+    plural: kabaneros
+    singular: kabanero
+  scope: Namespaced
+  subresources:
+    status: {}

--- a/deploy/crds/kabanero_v1alpha1_kabanero_crd.yaml
+++ b/deploy/crds/kabanero_v1alpha1_kabanero_crd.yaml
@@ -12,22 +12,6 @@ spec:
   scope: Namespaced
   subresources:
     status: {}
-  additionalPrinterColumns:
-  - JSONPath: .metadata.creationTimestamp
-    description: CreationTimestamp is a timestamp representing the server time when
-      this object was created. It is not guaranteed to be set in happens-before order
-      across separate operations.
-    name: Age
-    type: date
-  - JSONPath: .status.kabaneroInstance.version
-    description: Kabanero operator instance version.
-    name: Version
-    type: string
-  - JSONPath: .status.kabaneroInstance.ready
-    description: Kabanero operator instance readiness status. The status is directly
-      correlated to the availability of the operator's resources dependencies.
-    name: Ready
-    type: string
   validation:
     openAPIV3Schema:
       properties:

--- a/deploy/crds/kabanero_v1beta1_kabanero_crd.yaml
+++ b/deploy/crds/kabanero_v1beta1_kabanero_crd.yaml
@@ -34,7 +34,7 @@ spec:
                 repositories:
                   items:
                     properties:
-                      activateDefault:
+                      activateDefaultCollections:
                         type: boolean
                       name:
                         type: string

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -19,7 +19,7 @@ spec:
           image: kabanero-operator:latest
           command:
           - kabanero-operator
-          imagePullPolicy: Always
+          imagePullPolicy: Never
           env:
             - name: WATCH_NAMESPACE
               value: ""


### PR DESCRIPTION
The v1beta1 API version was introduced in the source in a prior pull request. This change converges the API versions into a single CRD. 