### PR TITLE
Restore property type removed by a previous commit

### DIFF
--- a/deploy/crds/kabanero_kabanero_crd.yaml
+++ b/deploy/crds/kabanero_kabanero_crd.yaml
@@ -188,6 +188,7 @@ spec:
                     items:
                       type: string
                     type: array
+                type: object
               kabaneroInstance:
                 description: Kabanero operator instance readiness status. The status
                   is directly correlated to the availability of resources dependencies.


### PR DESCRIPTION
Restores a line in deploy/crds/kabanero_kabanero_crd.yaml removed by previous PR.