### PR TITLE
Update Dockerfile for Redhat container certification

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,13 @@ ARG IMAGE=kabanero:latest
 
 FROM ${IMAGE}
 
+# The following labels are required for Redhat container certification
+LABEL vendor="Kabanero" \
+      name="Kabanero Operator" \
+      summary="Image for Kabanaro Operator" \
+      description="This image contains the controller for the Kabanero Foundation and Collection.  See https://github.com/kabanero-io/kabanero-operator/"
+
 COPY config /config
+
+# The licence must be here for Redhat container certification
+COPY LICENSE /licenses/


### PR DESCRIPTION
There were some labels missing on the container, and the container didn't contain a License.  