### PR TITLE
Add collection identifier to rendering context when processing yaml directives in release-0.1

### DIFF
--- a/pkg/controller/collection/archive.go
+++ b/pkg/controller/collection/archive.go
@@ -27,7 +27,7 @@ func DownloadToByte(url string) ([]byte, error) {
 //Read the manifests from a tar.gz archive
 //It would be better to use the manifest.yaml as the index, and check the signatures
 //For now, ignore manifest.yaml and return all other yaml files from the archive
-func DecodeManifests(archive []byte, collectionName string) ([]unstructured.Unstructured, error) {
+func DecodeManifests(archive []byte, renderingContext map[string]interface{}) ([]unstructured.Unstructured, error) {
 	manifests := []unstructured.Unstructured{}
 
 	r := bytes.NewReader(archive)
@@ -63,7 +63,7 @@ func DecodeManifests(archive []byte, collectionName string) ([]unstructured.Unst
 
 			//Apply the Kabanero yaml directive processor
 			s := &DirectiveProcessor{}
-			b, err = s.Render(b, map[string]interface{}{"CollectionName": collectionName})
+			b, err = s.Render(b, renderingContext)
 			if err != nil {
 				return nil, fmt.Errorf("Error processing directives %v: %v", header.Name, err.Error())
 			}
@@ -80,13 +80,13 @@ func DecodeManifests(archive []byte, collectionName string) ([]unstructured.Unst
 	return manifests, nil
 }
 
-func GetManifests(url string, collectionName string) ([]unstructured.Unstructured, error) {
+func GetManifests(url string, renderingContext map[string]interface{}) ([]unstructured.Unstructured, error) {
 	b, err := DownloadToByte(url)
 	if err != nil {
 		return nil, err
 	}
 
-	manifests, err := DecodeManifests(b, collectionName)
+	manifests, err := DecodeManifests(b, renderingContext)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/collection/archive_test.go
+++ b/pkg/controller/collection/archive_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestGetManifests(t *testing.T) {
-	manifests, err := GetManifests("https://github.com/kabanero-io/collections/releases/download/v0.0.1/incubator.java-microprofile.pipeline.default.tar.gz", "java-microprofile")
+	manifests, err := GetManifests("https://github.com/kabanero-io/collections/releases/download/v0.0.1/incubator.java-microprofile.pipeline.default.tar.gz", map[string]interface{}{"CollectionName": "Eclipse Microprofile", "CollectionId": "java-microprofile"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/controller/collection/collection_controller.go
+++ b/pkg/controller/collection/collection_controller.go
@@ -592,6 +592,11 @@ func activate(collectionResource *kabanerov1alpha1.Collection, collection *Colle
 //}
 
 func activatev2(collectionResource *kabanerov1alpha1.Collection, collection *IndexedCollectionV2, c client.Client) error {
+	//The context which will be used when rendering remote yaml
+	renderingContext := map[string]interface{}{
+		"CollectionId":   collection.Id,
+		"CollectionName": collection.Name,
+	}
 
 	// Detect if the version is changing from the active version.  If it is, we need to clean up the
 	// assets from the previous version.
@@ -612,7 +617,7 @@ func activatev2(collectionResource *kabanerov1alpha1.Collection, collection *Ind
 			log.Info(fmt.Sprintf("Preparing to delete asset %v", asset.Url))
 
 			// Retrieve manifests as unstructured
-			manifests, err := GetManifests(asset.Url, collection.Name)
+			manifests, err := GetManifests(asset.Url, renderingContext)
 			if err != nil {
 				log.Error(err, errorMessage, "resource", asset.Url)
 				collectionResource.Status.StatusMessage = errorMessage + ": " + err.Error()
@@ -682,7 +687,7 @@ func activatev2(collectionResource *kabanerov1alpha1.Collection, collection *Ind
 			log.Info(fmt.Sprintf("Applying asset %v", asset.Url))
 
 			// Retrieve manifests as unstructured
-			manifests, err := GetManifests(asset.Url, collection.Name)
+			manifests, err := GetManifests(asset.Url, renderingContext)
 			if err != nil {
 				return err
 			}

--- a/pkg/controller/collection/directive_processor.go
+++ b/pkg/controller/collection/directive_processor.go
@@ -45,7 +45,7 @@ func (g DirectiveProcessor) Render(b []byte, context map[string]interface{}) ([]
 
 //process_directive processes an individual directive like: #Kabanero! on activate substitute CollectionName for text '${collection-name}'
 func (g DirectiveProcessor) process_directive(directive string, text string, context map[string]interface{}) (string, error) {
-	textSubstitutionExpr := regexp.MustCompile(`#Kabanero!\son\sactivate\s(substitute\s(CollectionName)\s(for text)\s'(.+?)')`)
+	textSubstitutionExpr := regexp.MustCompile(`#Kabanero!\son\sactivate\s(substitute\s(.+?)\s(for text)\s'(.+?)')`)
 	if textSubstitutionExpr.MatchString(directive) {
 		groups := textSubstitutionExpr.FindStringSubmatch(directive)
 

--- a/pkg/controller/collection/directive_processor_test.go
+++ b/pkg/controller/collection/directive_processor_test.go
@@ -1,12 +1,19 @@
 package collection
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
 
 func TestDirectiveProcessor(t *testing.T) {
-	b := []byte(`
+	tests := []struct {
+		name     string
+		provided []byte
+		expected []byte
+	}{{
+		name: "Substitute CollectionName",
+		provided: []byte(`
 #Kabanero! on activate substitute CollectionName for text '${collection-name}'
 apiVersion: tekton.dev/v1alpha1
 kind: Pipeline
@@ -19,31 +26,70 @@ spec:
     - name: build-task
       taskRef:
         name: ${collection-name}-build-task
-    `)
+    `),
 
-	expected := []byte(`
+		expected: []byte(`
 apiVersion: tekton.dev/v1alpha1
 kind: Pipeline
 metadata:
-  name: MyCollection-build-deploy-pipeline
+  name: My Collection Name-build-deploy-pipeline
 spec:
   resources:
   - resource1
   tasks:
     - name: build-task
       taskRef:
-        name: MyCollection-build-task
-    `)
+        name: My Collection Name-build-task
+    `),
+	},
+		{
+			name: "Substitute CollectionId",
+			provided: []byte(`
+#Kabanero! on activate substitute CollectionId for text 'CollectionId'
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: CollectionId-build-deploy-pipeline
+spec:
+  resources:
+  - resource1
+  tasks:
+    - name: build-task
+      taskRef:
+        name: CollectionId-build-task
+    `),
 
-	context := map[string]interface{}{"CollectionName": "MyCollection"}
+			expected: []byte(`
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: my-collection-build-deploy-pipeline
+spec:
+  resources:
+  - resource1
+  tasks:
+    - name: build-task
+      taskRef:
+        name: my-collection-build-task
+    `),
+		}}
 
-	r := &DirectiveProcessor{}
-	b_output, err := r.Render(b, context)
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("%s", tc.name), func(t *testing.T) {
+			context := map[string]interface{}{
+				"CollectionName": "My Collection Name",
+				"CollectionId":   "my-collection",
+			}
 
-	if err != nil {
-		t.Fatal(err)
-	}
-	if strings.TrimSpace(string(b_output)) != strings.TrimSpace(string(expected)) {
-		t.Fatal("Output did not match expectations", string(b_output), string(expected))
+			r := &DirectiveProcessor{}
+			b_output, err := r.Render(tc.provided, context)
+
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.TrimSpace(string(b_output)) != strings.TrimSpace(string(tc.expected)) {
+				t.Fatal("Output did not match expectations", string(b_output), string(tc.expected))
+			}
+		})
 	}
 }


### PR DESCRIPTION
The yaml processor which was added in #145 included only the collection name. This change also includes the collection identifier.