### PR TITLE
157 image metadata in status

### DIFF
--- a/pkg/apis/kabanero/v1alpha1/collection_types.go
+++ b/pkg/apis/kabanero/v1alpha1/collection_types.go
@@ -35,6 +35,13 @@ type CollectionStatus struct {
 	AvailableVersion string `json:"availableVersion,omitempty"`
 	AvailableLocation string `json:"availableLocation,omitempty"`
 	StatusMessage string `json:"statusMessage,omitempty"`
+	Images []Image `json:"images,omitempty"`
+}
+
+// Image defines a container image used by a collection
+type Image struct {
+	Id                 string                   `json:"id,omitempty"`
+	Image              string                   `json:"image,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controller/collection/collection_controller.go
+++ b/pkg/controller/collection/collection_controller.go
@@ -659,6 +659,7 @@ func activatev2(collectionResource *kabanerov1alpha1.Collection, collection *Ind
 		// Indicate there is not currently an active version of this collection.
 		collectionResource.Status.ActiveVersion = ""
 		collectionResource.Status.ActiveAssets = nil
+		collectionResource.Status.Images = nil
 	}
 
 	// Now apply the new version
@@ -726,6 +727,16 @@ func activatev2(collectionResource *kabanerov1alpha1.Collection, collection *Ind
 
 	// Update the status of the Collection object to reflect the version we applied.
 	collectionResource.Status.ActiveVersion = collection.Version
+
+	// Update the status of the Collection object to reflect the images used
+	var statusImages []kabanerov1alpha1.Image
+	for _, image := range collection.Images {
+		var statusImage kabanerov1alpha1.Image
+		statusImage.Id = image.Id
+		statusImage.Image = image.Image
+		statusImages = append(statusImages, statusImage)
+	}
+	collectionResource.Status.Images = statusImages
 
 	return nil
 }


### PR DESCRIPTION
Create new status type to track Images used by a collection, which is identical to the IndexedCollectionV2.Images metadata

In practice,

```
oc get collections -o=yaml
apiVersion: v1
items:
- apiVersion: kabanero.io/v1beta1
  kind: Collection
  metadata:
    creationTimestamp: 2019-09-06T19:52:25Z
    generation: 1
    name: java-microprofile
    namespace: kabanero
    ownerReferences:
    - apiVersion: kabanero.io/v1alpha1
      controller: true
      kind: Kabanero
      name: kabanero
      uid: d8d3ee7d-d0df-11e9-a2f1-0016ac101f45
    resourceVersion: "34850"
    selfLink: /apis/kabanero.io/v1beta1/namespaces/kabanero/collections/java-microprofile
    uid: d96d9556-d0df-11e9-a2f1-0016ac101f45
  spec:
    name: java-microprofile
    version: 0.2.11
  status:
    activeAssets:
    - assetDigest: 30d72f17f698b9968a771c1763579b0f512bb1c03c5f3e4836399addb5064a22
      assetName: default
      status: active
      url: https://github.com/kabanero-io/collections/releases/download/v0.1.1/incubator.java-microprofile.v0.2.11.pipeline.default.tar.gz
    activeLocation: https://github.com/kabanero-io/collections/releases/download/v0.1.1/kabanero-index.yaml
    activeVersion: 0.2.11
    images:
    - id: java-microprofile
      image: kabanero/java-microprofile:0.2
```