### PR TITLE
sha256 signatures

### DIFF
--- a/pkg/controller/collection/collection_controller.go
+++ b/pkg/controller/collection/collection_controller.go
@@ -659,7 +659,7 @@ func activatev2(collectionResource *kabanerov1alpha1.Collection, collection *Ind
 			log.Info(fmt.Sprintf("Preparing to delete asset %v", asset.Url))
 
 			// Retrieve manifests as unstructured
-			manifests, err := GetManifests(asset.Url, renderingContext)
+			manifests, err := GetManifests(asset.Url, asset.Digest, renderingContext)
 			if err != nil {
 				log.Error(err, errorMessage, "resource", asset.Url)
 				collectionResource.Status.StatusMessage = errorMessage + ": " + err.Error()
@@ -705,7 +705,7 @@ func activatev2(collectionResource *kabanerov1alpha1.Collection, collection *Ind
 		log.Info(fmt.Sprintf("Applying asset %v", asset.Url))
 
 		// Retrieve manifests as unstructured
-		manifests, err := GetManifests(asset.Url, renderingContext)
+		manifests, err := GetManifests(asset.Url, asset.Sha256, renderingContext)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Check collection archive sha256 signature, and use archive manifest.yaml to check sha256 signatures of contained files

Requires using a collection release that contains a fix https://github.com/kabanero-io/collections/commit/25813a5afe4acb7b6d7fd969711fdf78e152539e for correctly publishing the sha256 signatures to the manifest.yaml, such as:

 https://github.com/kabanero-io/collections/releases/download/v0.2.0-beta1/kabanero-index.yaml