### PR TITLE
add rbac for landing page

### DIFF
--- a/config/orchestrations/landing/0.1/kabanero-landing.yaml
+++ b/config/orchestrations/landing/0.1/kabanero-landing.yaml
@@ -25,3 +25,52 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kabanero-landing
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kabanero-landing
+subjects:
+- kind: ServiceAccount
+  name: kabanero-landing
+  namespace: kabanero
+roleRef:
+  kind: ClusterRole
+  name: kabanero-landing
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kabanero-landing
+  namespace: kabanero
+rules:
+- apiGroups:
+  - ""
+  - route.openshift.io
+  attributeRestrictions: null
+  resources:
+  - routes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  - route.openshift.io
+  attributeRestrictions: null
+  resources:
+  - routes/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kabanero.io
+  attributeRestrictions: null
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
There is a new landing page coming that will show information using the Kubernetes API such as Kabanero instance name, date created, collection hub URL, and Collections installed. To do this the deployment will need some permissions to access resources via the API.

part of https://github.com/kabanero-io/kabanero-foundation/issues/75

Give the landing page permissions to:
* read/list/watch routes 
* read/list/watch routes/status
* read/list/watch all resources in the kabanero.io apigroup

These are cluster roles (for now) due to the fact there could be multiple kabanero instances in the future (in different namespaces).

This could open a discussion to whether we want a kabanero landing application for each instance or 1 for all instances.

Tested with a custom operator on OKD 3.1.1