### PR TITLE
Expose JwtExpiration

### DIFF
--- a/config/samples/full.yaml
+++ b/config/samples/full.yaml
@@ -40,6 +40,12 @@ spec:
     # Overrides the image uri
     image: kabanero/kabanero-command-line-services:0.1.1-rc.1
 
+    # Indicates the token expiration time 
+    # Specify a positive integer followed by a unit of time, which can be hours (h), minutes (m), or seconds (s). 
+    # For example, specify 30 seconds as 30s. 
+    # You can include multiple values in a single entry. For example, 1m30s is equivalent to 90 seconds.
+    sessionExpirationSeconds: "1440m"
+
   landing:
     # The landing page is enabled by default. To disable specify false.
     enable: true 

--- a/pkg/apis/kabanero/v1alpha1/kabanero_types.go
+++ b/pkg/apis/kabanero/v1alpha1/kabanero_types.go
@@ -81,6 +81,7 @@ type KabaneroCliServicesCustomizationSpec struct {
 	Image      string `json:"image,omitempty"`
 	Repository string `json:"repository,omitempty"`
 	Tag        string `json:"tag,omitempty"`
+	SessionExpirationSeconds string `json:"sessionExpirationSeconds,omitempty"`
 }
 
 type KabaneroLandingCustomizationSpec struct {


### PR DESCRIPTION
Results in envVar set

Question of whether the yaml field should be a string or int?

```
oc describe pod kabanero-cli-7f7688cbd8-jjqj6
Name:               kabanero-cli-7f7688cbd8-jjqj6
Namespace:          kabanero
Priority:           0
PriorityClassName:  <none>
Node:               annal3.fyre.ibm.com/172.16.20.219
Start Time:         Tue, 01 Oct 2019 11:00:54 -0400
Labels:             app=kabanero-cli
                    pod-template-hash=3932447684
Annotations:        openshift.io/scc=restricted
Status:             Running
IP:                 10.130.0.254
Controlled By:      ReplicaSet/kabanero-cli-7f7688cbd8
Containers:
  kabanero-cli:
    Container ID:   docker://84eaf21284bc5e16bf61c09735c48b7d3b092d23b4f3d73ea3586488a698f650
    Image:          kabanero/kabanero-command-line-services:0.1.1-rc.1
    Image ID:       docker-pullable://docker.io/kabanero/kabanero-command-line-services@sha256:9f569d24d1651f4a29aea44b67232a0d288e8a8ba4e7dda3ffc66837660e6601
    Port:           9443/TCP
    Host Port:      0/TCP
    State:          Running
      Started:      Tue, 01 Oct 2019 11:01:09 -0400
    Ready:          True
    Restart Count:  0
    Environment:
      KABANERO_CLI_NAMESPACE:  kabanero
      KABANERO_CLI_GROUP:      kabanero-io
      teamsInGroup_admin:      adminTeam@kabanero-io
      github.api.url:          https://api.github.com
      JwtExpiration:           60
      AESEncryptionKey:        <set to the key 'AESEncryptionKey' in secret 'kabanero-cli-aes-encryption-key-secret'>  Optional: false
    Mounts:
      /var/run/secrets/kubernetes.io/serviceaccount from kabanero-cli-token-lm5rj (ro)
Conditions:
  Type              Status
  Initialized       True
  Ready             True
  ContainersReady   True
  PodScheduled      True
Volumes:
  kabanero-cli-token-lm5rj:
    Type:        Secret (a volume populated by a Secret)
    SecretName:  kabanero-cli-token-lm5rj
    Optional:    false
QoS Class:       BestEffort
Node-Selectors:  node-role.kubernetes.io/compute=true
Tolerations:     <none>
```