### PR TITLE
Put build info into the main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ build-image: generate
   # pass the ldflags option.  The advice from operator-sdk was to run the 
   # commands separately here.
   # operator-sdk build ${IMAGE}
-	CGO_ENABLED=0 go build -o build/_output/bin/kabanero-operator -gcflags "all=-trimpath=$(GOPATH)" -asmflags "all=-trimpath=$(GOPATH)" -ldflags "-X main.GitTag=$(TRAVIS_TAG) -X main.GitCommit=$(TRAVIS_COMMIT) -X main.GitRepoSlug=$(TRAVIS_REPO_SLUG)" github.com/kabanero-io/kabanero-operator/cmd/manager
+	CGO_ENABLED=0 go build -o build/_output/bin/kabanero-operator -gcflags "all=-trimpath=$(GOPATH)" -asmflags "all=-trimpath=$(GOPATH)" -ldflags "-X main.GitTag=$(TRAVIS_TAG) -X main.GitCommit=$(TRAVIS_COMMIT) -X main.GitRepoSlug=$(TRAVIS_REPO_SLUG) -X main.BuildDate=`date -u +%Y%m%d.%H%M%S`" github.com/kabanero-io/kabanero-operator/cmd/manager
 	docker build -f build/Dockerfile -t ${IMAGE} .
   # This is a workaround until manfistival can interact with the virtual file system
 	docker build -t ${IMAGE} --build-arg IMAGE=${IMAGE} .

--- a/Makefile
+++ b/Makefile
@@ -11,23 +11,28 @@ build: generate
 	go install ./cmd/manager
 
 build-image: generate
-	operator-sdk build ${IMAGE}
-	# This is a workaround until manfistival can interact with the virtual file system
+  # These commands were taken from operator-sdk 0.8.1.  The sdk did not let us
+  # pass the ldflags option.  The advice from operator-sdk was to run the 
+  # commands separately here.
+  # operator-sdk build ${IMAGE}
+	CGO_ENABLED=0 go build -o build/_output/bin/kabanero-operator -gcflags "all=-trimpath=$(GOPATH)" -asmflags "all=-trimpath=$(GOPATH)" -ldflags "-X main.GitTag=$(TRAVIS_TAG) -X main.GitCommit=$(TRAVIS_COMMIT) -X main.GitRepoSlug=$(TRAVIS_REPO_SLUG)" github.com/kabanero-io/kabanero-operator/cmd/manager
+	docker build -f build/Dockerfile -t ${IMAGE} .
+  # This is a workaround until manfistival can interact with the virtual file system
 	docker build -t ${IMAGE} --build-arg IMAGE=${IMAGE} .
 
 push-image:
 ifneq "$(IMAGE)" "kabanero-operator:latest"
-	# Default push
+  # Default push
 	docker push $(IMAGE)
 
 ifdef TRAVIS_TAG
-	# This is a Travis tag build. Pushing using Docker tag TRAVIS_TAG
+  # This is a Travis tag build. Pushing using Docker tag TRAVIS_TAG
 	docker tag $(IMAGE) $(REPOSITORY):$(TRAVIS_TAG)
 	docker push $(REPOSITORY):$(TRAVIS_TAG)
 endif
 
 ifdef TRAVIS_BRANCH
-	# This is a Travis branch build. Pushing using Docker tag TRAVIS_BRANCH
+  # This is a Travis branch build. Pushing using Docker tag TRAVIS_BRANCH
 	docker tag $(IMAGE) $(REPOSITORY):$(TRAVIS_BRANCH)
 	docker push $(REPOSITORY):$(TRAVIS_BRANCH)
 endif
@@ -48,13 +53,13 @@ install:
 	kubectl config set-context $$(kubectl config current-context) --namespace=kabanero
 	kubectl apply -f deploy/crds/kabanero_kabanero_crd.yaml
 	kubectl apply -f deploy/crds/kabanero_collection_crd.yaml
-	
+
 deploy: 
 	kubectl create namespace kabanero || true
 
 ifneq "$(IMAGE)" "kabanero-operator:latest"
-	# By default there is no image pull policy for local image. However, for other images
-	# substitute current image name, and update the pull policy to always pull images.
+  # By default there is no image pull policy for local image. However, for other images
+  # substitute current image name, and update the pull policy to always pull images.
 	sed -i.bak -e 's!imagePullPolicy: Never!imagePullPolicy: Always!' deploy/operator.yaml
 	sed -i.bak -e 's!image: kabanero-operator:latest!image: ${IMAGE}!' deploy/operator.yaml
 endif
@@ -70,7 +75,7 @@ ifeq (, $(shell which dep))
 endif
 	dep ensure
 
-	# Remove some creative commons licensed tests/samples
+  # Remove some creative commons licensed tests/samples
 	rm vendor/golang.org/x/net/http2/h2demo/tmpl.go
 	rm -r vendor/golang.org/x/text/internal/testtext
 

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -37,10 +37,27 @@ var (
 )
 var log = logf.Log.WithName("cmd")
 
+// These variables are injected during the build using ldflags
+var GitTag string
+var GitCommit string
+var GitRepoSlug string
+
 func printVersion() {
 	log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
 	log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
 	log.Info(fmt.Sprintf("Version of operator-sdk: %v", sdkVersion.Version))
+	
+	if len(GitTag) > 0 {
+		log.Info(fmt.Sprintf("kabanero-operator Git tag: %s", GitTag))
+	}
+
+	if len(GitCommit) > 0 {
+		log.Info(fmt.Sprintf("kabanero-operator Git commit: %s", GitCommit))
+	}
+
+	if len(GitRepoSlug) > 0 {
+		log.Info(fmt.Sprintf("kabanero-operator Git repository: %s", GitRepoSlug))
+	}
 }
 
 func main() {

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -41,6 +41,7 @@ var log = logf.Log.WithName("cmd")
 var GitTag string
 var GitCommit string
 var GitRepoSlug string
+var BuildDate string
 
 func printVersion() {
 	log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
@@ -58,6 +59,11 @@ func printVersion() {
 	if len(GitRepoSlug) > 0 {
 		log.Info(fmt.Sprintf("kabanero-operator Git repository: %s", GitRepoSlug))
 	}
+
+	if len(BuildDate) == 0 {
+		BuildDate = "unspecified"
+	}
+	log.Info(fmt.Sprintf("kabanero-operator build date: %s", BuildDate))
 }
 
 func main() {


### PR DESCRIPTION
It occurred to me when I was helping someone debug a problem using `kabanero/kabanero-operator:latest` that it was really hard to know what level of the operator they were using.  Even if they are using a named release, they can use that release to install a prior version of Kabanero (ie operator 0.2.0 can be used to install 0.1.2).  It would be nice to output some build information at the top of the log.  This PR will include information from the travis build, including commit ID, tag (for named builds) and the github repository that was used.  Here is an example where Travis set the repository (but not the commit or tag):
```
{"level":"info","ts":1570202501.6574814,"logger":"cmd","msg":"Go Version: go1.12.7"}
{"level":"info","ts":1570202501.6575618,"logger":"cmd","msg":"Go OS/Arch: linux/amd64"}
{"level":"info","ts":1570202501.6575706,"logger":"cmd","msg":"Version of operator-sdk: v0.7.0+git"}
{"level":"info","ts":1570202501.6575778,"logger":"cmd","msg":"kabanero-operator Git repository: kaczyns/kabanero-operator"}
```