### PR TITLE
Remove Minikube information from the readme.  Update Istio pre-req.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # kabanero-operator
-The Kabanero platform operator
+The following README pertains to kabanero-operator development.  If you are trying to use the operator to try Kabanero on your cluster, please see the [install instructions](https://kabanero.io/docs/ref/general/installing-kabanero-foundation.html).
 
 # Status
 [![Build Status](https://travis-ci.org/kabanero-io/kabanero-operator.svg?branch=master)](https://travis-ci.org/kabanero-io/kabanero-operator)
+
+The Kabanero operator is developed using `operator-sdk` version 0.8.1.
 
 ## Clone the Kabanero operator
 
@@ -11,38 +13,9 @@ git clone https://github.com/kabanero-io/kabanero-operator
 cd kabanero-operator
 ```
 
-# Quickstart - minikube
+# Quickstart - OpenShift 3.11 / OKD 3.11
 
-Create a minikube instance: 
-```
-minikube start --memory=8192 --cpus=4 \
-  --kubernetes-version=v1.12.0 \
-  --vm-driver=hyperkit \
-  --disk-size=30g \
-  --extra-config=apiserver.enable-admission-plugins="LimitRanger,NamespaceExists,NamespaceLifecycle,ResourceQuota,ServiceAccount,DefaultStorageClass,MutatingAdmissionWebhook"
-
-kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/istio-crds.yaml
-curl -L https://github.com/knative/serving/releases/download/v0.4.0/istio.yaml | sed 's/LoadBalancer/NodePort/' | kubectl apply --filename -
-```
-
-## Create Kabanero CRDs
-
-```
-make install
-```
-
-## Deploy the CRDs and some of the other controllers
-
-```
-make deploy
-```
-## Deploy the sample
-
-```
-kubectl apply -n kabanero -f config/samples/full.yaml
-```
-
-# Quickstart - OpenShift
+We recomment you follow the install instructions reference above to set up your cluster the first time.  If you would rather set up manually, please continue with the following steps:
 
 ## Login
 (example)
@@ -53,10 +26,7 @@ oc login -u admin -p admin https://openshift.my.com:8443/
 
 ## Deploy Istio
 
-```
-kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/istio-crds.yaml
-curl -L https://github.com/knative/serving/releases/download/v0.4.0/istio.yaml | sed 's/LoadBalancer/NodePort/' | kubectl apply --filename -
-```
+Kabanero on OKD 3.11 / OpenShift 3.11 has been tested with Istio version 1.1.7.  Follow the instructions here to deploy the [Quick Start Evaluation Install](https://archive.istio.io/v1.1/docs/setup/kubernetes/install/kubernetes/).  We suggest you pick the Permissive Mutual TLS configuration to get started.
 
 ## Create Kabanero CRDs
 
@@ -64,7 +34,7 @@ curl -L https://github.com/knative/serving/releases/download/v0.4.0/istio.yaml |
 make install
 ```
 
-## Deploy the CRDs and some of the other controllers
+## Deploy the CRDs and some of the other controllers (Knative, Tekton)
 
 ```
 make deploy
@@ -89,7 +59,7 @@ openshift-pipelines-operator-c56876c69-hf74v   1/1       Running   0          5m
 ## Deploy the sample
 
 ```
-kubectl apply -n kabanero -f config/samples/full.yaml
+kubectl apply -n kabanero -f config/samples/default.yaml
 ```
 
 kubectl get pods -n kabanero
@@ -103,3 +73,10 @@ knative-serving-operator-8c7858985-v7zrd       1/1       Running   0          2m
 openshift-pipelines-operator-c56876c69-6jwqw   1/1       Running   0          2m
 tekton-pipelines-controller-5576fbb979-mv8hp   1/1       Running   0          55s
 tekton-pipelines-webhook-78bf9c5f46-9pzlj      1/1       Running   0          55s
+```
+
+# Quickstart - minikube
+
+Kabanero is not currently supported on Minikube, due to the resource requirements of its dependencies (Istio, Knative and Tekton) and due to the Kabanero-operator's dependencies on OpenShift types like `Routes`.
+
+Some folks have had success installing on Minishift.  For example, see https://github.com/nastacio/kabanero-minishift.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ cd kabanero-operator
 
 # Quickstart - OpenShift 3.11 / OKD 3.11
 
-We recomment you follow the install instructions reference above to set up your cluster the first time.  If you would rather set up manually, please continue with the following steps:
+We recommend you follow the install instructions referenced above to set up your cluster for the first time.  If you would rather set it up manually, please continue with the following steps:
 
 ## Login
 (example)
@@ -48,12 +48,13 @@ kubectl get pods -n kabanero
 (example command output)
 
 ```
-[root@openshist kabanero-operator]# kubectl get pods -n kabanero
-NAME                                           READY     STATUS    RESTARTS   AGE
-kabanero-operator-dd997974-5nfj4               1/1       Running   0          5m
-knative-eventing-operator-658765d7d6-pq5bk     1/1       Running   0          5m
-knative-serving-operator-8c7858985-plvh8       1/1       Running   0          5m
-openshift-pipelines-operator-c56876c69-hf74v   1/1       Running   0          5m
+[admin@openshift kabanero-operator]# kubectl get pods -n kabanero
+NAME                                                        READY     STATUS    RESTARTS   AGE
+controller-manager-0                                        1/1       Running   2          2d
+kabanero-operator-7974456fc-jc2dl                           1/1       Running   0          27m
+knative-eventing-operator-67cdf5dc9f-s4bth                  1/1       Running   0          2d
+knative-serving-operator-b64558bbc-9ndb5                    1/1       Running   0          2d
+openshift-pipelines-operator-66c4d787cf-f2xwt               1/1       Running   0          2d
 ```
 
 ## Deploy the sample
@@ -65,14 +66,16 @@ kubectl apply -n kabanero -f config/samples/default.yaml
 kubectl get pods -n kabanero
 ```
 (example command output)
-[root@openshist kabanero-operator]# kubectl get pods -n kabanero
-NAME                                           READY     STATUS    RESTARTS   AGE
-kabanero-operator-dd997974-4cqnt               1/1       Running   0          2m
-knative-eventing-operator-658765d7d6-6ptqc     1/1       Running   0          2m
-knative-serving-operator-8c7858985-v7zrd       1/1       Running   0          2m
-openshift-pipelines-operator-c56876c69-6jwqw   1/1       Running   0          2m
-tekton-pipelines-controller-5576fbb979-mv8hp   1/1       Running   0          55s
-tekton-pipelines-webhook-78bf9c5f46-9pzlj      1/1       Running   0          55s
+[admin@openshift kabanero-operator]# kubectl get pods -n kabanero
+NAME                                                        READY     STATUS    RESTARTS   AGE
+appsody-operator-79ccd57895-j7d9s                           1/1       Running   0          2d
+controller-manager-0                                        1/1       Running   2          2d
+kabanero-cli-679cbddb4f-gt5b6                               1/1       Running   0          2d
+kabanero-landing-775584bbd4-4m9zb                           1/1       Running   0          2d
+kabanero-operator-7974456fc-jc2dl                           1/1       Running   0          27m
+knative-eventing-operator-67cdf5dc9f-s4bth                  1/1       Running   0          2d
+knative-serving-operator-b64558bbc-9ndb5                    1/1       Running   0          2d
+openshift-pipelines-operator-66c4d787cf-f2xwt               1/1       Running   0          2d
 ```
 
 # Quickstart - minikube


### PR DESCRIPTION
fixes #110 
Remove the Minikube information from the README.md.  Also update the Istio prereq information.  Suggest that people use the install script instead of the readme.