### PR TITLE
Don't update the OKD 3.x console if the config map doesn't exist

### DIFF
--- a/pkg/controller/kabaneroplatform/landing.go
+++ b/pkg/controller/kabaneroplatform/landing.go
@@ -95,8 +95,12 @@ func deployLandingPage(k *kabanerov1alpha1.Kabanero, c client.Client) error {
 		return err
 	}
 
-	// Update the web console's ConfigMap with custom data.
+	// Update the web console's ConfigMap with custom data.  If we could
+	// not find the web console config map, skip it.
 	err = customizeWebConsole(k, c, clientset, config, landingURL)
+	if apierrors.IsNotFound(err) {
+		err = nil
+	}
 
 	return err
 }


### PR DESCRIPTION
For now, if running on OCP 4.x, we should let the Kab operator continue doing its thing if the config map for the OKD 3.x / OCP 3.x console is not there.