### PR TITLE
Compile operator-registry during travis build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Temporary Build Files
 build/_output
 build/_test
+bundles.db
 # Created by https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
 ### Emacs ###
 # -*- mode: gitignore; -*-

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Temporary Build Files
 build/_output
 build/_test
+build/registry
 bundles.db
 # Created by https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
 ### Emacs ###

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
 - rsync -az ${TRAVIS_BUILD_DIR}/ $HOME/gopath/src/github.com/kabanero-io/kabanero-operator
 - export TRAVIS_BUILD_DIR=$HOME/gopath/src/github.com/kabanero-io/kabanero-operator
 - cd ${HOME}/gopath/src/github.com/kabanero-io/kabanero-operator
-- if [ ! -z \"$DOCKER_USERNAME\" ]; then docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD || true; fi
+- if [ ! -z ${DOCKER_USERNAME} ]; then docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD || true; fi
 
 script:
 - make check

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,13 @@ build-image: generate
   # This is a workaround until manfistival can interact with the virtual file system
 	docker build -t ${IMAGE} --build-arg IMAGE=${IMAGE} .
   # Build an OLM private registry for Kabanero
-	cp deploy/crds/kabanero_v1alpha1_*_crd.yaml registry/manifests/kabanero-operator/0.3.0/
-	docker build -t ${REGISTRY_IMAGE} -f registry/Dockerfile registry/
+	mkdir -p build/registry
+	cp -R registry/manifests build/registry/
+	cp registry/Dockerfile build/registry/Dockerfile
+	cp deploy/crds/kabanero_v1alpha1_*_crd.yaml build/registry/manifests/kabanero-operator/0.3.0/
+	sed -e "s!kabanero/kabanero-operator:latest!${IMAGE}!" registry/manifests/kabanero-operator/0.3.0/kabanero-operator.v0.3.0.clusterserviceversion.yaml > build/registry/manifests/kabanero-operator/0.3.0/kabanero-operator.v0.3.0.clusterserviceversion.yaml
+	docker build -t ${REGISTRY_IMAGE} -f build/registry/Dockerfile build/registry/
+	rm -R build/registry
 
 push-image:
 ifneq "$(IMAGE)" "kabanero-operator:latest"

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
 # The Docker image in format repository:tag. Repository may contain a remote reference.
 # Override in order to customize
 IMAGE ?= kabanero-operator:latest
+REGISTRY_IMAGE ?= kabanero-operator-registry:latest
 
 # Computed repository name (no tag) including repository host/path reference
 REPOSITORY=$(firstword $(subst :, ,${IMAGE}))
+REGISTRY_REPOSITORY=$(firstword $(subst :, ,${REGISTRY_IMAGE}))
 
 .PHONY: build deploy build-image push-image
 
@@ -19,22 +21,30 @@ build-image: generate
 	docker build -f build/Dockerfile -t ${IMAGE} .
   # This is a workaround until manfistival can interact with the virtual file system
 	docker build -t ${IMAGE} --build-arg IMAGE=${IMAGE} .
+  # Build an OLM private registry for Kabanero
+	cp deploy/crds/kabanero_v1alpha1_*_crd.yaml registry/manifests/kabanero-operator/0.3.0/
+	docker build -t ${REGISTRY_IMAGE} -f registry/Dockerfile registry/
 
 push-image:
 ifneq "$(IMAGE)" "kabanero-operator:latest"
   # Default push
 	docker push $(IMAGE)
+	docker push $(REGISTRY_IMAGE)
 
 ifdef TRAVIS_TAG
   # This is a Travis tag build. Pushing using Docker tag TRAVIS_TAG
 	docker tag $(IMAGE) $(REPOSITORY):$(TRAVIS_TAG)
 	docker push $(REPOSITORY):$(TRAVIS_TAG)
+	docker tag $(REGISTRY_IMAGE) $(REGISTRY_REPOSITORY):$(TRAVIS_TAG)
+	docker push $(REGISTRY_REPOSITORY):$(TRAVIS_TAG)
 endif
 
 ifdef TRAVIS_BRANCH
   # This is a Travis branch build. Pushing using Docker tag TRAVIS_BRANCH
 	docker tag $(IMAGE) $(REPOSITORY):$(TRAVIS_BRANCH)
 	docker push $(REPOSITORY):$(TRAVIS_BRANCH)
+	docker tag $(REGISTRY_IMAGE) $(REGISTRY_REPOSITORY):$(TRAVIS_BRANCH)
+	docker push $(REGISTRY_REPOSITORY):$(TRAVIS_BRANCH)
 endif
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ REGISTRY_IMAGE ?= kabanero-operator-registry:latest
 REPOSITORY=$(firstword $(subst :, ,${IMAGE}))
 REGISTRY_REPOSITORY=$(firstword $(subst :, ,${REGISTRY_IMAGE}))
 
-.PHONY: build deploy build-image push-image
+.PHONY: build deploy deploy-olm build-image push-image
 
 build: generate
 	go install ./cmd/manager
@@ -81,6 +81,12 @@ endif
 	rm deploy/operator.yaml.bak || true
 	kubectl config set-context $$(kubectl config current-context) --namespace=kabanero
 	kubectl apply -f deploy/
+
+deploy-olm:
+	kubectl create namespace kabanero || true
+	sed -i.bak -e "s!image: KABANERO_REGISTRY_IMAGE!image: ${REGISTRY_IMAGE}!" deploy/olm/01-catalog-source.yaml
+	rm deploy/olm/01-catalog-source.yaml.bak || true
+	kubectl apply -f deploy/olm/
 
 check: format build #test
 

--- a/deploy/olm/00-operator-group.yaml
+++ b/deploy/olm/00-operator-group.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: kabanero
+  namespace: kabanero
+spec:
+  targetNamespaces:
+  - kabanero

--- a/deploy/olm/01-catalog-source.yaml
+++ b/deploy/olm/01-catalog-source.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: kabanero-catalog
+  namespace: openshift-marketplace
+spec:
+  sourceType: grpc
+  image: KABANERO_REGISTRY_IMAGE

--- a/deploy/olm/02-subscription.yaml
+++ b/deploy/olm/02-subscription.yaml
@@ -1,0 +1,12 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: kabanero-operator
+  namespace: kabanero
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: kabanero-operator
+  source: kabanero-catalog
+  sourceNamespace: openshift-marketplace
+  startingCSV: kabanero-operator.v0.3.0

--- a/registry/Dockerfile
+++ b/registry/Dockerfile
@@ -1,0 +1,13 @@
+FROM quay.io/operator-framework/upstream-registry-builder as builder
+
+# This dockerfile is taken from the operator-registry upstream example
+COPY manifests manifests
+RUN ./bin/initializer -o ./bundles.db
+
+FROM scratch
+COPY --from=builder /build/bundles.db /bundles.db
+COPY --from=builder /build/bin/registry-server /registry-server
+COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
+EXPOSE 50051
+ENTRYPOINT ["/registry-server"]
+CMD ["--database", "bundles.db"]

--- a/registry/manifests/kabanero-operator/0.3.0/kabanero-operator.v0.3.0.clusterserviceversion.yaml
+++ b/registry/manifests/kabanero-operator/0.3.0/kabanero-operator.v0.3.0.clusterserviceversion.yaml
@@ -1,7 +1,7 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: kabanero-operator.v0.1.0
+  name: kabanero-operator.v0.3.0
   namespace: placeholder
   annotations:
     capabilities: Basic Install
@@ -21,12 +21,12 @@ metadata:
             "name": "kabanero"
           },
           "spec": {
-            "version": "0.1.0",
+            "version": "0.3.0",
             "collections": {
               "repositories": [
                 {
                   "name": "incubator",
-                  "url": "https://github.com/kabanero-io/collections/releases/download/v0.1.0/kabanero-index.yaml",
+                  "url": "https://github.com/kabanero-io/collections/releases/download/v0.3.0/kabanero-index.yaml",
                   "activateDefaultCollections": true
                 }
               ]
@@ -45,11 +45,10 @@ metadata:
         }
       ]
 spec:
-  # TODO: minKubeVersion 1.12 is invalid when used with  server version (1.11.0+d4cacc0)
-  minKubeVersion: 1.11.0
+  minKubeVersion: 1.14.0
   apiservicedefinitions: {}
   maturity: alpha
-  version: 0.1.0
+  version: 0.3.0
   displayName: Kabanero Operator
   description: |
     The Kabanero operator is used to manage Kabanero Foundation instances on your Open Shift or Kubernetes cluster.
@@ -230,6 +229,24 @@ spec:
                 name: kabanero-operator
                 resources: {}
               serviceAccountName: kabanero-operator
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          verbs:
+          - get
+          - create
+          - list
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumes
+          verbs:
+          - get
+          - create
+        serviceAccountName: kabanero-operator
       permissions:
       - rules:
         - apiGroups:
@@ -245,6 +262,7 @@ spec:
           resources:
           - configmaps
           - services
+          - serviceaccounts
           verbs:
           - get
           - create

--- a/registry/manifests/kabanero-operator/0.3.0/kabanero_v1alpha1_collection_crd.yaml
+++ b/registry/manifests/kabanero-operator/0.3.0/kabanero_v1alpha1_collection_crd.yaml
@@ -1,0 +1,86 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: collections.kabanero.io
+spec:
+  group: kabanero.io
+  names:
+    kind: Collection
+    listKind: CollectionList
+    plural: collections
+    singular: collection
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            desiredState:
+              type: string
+            name:
+              type: string
+            repositoryUrl:
+              type: string
+            version:
+              type: string
+          type: object
+        status:
+          properties:
+            activeAssets:
+              items:
+                properties:
+                  assetDigest:
+                    type: string
+                  assetName:
+                    type: string
+                  status:
+                    type: string
+                  statusMessage:
+                    type: string
+                  url:
+                    type: string
+                type: object
+              type: array
+            activeDigest:
+              type: string
+            activeLocation:
+              type: string
+            activeVersion:
+              type: string
+            availableLocation:
+              type: string
+            availableVersion:
+              type: string
+            images:
+              items:
+                properties:
+                  id:
+                    type: string
+                  image:
+                    type: string
+                type: object
+              type: array
+            status:
+              type: string
+            statusMessage:
+              type: string
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/registry/manifests/kabanero-operator/0.3.0/kabanero_v1alpha1_kabanero_crd.yaml
+++ b/registry/manifests/kabanero-operator/0.3.0/kabanero_v1alpha1_kabanero_crd.yaml
@@ -1,0 +1,260 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kabaneros.kabanero.io
+spec:
+  group: kabanero.io
+  names:
+    kind: Kabanero
+    listKind: KabaneroList
+    plural: kabaneros
+    singular: kabanero
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            appsodyOperator:
+              properties:
+                enable:
+                  type: boolean
+                image:
+                  type: string
+                repository:
+                  type: string
+                tag:
+                  type: string
+                version:
+                  type: string
+              type: object
+            che:
+              properties:
+                cheOperator:
+                  properties:
+                    image:
+                      type: string
+                    repository:
+                      type: string
+                    tag:
+                      type: string
+                    version:
+                      type: string
+                  type: object
+                cheOperatorInstance:
+                  properties:
+                    cheWorkspaceClusterRole:
+                      type: string
+                  type: object
+                enable:
+                  type: boolean
+                kabaneroChe:
+                  properties:
+                    image:
+                      type: string
+                    repository:
+                      type: string
+                    tag:
+                      type: string
+                    version:
+                      type: string
+                  type: object
+              type: object
+            cliServices:
+              properties:
+                image:
+                  type: string
+                repository:
+                  type: string
+                sessionExpirationSeconds:
+                  type: string
+                tag:
+                  type: string
+                version:
+                  description: 'Future: Enable     bool   `json:"enable,omitempty"`'
+                  type: string
+              type: object
+            collections:
+              properties:
+                repositories:
+                  items:
+                    properties:
+                      activateDefaultCollections:
+                        type: boolean
+                      name:
+                        type: string
+                      skipCertVerification:
+                        type: boolean
+                      url:
+                        type: string
+                    type: object
+                  type: array
+              type: object
+            github:
+              properties:
+                apiUrl:
+                  type: string
+                organization:
+                  type: string
+                teams:
+                  items:
+                    type: string
+                  type: array
+              type: object
+            landing:
+              properties:
+                enable:
+                  type: boolean
+                version:
+                  type: string
+              type: object
+            targetNamespaces:
+              items:
+                type: string
+              type: array
+            tekton:
+              properties:
+                disabled:
+                  type: boolean
+                version:
+                  type: string
+              type: object
+            version:
+              type: string
+          type: object
+        status:
+          properties:
+            appsody:
+              description: Appsody instance readiness status.
+              properties:
+                errorMessage:
+                  type: string
+                ready:
+                  type: string
+              type: object
+            che:
+              description: Che instance readiness status.
+              properties:
+                cheOperator:
+                  properties:
+                    version:
+                      type: string
+                  type: object
+                errorMessage:
+                  type: string
+                kabaneroChe:
+                  properties:
+                    version:
+                      type: string
+                  type: object
+                kabaneroCheInstance:
+                  properties:
+                    cheImage:
+                      type: string
+                    cheImageTag:
+                      type: string
+                    cheWorkspaceClusterRole:
+                      type: string
+                  type: object
+                ready:
+                  type: string
+              type: object
+            cli:
+              description: CLI readiness status.
+              properties:
+                errorMessage:
+                  type: string
+                hostnames:
+                  items:
+                    type: string
+                  type: array
+                ready:
+                  type: string
+              type: object
+            kabaneroInstance:
+              description: Kabanero operator instance readiness status. The status
+                is directly correlated to the availability of resources dependencies.
+              properties:
+                errorMessage:
+                  type: string
+                ready:
+                  type: string
+                version:
+                  type: string
+              type: object
+            kappnav:
+              description: Kabanero Application Navigator instance readiness status.
+              properties:
+                apiLocations:
+                  items:
+                    type: string
+                  type: array
+                errorMessage:
+                  type: string
+                ready:
+                  type: string
+                uiLocations:
+                  items:
+                    type: string
+                  type: array
+              type: object
+            knativeEventing:
+              description: Knative eventing instance readiness status.
+              properties:
+                errorMessage:
+                  type: string
+                ready:
+                  type: string
+                version:
+                  type: string
+              type: object
+            knativeServing:
+              description: Knative serving instance readiness status.
+              properties:
+                errorMessage:
+                  type: string
+                ready:
+                  type: string
+                version:
+                  type: string
+              type: object
+            landing:
+              description: Kabanero Landing page readiness status.
+              properties:
+                errorMessage:
+                  type: string
+                ready:
+                  type: string
+                version:
+                  type: string
+              type: object
+            tekton:
+              description: Tekton instance readiness status.
+              properties:
+                errorMessage:
+                  type: string
+                ready:
+                  type: string
+                version:
+                  type: string
+              type: object
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/registry/manifests/kabanero-operator/kabanero-operator-package.yaml
+++ b/registry/manifests/kabanero-operator/kabanero-operator-package.yaml
@@ -1,6 +1,6 @@
 packageName: kabanero-operator
 channels:
 - name: alpha
-  currentCSV: kabanero-operator.v0.1.0
+  currentCSV: kabanero-operator.v0.3.0
 defaultChannel: alpha
 


### PR DESCRIPTION
Build a private registry and push it to docker hub during the Travis build.

The expectation is that the registry can be used to install the Kabanero operator via OLM from an install script.

This is not a production-ready solution - it will need to be modified, but this will establish the framework we will work from.