### PR TITLE
Fix up status issues on OCP 4.2

### DIFF
--- a/pkg/controller/kabaneroplatform/kabaneroplatform_controller.go
+++ b/pkg/controller/kabaneroplatform/kabaneroplatform_controller.go
@@ -346,8 +346,8 @@ func processStatus(ctx context.Context, request reconcile.Request, k *kabanerov1
 	// Gather the status of all resource dependencies.
 	isAppsodyReady, _ := getAppsodyStatus(k, c, reqLogger)
 	isTektonReady, _ := getTektonStatus(k, c)
-	isKnativeEventingReady, _ := getKnativeServingStatus(k, c)
-	isKnativeServingReady, _ := getKnativeEventingStatus(k, c)
+	isKnativeServingReady, _ := getKnativeServingStatus(k, c, reqLogger)
+	isKnativeEventingReady, _ := getKnativeEventingStatus(k, c, reqLogger)
 	isCliRouteReady, _ := getCliRouteStatus(k, reqLogger, c)
 	isKabaneroLandingReady, _ := getKabaneroLandingPageStatus(k, c)
 	isKubernetesAppNavigatorReady, _ := getKappnavStatus(k, c)

--- a/pkg/controller/kabaneroplatform/knative_eventing.go
+++ b/pkg/controller/kabaneroplatform/knative_eventing.go
@@ -2,33 +2,65 @@ package kabaneroplatform
 
 import (
 	"context"
-	"fmt"
+	"encoding/json"
 	"strings"
 
+	"github.com/go-logr/logr"
 	kabanerov1alpha1 "github.com/kabanero-io/kabanero-operator/pkg/apis/kabanero/v1alpha1"
-	knev1alpha1 "github.com/openshift-knative/knative-eventing-operator/pkg/apis/eventing/v1alpha1"
+	knev1alpha1 "github.com/openshift-knative/knative-eventing-operator/pkg/apis/eventing/v1alpha1"	
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Retrieves the current knative eventing instance status.
-func getKnativeEventingStatus(k *kabanerov1alpha1.Kabanero, c client.Client) (bool, error) {
+func getKnativeEventingStatus(k *kabanerov1alpha1.Kabanero, c client.Client, reqLogger logr.Logger) (bool, error) {
 	k.Status.KnativeEventing.ErrorMessage = ""
 	k.Status.KnativeEventing.Ready = "False"
 
-	// Get the knative eventing installation instance.
+	// Hack get unstructured and then feed it into the knative-eventing object as JSON.
+	// The controller-runtime client is a caching client for reads and I can't figure out
+	// how to get it to cache arbitrary objects in another namespace.  Unstructured reads
+	// are not cached.
+	kneInstance := &unstructured.Unstructured{}
+	kneInstance.SetGroupVersionKind(schema.GroupVersionKind{
+		Kind:    "KnativeEventing",
+		Group:   "eventing.knative.dev",
+		Version: "v1alpha1",
+	})
+
 	kneInstNamespace, kneInstName := "knative-eventing", "knative-eventing"
-	kne := &knev1alpha1.KnativeEventing{}
 	err := c.Get(context.TODO(), client.ObjectKey{
-		Namespace: kneInstNamespace,
-		Name:      kneInstName}, kne)
+		Name:      kneInstName,
+		Namespace: kneInstNamespace}, kneInstance)
+
 	if err != nil {
-		message := "Knative eventing instance with the name of " + kneInstName + " under the namespace of " + kneInstNamespace + " could not be found."
-		k.Status.KnativeEventing.Ready = "False"
-		k.Status.KnativeEventing.ErrorMessage = message
-		fmt.Println("Error while assessing Knative eventing readiness. "+message, err)
+		if apierrors.IsNotFound(err) {
+			k.Status.KnativeEventing.ErrorMessage = "Knative eventing instance with the name of " + kneInstName + " under the namespace of " + kneInstNamespace + " could not be found."
+		} else {
+			k.Status.KnativeEventing.ErrorMessage = "Error retrieving KnativeEventing instance: " + err.Error()
+		}
+
+		reqLogger.Error(err, k.Status.KnativeEventing.ErrorMessage)
+		return false, err
+	}
+	
+	data, err := kneInstance.MarshalJSON()
+	if err != nil {
+		k.Status.KnativeEventing.ErrorMessage = err.Error()
+		reqLogger.Error(err, "Error marshalling unstructured KnativeEventing data")
 		return false, err
 	}
 
+	kne := &knev1alpha1.KnativeEventing{}
+	err = json.Unmarshal(data, kne)
+	if err != nil {
+		k.Status.KnativeEventing.ErrorMessage = err.Error()
+		reqLogger.Error(err, "Error unmarshalling unstructured KnativeEventing data")
+		return false, err
+	}
+	
 	// Find the ready type condition. A status can be either True, False, or Unknown.
 	// An Unknown status value is treated the same as a value of False.
 	statusReadyType := "ready"

--- a/pkg/controller/kabaneroplatform/knative_serving.go
+++ b/pkg/controller/kabaneroplatform/knative_serving.go
@@ -2,31 +2,62 @@ package kabaneroplatform
 
 import (
 	"context"
-	"fmt"
+	"encoding/json"
 	"strings"
 
+	"github.com/go-logr/logr"
 	kabanerov1alpha1 "github.com/kabanero-io/kabanero-operator/pkg/apis/kabanero/v1alpha1"
 	knsv1alpha1 "github.com/knative/serving-operator/pkg/apis/serving/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Retrieves the knative serving instance status.
-func getKnativeServingStatus(k *kabanerov1alpha1.Kabanero, c client.Client) (bool, error) {
+func getKnativeServingStatus(k *kabanerov1alpha1.Kabanero, c client.Client, reqLogger logr.Logger) (bool, error) {
 	k.Status.KnativeServing.ErrorMessage = ""
 	k.Status.KnativeServing.Ready = "False"
 
-	// Get the knative serving installation instance.
+	// Hack get unstructured and then feed it into the knative-serving object as JSON.
+	// The controller-runtime client is a caching client for reads and I can't figure out
+	// how to get it to cache arbitrary objects in another namespace.  Unstructured reads
+	// are not cached.
+	knsInstance := &unstructured.Unstructured{}
+	knsInstance.SetGroupVersionKind(schema.GroupVersionKind{
+		Kind:    "KnativeServing",
+		Group:   "serving.knative.dev",
+		Version: "v1alpha1",
+	})
+
 	knsInstNamespace, knsInstName := "knative-serving", "knative-serving"
-	kns := &knsv1alpha1.KnativeServing{}
 	err := c.Get(context.TODO(), client.ObjectKey{
-		Namespace: knsInstNamespace,
-		Name:      knsInstName}, kns)
+		Name:      knsInstName,
+		Namespace: knsInstNamespace}, knsInstance)
 
 	if err != nil {
-		message := "Knative serving instance with the name of " + knsInstName + " under the namespace of " + knsInstNamespace + " could not be found."
-		k.Status.KnativeServing.Ready = "False"
-		k.Status.KnativeServing.ErrorMessage = message
-		fmt.Println("Error while assessing Knative serving readiness. "+message, err)
+		if apierrors.IsNotFound(err) {
+			k.Status.KnativeServing.ErrorMessage = "Knative serving instance with the name of " + knsInstName + " under the namespace of " + knsInstNamespace + " could not be found."
+		} else {
+			k.Status.KnativeServing.ErrorMessage = "Error retrieving KnativeServing instance: " + err.Error()
+		}
+
+		reqLogger.Error(err, k.Status.KnativeServing.ErrorMessage)
+		return false, err
+	}
+	
+	data, err := knsInstance.MarshalJSON()
+	if err != nil {
+		k.Status.KnativeServing.ErrorMessage = err.Error()
+		reqLogger.Error(err, "Error marshalling unstructured KnativeServing data")
+		return false, err
+	}
+
+	kns := &knsv1alpha1.KnativeServing{}
+	err = json.Unmarshal(data, kns)
+	if err != nil {
+		k.Status.KnativeServing.ErrorMessage = err.Error()
+		reqLogger.Error(err, "Error unmarshalling unstructured KnativeServing data")
 		return false, err
 	}
 

--- a/pkg/controller/kabaneroplatform/landing.go
+++ b/pkg/controller/kabaneroplatform/landing.go
@@ -95,12 +95,8 @@ func deployLandingPage(k *kabanerov1alpha1.Kabanero, c client.Client) error {
 		return err
 	}
 
-	// Update the web console's ConfigMap with custom data.  If we could
-	// not find the web console config map, skip it.
+	// Update the web console's ConfigMap with custom data.
 	err = customizeWebConsole(k, c, clientset, config, landingURL)
-	if apierrors.IsNotFound(err) {
-		err = nil
-	}
 
 	return err
 }
@@ -230,6 +226,11 @@ func customizeWebConsole(k *kabanerov1alpha1.Kabanero, c client.Client, clientse
 	// Get a copy of the web-console ConfigMap.
 	cm, err := getWebConsoleConfigMap(c, config)
 	if err != nil {
+		// If couldn't find the web console config map, nothing to do.
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		
 		return err
 	}
 
@@ -328,6 +329,11 @@ func removeWebConsoleCustomization(k *kabanerov1alpha1.Kabanero, c client.Client
 	// Get a copy of the web-console ConfigMap.
 	cm, err := getWebConsoleConfigMap(c, config)
 	if err != nil {
+		// If we couldn't find the config map, there is nothing to do.
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		
 		return err
 	}
 


### PR DESCRIPTION
This is basically the @mezarin told-you-so PR :-)
- The landing page reconcile had another problem in the `cleanup()` method when a `kabanero` instance is deleted.  It can't find the web console config map and so loops without removing its finalizer.  The `kabanero` instance never gets deleted.  I ended u[p fixing it the way Ed suggested in the first place.
- The Knative serving and eventing status is never resolved.  The controller-runtime client is a caching read client which means it doesn't pass read requests thru to the API server.  It reads them from a cache.  Near as I can tell, the cache is populated based on the namespace you've specified when the `manager` starts.  In the past I think we may have been inadvertently passing `""` which is all namespaces.  Now that we're using OLM, we're passing the correct namespace.  I think this means that the cache is not getting populated for other namespaces (other than the namespace that you're in).  I can't figure out how to add a namespace to the cache without also causing the controller to "watch" that namespace.  As a hack/workaround, `Unstructured` requests are never read from the cache, so I'm reading these as unstructured and then round-tripping thru JSON to populate the knative structure.  Long term we need to figure out how to add another namespace to the cache.  We are going to have this problem in other places too.