### PR TITLE
262

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,11 @@ deploy:
 - provider: releases
   api_key: 
     secure: "oYX+vkYZbMPD6ZrTfgpgG0Hxug9jUP6ogVEEOQJnRw+eU7qUAfZT2pyl7fLwfMVUAum/Gp/uWRXYbohCxtyV18VIjBMbM4lsTrWSrggzq6JlMOd/J8Fx/BkWHDFQ0nx4MlDL8BdJbhUjrSleOKp8mW+yJhxuaq1z87svjZ6jxZeaGRTo5jxBcAmATB+VOKUm0z7cxoZC1p0IyQYhAPEVJ2GQd2/jDhRCJvTp99WTgg5PmUA350rSIObzB1Tf+o+gmUCl+Yi3fE1ITTeGU/lam0CXGGMZnDJVeDg6NGmP2f9hbYGyb5yim2xQoIUOgB21XNRRFydhTZaNy4saHaay5EL4KFDvDZ5CLBEr0y9GF9ODi2hNZ1QmlQ6S+HSQ8KXAKNC1kEYnF2N5f7uakEBtwvr4Y+1AtCFSc9bjPlgy3uGWGgTCjy/swchf8fMp56SmocLHII4enj5ESTGvn2t8efjCq13/sGZJSOKrQ+1CLUlPyG+zi/O456umMBx203rFRaNMkb+aZFFt/nQNzF/kSXegfpV9x70bZPQvqWbZ30jZX7UxaxGef/f+IjDPYvz8aEKA0HZH7goEQfFOZ8NAakZEPyd+I82yQJykAYsXHTMgiAj1VUetQCNqvKUtWp2aG0FtYiTo3uO1f/efq9+Ah8TJcCwyNcUCspScc8owOtI="
-  file: "deploy/kabanero-operators.yaml"
+  file: 
+    - "deploy/kabanero-subscriptions.yaml"
+    - "deploy/kabanero-customresources.yaml"
+    - "deploy/install.sh"
+    - "deploy/uninstall.sh"
   skip_cleanup: true
   on:
     repo: kabanero-io/kabanero-operator

--- a/.travis/prepare_release.sh
+++ b/.travis/prepare_release.sh
@@ -1,12 +1,8 @@
 #!/bin/bash
-BASEPATH=$(dirname $(dirname $0))
 
-# Split the IMAGE variable into repository and tag parts
-# e.g. kabanero/kabanero-operator:0.1.1 -> kabanero/kabanero-operator
-IFS=’:’ read -ra REPOSITORY <<< "$IMAGE"
+# Split the REGISTRY_IMAGE variable into repository and tag parts
+# e.g. kabanero/kabanero-operator-registry:0.3.0 -> kabanero/kabanero-operator-registry
+IFS=’:’ read -ra REPOSITORY <<< "$REGISTRY_IMAGE"
 
-# Levearge the gen_operator_deployment.sh script to generate deploy/kabanero-operators.yaml
-$BASEPATH/contrib/gen_operator_deployment.sh $REPOSITORY:$TRAVIS_TAG
-
-# Assure pull policies are set
-sed -i.bak -e 's!imagePullPolicy: .*$!imagePullPolicy: Always!' deploy/kabanero-operators.yaml
+# Set the tag for the kabanero CatalogSource
+sed -i.bak -e "s,kabanero/kabanero-operator-registry:latest,kabanero/kabanero-operator-registry:$TRAVIS_TAG," deploy/kabanero-operators.yaml

--- a/.travis/prepare_release.sh
+++ b/.travis/prepare_release.sh
@@ -5,4 +5,4 @@
 IFS=’:’ read -ra REPOSITORY <<< "$REGISTRY_IMAGE"
 
 # Set the tag for the kabanero CatalogSource
-sed -i.bak -e "s,kabanero/kabanero-operator-registry:latest,kabanero/kabanero-operator-registry:$TRAVIS_TAG," deploy/kabanero-operators.yaml
+sed -i.bak -e "s,kabanero/kabanero-operator-registry:latest,kabanero/kabanero-operator-registry:$TRAVIS_TAG," deploy/kabanero-subscriptions.yaml

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+
+set -Eeox pipefail
+
+RELEASE="${RELEASE:-0.3.0}"
+KABANERO_SUBSCRIPTIONS_YAML="${KABANERO_SUBSCRIPTIONS_YAML:-https://github.com/kabanero-io/kabanero-operator/releases/download/$RELEASE/kabanero-subscriptions.yaml}"
+KABANERO_CUSTOMRESOURCES_YAML="${KABANERO_CUSTOMRESOURCES_YAML:-https://github.com/kabanero-io/kabanero-operator/releases/download/$RELEASE/kabanero-customresources.yaml}"
+SLEEP_LONG="${SLEEP_LONG:-5}"
+SLEEP_SHORT="${SLEEP_SHORT:-2}"
+
+# Check Subscriptions: subscription-name, namespace
+checksub () {
+	echo "Waiting for Subscription $1 InstallPlan to complete."
+
+	# Wait for the InstallPlan to be generated and available on status
+	unset INSTALL_PLAN
+	until oc get subscription $1 -n $2 --output=jsonpath={.status.installPlanRef.name}
+	do
+		sleep $SLEEP_SHORT
+	done
+
+	# Get the InstallPlan
+	until [ -n "$INSTALL_PLAN" ]
+	do
+		sleep $SLEEP_SHORT
+		INSTALL_PLAN=$(oc get subscription $1 -n $2 --output=jsonpath={.status.installPlanRef.name})
+	done
+
+	# Wait for the InstallPlan to Complete
+	unset PHASE
+	until [ "$PHASE" == "Complete" ]
+	do
+		PHASE=$(oc get installplan $INSTALL_PLAN -n $2 --output=jsonpath={.status.phase})
+		sleep $SLEEP_SHORT
+	done
+	
+	# Get installed CluserServiceVersion
+	unset CSV
+	until [ -n "$CSV" ]
+	do
+		sleep $SLEEP_SHORT
+		CSV=$(oc get subscription $1 -n $2 --output=jsonpath={.status.installedCSV})
+	done
+	
+	# Wait for the CSV
+	unset PHASE
+	until [ "$PHASE" == "Succeeded" ]
+	do
+		PHASE=$(oc get clusterserviceversion $CSV -n $2 --output=jsonpath={.status.phase})
+		sleep $SLEEP_SHORT
+	done
+}
+
+### CatalogSource
+
+# Install Kabanero CatalogSource
+oc apply -f $KABANERO_SUBSCRIPTIONS_YAML --selector kabanero.io/install=00-catalogsource
+
+# Check the CatalogSource is ready
+unset LASTOBSERVEDSTATE
+until [ "$LASTOBSERVEDSTATE" == "READY" ]
+do
+	echo "Waiting for CatalogSource kabanero-catalog to be ready."
+	LASTOBSERVEDSTATE=$(oc get catalogsource kabanero-catalog -n openshift-marketplace --output=jsonpath={.status.connectionState.lastObservedState})
+	sleep $SLEEP_SHORT
+done
+
+### Subscriptions
+
+# Install 10-subscription (elasticsearch, jaeger, kiali)
+oc apply -f $KABANERO_SUBSCRIPTIONS_YAML --selector kabanero.io/install=10-subscription
+
+# Verify Subscriptions
+checksub elasticsearch-operator openshift-operators
+checksub jaeger-product openshift-operators
+checksub kiali-ossm openshift-operators
+
+# Install 11-subscription (servicemesh)
+oc apply -f $KABANERO_SUBSCRIPTIONS_YAML --selector kabanero.io/install=11-subscription
+
+# Verify Subscriptions
+checksub servicemeshoperator openshift-operators
+
+# Install 12-subscription (eventing, serving)
+oc apply -f $KABANERO_SUBSCRIPTIONS_YAML --selector kabanero.io/install=12-subscription
+
+# Verify Subscriptions
+checksub knative-eventing-operator-alpha-community-operators-openshift-marketplace openshift-operators
+checksub serverless-operator openshift-operators
+
+# Install 13-subscription (pipelines, appsody)
+oc apply -f $KABANERO_SUBSCRIPTIONS_YAML --selector kabanero.io/install=13-subscription
+
+# Verify Subscriptions
+checksub openshift-pipelines-operator-dev-preview-community-operators-openshift-marketplace openshift-operators
+checksub appsody-operator-certified-beta-certified-operators-openshift-marketplace openshift-operators
+
+# Install 14-subscription (che, kabanero)
+oc apply -f $KABANERO_SUBSCRIPTIONS_YAML --selector kabanero.io/install=14-subscription
+
+# Verify Subscriptions
+checksub eclipse-che kabanero
+checksub kabanero-operator kabanero
+
+
+### CustomResources
+
+# ServiceMeshControlplane
+oc apply -f $KABANERO_CUSTOMRESOURCES_YAML --selector kabanero.io/install=20-cr-servicemeshcontrolplane
+
+# Check the ServiceMeshControlPlane is ready, last condition should reflect readiness
+unset STATUS
+unset TYPE
+until [ "$STATUS" == "True" ] && [ "$TYPE" == "Ready" ]
+do
+	echo "Waiting for ServiceMeshControlPlane basic-install to be ready."
+	TYPE=$(oc get servicemeshcontrolplane -n istio-system basic-install --output=jsonpath={.status.conditions[-1:].type})
+	STATUS=$(oc get servicemeshcontrolplane -n istio-system basic-install --output=jsonpath={.status.conditions[-1:].status})
+	sleep $SLEEP_SHORT
+done
+
+# ServiceMeshMemberRole
+oc apply -f $KABANERO_CUSTOMRESOURCES_YAML --selector kabanero.io/install=21-cr-servicemeshmemberrole
+
+# Serving
+oc apply -f $KABANERO_CUSTOMRESOURCES_YAML --selector kabanero.io/install=22-cr-knative-serving
+
+# Check the KnativeServing is ready, last condition should reflect readiness
+unset STATUS
+unset TYPE
+until [ "$STATUS" == "True" ] && [ "$TYPE" == "Ready" ]
+do
+	echo "Waiting for KnativeServing knative-serving to be ready."
+	TYPE=$(oc get knativeserving knative-serving -n knative-serving --output=jsonpath={.status.conditions[-1:].type})
+	STATUS=$(oc get knativeserving knative-serving -n knative-serving --output=jsonpath={.status.conditions[-1:].status})
+	sleep $SLEEP_SHORT
+done
+
+# Kabanero
+oc apply -f $KABANERO_CUSTOMRESOURCES_YAML --selector kabanero.io/install=23-cr-kabanero
+
+# Check the Kabanero is ready
+unset READY
+until [ "$READY" == "True" ]
+do
+	echo "Waiting for Kabanero kabanero to be ready."
+	READY=$(oc get kabanero kabanero -n kabanero --output=jsonpath={.status.kabaneroInstance.ready})
+	sleep $SLEEP_SHORT
+done
+
+
+# Github Sources
+oc apply -f https://github.com/knative/eventing-contrib/releases/download/v0.9.0/github.yaml
+
+# Need to wait for knative serving CRDs before installing tekton webhook extension
+until oc get crd services.serving.knative.dev 
+do
+	echo "Waiting for CustomResourceDefinition services.serving.knative.dev to be ready."
+	sleep $SLEEP_SHORT
+done
+
+# Tekton Dashboard
+oc new-project tekton-pipelines || true
+oc apply -f https://github.com/tektoncd/dashboard/releases/download/v0.2.0/openshift-webhooks-extension.yaml
+oc apply -f https://github.com/tektoncd/dashboard/releases/download/v0.2.0/openshift-tekton-dashboard.yaml

--- a/deploy/kabanero-customresources.yaml
+++ b/deploy/kabanero-customresources.yaml
@@ -75,7 +75,7 @@ metadata:
 spec:
   members:
   - knative-serving
-  - openshift-pipelines
+  - tekton-pipelines
   - kabanero
 ---
 apiVersion: v1

--- a/deploy/kabanero-customresources.yaml
+++ b/deploy/kabanero-customresources.yaml
@@ -1,0 +1,111 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: istio-system
+  labels:
+    kabanero.io/install: 20-cr-servicemeshcontrolplane
+    kabanero.io/namespace: 'true'
+---
+apiVersion: maistra.io/v1
+kind: ServiceMeshControlPlane
+metadata:
+  name: basic-install
+  namespace: istio-system
+  labels:
+    kabanero.io/install: 20-cr-servicemeshcontrolplane
+spec:
+  istio:
+    global:
+      multitenant: true
+      proxy:
+        autoInject: disabled
+      omitSidecarInjectorConfigMap: true
+      disablePolicyChecks: false
+      defaultPodDisruptionBudget:
+        enabled: false
+    istio_cni:
+      enabled: true
+    gateways:
+      istio-ingressgateway:
+        autoscaleEnabled: false
+        type: LoadBalancer
+      istio-egressgateway:
+        enabled: false
+      cluster-local-gateway:
+        autoscaleEnabled: false
+        enabled: true
+        labels:
+          app: cluster-local-gateway
+          istio: cluster-local-gateway
+        ports:
+          - name: status-port
+            port: 15020
+          - name: http2
+            port: 80
+            targetPort: 8080
+          - name: https
+            port: 443
+    mixer:
+      enabled: false
+      policy:
+        enabled: false
+      telemetry:
+        enabled: false
+    pilot:
+      autoscaleEnabled: false
+      sidecar: false
+    kiali:
+      enabled: false
+    tracing:
+      enabled: false
+    prometheus:
+      enabled: false
+    grafana:
+      enabled: false
+    sidecarInjectorWebhook:
+      enabled: false
+---
+apiVersion: maistra.io/v1
+kind: ServiceMeshMemberRoll
+metadata:
+  name: default
+  namespace: istio-system
+  labels:
+    kabanero.io/install: 21-cr-servicemeshmemberrole
+spec:
+  members:
+  - knative-serving
+  - openshift-pipelines
+  - kabanero
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: knative-serving
+  labels:
+    kabanero.io/install: 22-cr-knative-serving
+    kabanero.io/namespace: 'true'
+---
+apiVersion: serving.knative.dev/v1alpha1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+  namespace: knative-serving
+  labels:
+    kabanero.io/install: 22-cr-knative-serving
+---
+apiVersion: kabanero.io/v1alpha1
+kind: Kabanero
+metadata:
+  name: kabanero
+  namespace: kabanero
+  labels:
+    kabanero.io/install: 23-cr-kabanero
+spec:
+  version: "0.2.0"
+  collections: 
+    repositories: 
+    - name: central
+      url: https://github.com/kabanero-io/collections/releases/download/0.2.0/kabanero-index.yaml
+      activateDefaultCollections: true
+---

--- a/deploy/kabanero-subscriptions.yaml
+++ b/deploy/kabanero-subscriptions.yaml
@@ -1,0 +1,181 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: kabanero-catalog
+  namespace: openshift-marketplace
+  labels:
+    kabanero.io/install: 00-catalogsource
+spec:
+  sourceType: grpc
+  image: kabanero/kabanero-operator-registry:latest
+  publisher: kabanero.io
+  displayName: Kabanero Operators
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: elasticsearch-operator
+  namespace: openshift-operators
+  labels:
+    kabanero.io/install: 10-subscription
+spec:
+  channel: "4.2"
+  installPlanApproval: Automatic
+  name: elasticsearch-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: jaeger-product
+  namespace: openshift-operators
+  labels:
+    kabanero.io/install: 10-subscription
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: jaeger-product
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: kiali-ossm
+  namespace: openshift-operators
+  labels:
+    kabanero.io/install: 10-subscription
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: kiali-ossm
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: servicemeshoperator
+  namespace: openshift-operators
+  labels:
+    kabanero.io/install: 11-subscription
+spec:
+  channel: "1.0"
+  installPlanApproval: Automatic
+  name: servicemeshoperator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: knative-eventing-operator-alpha-community-operators-openshift-marketplace
+  namespace: openshift-operators
+  labels:
+    kabanero.io/install: 12-subscription
+spec:
+  channel: alpha
+  config:
+    resources: {}
+  installPlanApproval: Automatic
+  name: knative-eventing-operator
+  source: community-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: knative-eventing-operator.v0.8.0
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: serverless-operator
+  namespace: openshift-operators
+  labels:
+    kabanero.io/install: 12-subscription
+spec:
+  channel: kabanero-release-0.3.0
+  installPlanApproval: Automatic
+  name: serverless-operator
+  source: kabanero-catalog
+  sourceNamespace: openshift-marketplace
+  startingCSV: serverless-operator.v1.1.0
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-pipelines-operator-dev-preview-community-operators-openshift-marketplace
+  namespace: openshift-operators
+  labels:
+    kabanero.io/install: 13-subscription
+spec:
+  channel: dev-preview
+  config:
+    resources: {}
+  installPlanApproval: Automatic
+  name: openshift-pipelines-operator
+  source: community-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: openshift-pipelines-operator.v0.7.0
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: appsody-operator-certified-beta-certified-operators-openshift-marketplace
+  namespace: openshift-operators
+  labels:
+    kabanero.io/install: 13-subscription
+spec:
+  channel: beta
+  config:
+    resources: {}
+  installPlanApproval: Automatic
+  name: appsody-operator-certified
+  source: certified-operators
+  sourceNamespace: openshift-marketplace
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kabanero
+  labels:
+    kabanero.io/install: 14-subscription
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: kabanero
+  namespace: kabanero
+  labels:
+    kabanero.io/install: 14-subscription
+spec:
+  targetNamespaces:
+  - kabanero
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: eclipse-che
+  namespace: kabanero
+  labels:
+    kabanero.io/install: 14-subscription
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: eclipse-che
+  source: community-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: eclipse-che.v7.3.0
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: kabanero-operator
+  namespace: kabanero
+  labels:
+    kabanero.io/install: 14-subscription
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: kabanero-operator
+  source: kabanero-catalog
+  sourceNamespace: openshift-marketplace
+---

--- a/deploy/uninstall.sh
+++ b/deploy/uninstall.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+
+set -x pipefail
+
+# By default, this script will remove all instances of AppsodyApplication
+# from the cluster, and delete the CRD.  To prevent this, comment the
+# following line.
+APPSODY_UNINSTALL=1
+
+RELEASE="${RELEASE:-0.3.0}"
+KABANERO_SUBSCRIPTIONS_YAML="${KABANERO_SUBSCRIPTIONS_YAML:-https://github.com/kabanero-io/kabanero-operator/releases/download/$RELEASE/kabanero-subscriptions.yaml}"
+KABANERO_CUSTOMRESOURCES_YAML="${KABANERO_CUSTOMRESOURCES_YAML:-https://github.com/kabanero-io/kabanero-operator/releases/download/$RELEASE/kabanero-customresources.yaml}"
+SLEEP_LONG="${SLEEP_LONG:-5}"
+SLEEP_SHORT="${SLEEP_SHORT:-2}"
+
+
+
+### CustomResources
+
+# If we're completely removing Appsody, make sure all instances of the
+# Appsody application CRD are deleted.  This gives the Appsody operator
+# a chance to process any finalizers which may be set, before the operator
+# is removed (by removing the Kabanero instance, later).
+if [ "$APPSODY_UNINSTALL" -eq 1 ] ; then
+
+    # Make sure the Appsody CRD still exists...
+    if [ `oc get crds appsodyapplications.appsody.dev --no-headers --ignore-not-found | wc -l` -gt 0 ] ; then
+
+        # Delete any "Kind: AppsodyApplication" objects in this cluster.  Print
+        # a list of each instance along with its namespace.  Then delete them 
+        # one by one.
+        oc get AppsodyApplication --all-namespaces -o=custom-columns=NAME:.metadata.name,NAMESPACE:.metadata.namespace --no-headers --ignore-not-found | while read APP_NAME APP_NAMESPACE; do oc delete AppsodyApplication $APP_NAME --namespace $APP_NAMESPACE; done
+
+        # Wait for all of the application instances to be deleted.  We don't 
+        # want to delete the Appsody operator until the operator has had a
+        # chance to process its finalizer.
+        echo "Waiting for AppsodyApplication instances to be deleted...."
+        LOOP_COUNT=0
+        while [ `oc get AppsodyApplication --all-namespaces | wc -l` -gt 0 ]
+        do
+            sleep 5
+            LOOP_COUNT=`expr $LOOP_COUNT + 1`
+            if [ $LOOP_COUNT -gt 10 ] ; then
+                echo "Timed out waiting for AppsodyApplication instances to be deleted"
+                exit 1
+            fi
+        done
+    fi
+fi
+
+# Delete CustomResources, do not delete namespaces , which can lead to finalizer problems.
+oc delete -f $KABANERO_CUSTOMRESOURCES_YAML --ignore-not-found --selector kabanero.io/install=23-cr-kabanero,kabanero.io/namespace!=true
+oc delete -f $KABANERO_CUSTOMRESOURCES_YAML --ignore-not-found --selector kabanero.io/install=22-cr-knative-serving,kabanero.io/namespace!=true
+oc delete -f $KABANERO_CUSTOMRESOURCES_YAML --ignore-not-found --selector kabanero.io/install=21-cr-servicemeshmemberrole,kabanero.io/namespace!=true
+oc delete -f $KABANERO_CUSTOMRESOURCES_YAML --ignore-not-found --selector kabanero.io/install=20-cr-servicemeshcontrolplane,kabanero.io/namespace!=true
+
+
+# CRDs still exist
+if [ `oc get crds kabaneros.kabanero.io --no-headers --ignore-not-found | wc -l` -gt 0 ] ; then 
+
+    # Delete any "Kind: Kabanero" objects in this cluster.  Print a list of
+    # each Kabanero instance along with its namespace.  Then delete them one
+    # by one.
+    oc get kabaneros --all-namespaces -o=custom-columns=NAME:.metadata.name,NAMESPACE:.metadata.namespace --no-headers --ignore-not-found | while read KAB_NAME KAB_NAMESPACE; do oc delete kabanero $KAB_NAME --namespace $KAB_NAMESPACE; done
+
+    # Wait for all of the Kabanero instances to be deleted.  We don't want to
+    # delete the Kabanero operator until the operator has had a chance to
+    # process its finalizer.
+    echo "Waiting for Kabanero instances to be deleted...."
+    LOOP_COUNT=0
+    while [ `oc get kabaneros --all-namespaces | wc -l` -gt 0 ]
+    do
+        sleep 5
+        LOOP_COUNT=`expr $LOOP_COUNT + 1`
+        if [ $LOOP_COUNT -gt 10 ] ; then
+            echo "Timed out waiting for Kabanero instances to be deleted"
+            exit 1
+        fi
+    done
+fi
+
+
+
+
+
+# Tekton Dashboard
+oc delete --ignore-not-found -f https://github.com/tektoncd/dashboard/releases/download/v0.2.0/openshift-tekton-dashboard.yaml
+oc delete --ignore-not-found -f https://github.com/tektoncd/dashboard/releases/download/v0.2.0/openshift-webhooks-extension.yaml
+
+# Github Sources
+oc delete -f https://github.com/knative/eventing-contrib/releases/download/v0.9.0/github.yaml
+
+### Subscriptions
+
+# Args: subscription metadata.name, namespace
+# Deletes Subscription, InstallPlan, CSV
+unsubscribe () {
+	# Get InstallPlan
+	INSTALL_PLAN=$(oc get subscription $1 -n $2 --output=jsonpath={.status.installPlanRef.name})
+	
+	# Get CluserServiceVersion
+	CSV=$(oc get subscription $1 -n $2 --output=jsonpath={.status.installedCSV})
+	
+	# Delete Subscription 
+	oc delete subscription $1 -n $2
+
+	# Delete the InstallPlan
+	oc delete installplan $INSTALL_PLAN -n $2
+	
+	# Delete the Installed ClusterServiceVersion
+	oc delete clusterserviceversion $CSV -n $2
+	
+	# Waat for the Copied ClusterServiceVersions to cleanup
+	if [ -n "$CSV" ] ; then
+		while [ `oc get clusterserviceversions $CSV --all-namespaces | wc -l` -gt 0 ]
+		do
+			sleep 5
+			LOOP_COUNT=`expr $LOOP_COUNT + 1`
+			if [ $LOOP_COUNT -gt 10 ] ; then
+					echo "Timed out waiting for Copied ClusterServiceVersions $CSV to be deleted"
+					exit 1
+			fi
+		done
+	fi
+}
+
+unsubscribe kabanero-operator kabanero
+
+unsubscribe serverless-operator openshift-operators
+
+unsubscribe openshift-pipelines-operator-dev-preview-community-operators-openshift-marketplace openshift-operators
+
+unsubscribe knative-eventing-operator-alpha-community-operators-openshift-marketplace openshift-operators
+
+unsubscribe appsody-operator-certified-beta-certified-operators-openshift-marketplace openshift-operators
+
+unsubscribe servicemeshoperator openshift-operators
+
+unsubscribe kiali-ossm openshift-operators
+
+unsubscribe jaeger-product openshift-operators
+
+unsubscribe elasticsearch-operator openshift-operators
+
+unsubscribe eclipse-che kabanero
+
+# Delete OperatorGroup
+oc delete -n kabanero operatorgroup kabanero
+
+# Delete CatalogSource
+oc delete -n openshift-marketplace catalogsource kabanero-catalog
+
+# Cleanup from the openshift service mesh readme
+oc delete validatingwebhookconfiguration/openshift-operators.servicemesh-resources.maistra.io
+oc delete -n openshift-operators daemonset/istio-node
+oc delete clusterrole/istio-admin
+oc get crds -o name | grep '.*\.istio\.io' | xargs -r -n 1 oc delete
+oc get crds -o name | grep '.*\.maistra\.io' | xargs -r -n 1 oc delete


### PR DESCRIPTION
Changes for #262 and #263 

Publish the subscription & customresources yaml.
Publish install and uninstall scripts.

prepare_release need only substitute the tagged REGISTRY_IMAGE for the Kabanero CatalogSource


When a release is published, it will publish two yamls, an install script, and an uninstall script.


