### PR TITLE
Remove create default kabanero instance from install script

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -136,19 +136,6 @@ do
 	sleep $SLEEP_SHORT
 done
 
-# Kabanero
-oc apply -f $KABANERO_CUSTOMRESOURCES_YAML --selector kabanero.io/install=23-cr-kabanero
-
-# Check the Kabanero is ready
-unset READY
-until [ "$READY" == "True" ]
-do
-	echo "Waiting for Kabanero kabanero to be ready."
-	READY=$(oc get kabanero kabanero -n kabanero --output=jsonpath={.status.kabaneroInstance.ready})
-	sleep $SLEEP_SHORT
-done
-
-
 # Github Sources
 oc apply -f https://github.com/knative/eventing-contrib/releases/download/v0.9.0/github.yaml
 
@@ -163,3 +150,21 @@ done
 oc new-project tekton-pipelines || true
 oc apply -f https://github.com/tektoncd/dashboard/releases/download/v0.2.1/openshift-tekton-webhooks-extension-release.yaml
 oc apply -f https://github.com/tektoncd/dashboard/releases/download/v0.2.1/openshift-tekton-dashboard-release.yaml
+
+# Install complete.  give instructions for how to create an instance.
+SAMPLE_KAB_INSTANCE_URL=https://raw.githubusercontent.com/kabanero-io/kabanero-operator/${RELEASE}/config/samples/default.yaml
+
+# Turn off debugging, and wait 3 seconds for it to flush output, before
+# printing instructions.
+set +x
+sleep 3
+echo "***************************************************************************"
+echo "*                                                                          "
+echo "*  The installation script is complete.  You can now create an instance    "
+echo "*  of the Kabanero CR.  If you have cloned and curated a collection set,   "
+echo "*  apply the Kabanero CR that you created.  Or, to create the default      "
+echo "*  instance:                                                               "
+echo "*                                                                          "
+echo "*      oc apply -n kabanero -f ${SAMPLE_KAB_INSTANCE}                  "
+echo "*                                                                          "
+echo "***************************************************************************"

--- a/deploy/kabanero-customresources.yaml
+++ b/deploy/kabanero-customresources.yaml
@@ -94,18 +94,3 @@ metadata:
   labels:
     kabanero.io/install: 22-cr-knative-serving
 ---
-apiVersion: kabanero.io/v1alpha1
-kind: Kabanero
-metadata:
-  name: kabanero
-  namespace: kabanero
-  labels:
-    kabanero.io/install: 23-cr-kabanero
-spec:
-  version: "0.2.0"
-  collections: 
-    repositories: 
-    - name: central
-      url: https://github.com/kabanero-io/collections/releases/download/0.2.0/kabanero-index.yaml
-      activateDefaultCollections: true
----

--- a/deploy/uninstall.sh
+++ b/deploy/uninstall.sh
@@ -49,7 +49,6 @@ if [ "$APPSODY_UNINSTALL" -eq 1 ] ; then
 fi
 
 # Delete CustomResources, do not delete namespaces , which can lead to finalizer problems.
-oc delete -f $KABANERO_CUSTOMRESOURCES_YAML --ignore-not-found --selector kabanero.io/install=23-cr-kabanero,kabanero.io/namespace!=true
 oc delete -f $KABANERO_CUSTOMRESOURCES_YAML --ignore-not-found --selector kabanero.io/install=22-cr-knative-serving,kabanero.io/namespace!=true
 oc delete -f $KABANERO_CUSTOMRESOURCES_YAML --ignore-not-found --selector kabanero.io/install=21-cr-servicemeshmemberrole,kabanero.io/namespace!=true
 oc delete -f $KABANERO_CUSTOMRESOURCES_YAML --ignore-not-found --selector kabanero.io/install=20-cr-servicemeshcontrolplane,kabanero.io/namespace!=true


### PR DESCRIPTION
We received feedback from system test in the previous release, that it would be better if the install script did not deploy the default Kabanero instance.  Instead, the installer could choose to use one that they had previously created, pointing to their own curated collection set.  I've tried to carry forward that logic to the OCP 4.2 install script.