### PR TITLE
update landing page to 0.3.0-rc.1 tag

### DIFF
--- a/config/versions.yaml
+++ b/config/versions.yaml
@@ -22,11 +22,11 @@ kabanero:
 
 related-software:
   landing:
-  - version: "0.2.0"
+  - version: "0.3.0-rc.1"
     orchestrations: "orchestrations/landing/0.1"
     identifiers:
       repository: "kabanero/landing"
-      tag: "0.2.0"
+      tag: "0.3.0-rc.1"
 
   cli-services: 
   - version: "0.3.0-alpha.1"

--- a/config/versions.yaml
+++ b/config/versions.yaml
@@ -16,7 +16,7 @@ kabanero:
 - version: "0.3.0"
   related-versions: 
     cli-services: "0.3.0-alpha.1"
-    landing: "0.2.0"
+    landing: "0.3.0-rc.1"
     kabanero-che: "0.5.0"
     webhook: "0.1.0"
 


### PR DESCRIPTION
`kabanero/landing:0.3.0-rc1` tag is available now here https://hub.docker.com/r/kabanero/landing/tags