### PR TITLE
Build registry from UBI image to pass Red Hat container certification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ build-image: generate
   # variable changes to '0.4.0' or whatever, and the CRDs for 0.3.0 become
   # static.
 	mkdir -p build/registry
+	cp LICENSE build/registry/LICENSE
 	cp -R registry/manifests build/registry/
 	cp registry/Dockerfile build/registry/Dockerfile
 	cp deploy/crds/kabanero_kabanero_crd.yaml deploy/crds/kabanero_collection_crd.yaml build/registry/manifests/kabanero-operator/0.3.0/

--- a/registry/Dockerfile
+++ b/registry/Dockerfile
@@ -4,10 +4,21 @@ FROM quay.io/operator-framework/upstream-registry-builder as builder
 COPY manifests manifests
 RUN ./bin/initializer -o ./bundles.db
 
-FROM scratch
+FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
+
+# The following labels are required for Redhat container certification
+LABEL vendor="Kabanero" \
+      name="Kabanero Operator Registry" \
+      summary="Image for Kabanaro Operator Registry" \
+      description="This image contains the registry that the Kabanero CatalogSource will read the Kabanero Operator from.  See https://github.com/kabanero-io/kabanero-operator/"
+
 COPY --from=builder /build/bundles.db /bundles.db
 COPY --from=builder /build/bin/registry-server /registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
+
+# The licence must be here for Redhat container certification
+COPY LICENSE /licenses/
+
 EXPOSE 50051
 ENTRYPOINT ["/registry-server"]
 CMD ["--database", "bundles.db"]


### PR DESCRIPTION
Our registry container image did not pass Red Hat container certification because:
1) It was not built from the UBI image
2) It was missing some labels and a license file

I've fixed those things here.