### PR TITLE
Change the RepositoryUrl on a collection when the URL changes

### DIFF
--- a/pkg/controller/collection/collection_controller.go
+++ b/pkg/controller/collection/collection_controller.go
@@ -457,6 +457,10 @@ func updateAssetStatus(status *kabanerov1alpha1.CollectionStatus, pipeline Pipel
 		return
 	}
 
+	// Update the URL and digest of the pipeline in case the URL changed.
+	status.ActivePipelines[matchingPipelineIndex].Url = pipeline.Url
+	status.ActivePipelines[matchingPipelineIndex].Digest = pipeline.Sha256
+	
 	// Next find the asset in the Pipeline status.
 	for index, curAssetStatus := range matchingPipeline.ActiveAssets {
 		if assetMatch(curAssetStatus, asset) {

--- a/pkg/controller/kabaneroplatform/featured_collections.go
+++ b/pkg/controller/kabaneroplatform/featured_collections.go
@@ -91,6 +91,7 @@ func reconcileFeaturedCollections(ctx context.Context, k *kabanerov1alpha1.Kaban
 			}
 
 			collectionResource.Spec.Version = findMaxVersionCollectionWithId(featured, c.Id)
+			collectionResource.Spec.RepositoryUrl = data.repositoryConfig.Url
 			err = updateCollection(ctx, collectionResource)
 			if err != nil {
 				return err


### PR DESCRIPTION
Fixes #286 
Fixes #292 
There is a field in the `kind: Collection` for a repository URL.  This field is currently ignored by the collection controller (the controller prefers to look for the associated `kind: Kabanero` and search for the collection in its repository list).  When the repository URL is changed in the `Kabanero` repository list, the kabanero controller will iterate all of the collections therein and make sure an associated `Collection` object exists.  In the case where the new repository does not have a newer version of a collection, the `Collection` object does not change at all, and therefore the collection controller does not try to reconcile it.  This means that any changed assets in the collection are not loaded immediately.  This is understandable since the version of the collection should have changed if assets were to be reloaded.

There are currently cases where a collection hub is re-built with no changes.  For example, moving the collection hub from github.com/kabanero-io to private.github.com/my-repo.  The first move might just be duplicating all of the collections.  It would be good if the collection controller could detect this, and re-load all of the assets from the new location, even if they are un-changed.

By putting the repository URL in the previously-unused repositoryURL field of the `kind: Collection`, the collection controller will reconcile the collection when the URL changes.  This will currently cause all of the assets to be re-loaded from the new location.  Whether this is appropriate or not is up for debate - it seems like they should not be re-loaded if the digest of the individual assets is the same as it was before.  But in any case - the desired behavior is achieved - the `Collection` is updated to reflect that it was loaded from the new location.

The changes in this PR will likely be rendered moot by the "multiple versions of the same collection activate at the same time" changes being proposed in #288 .