### PR TITLE
Bump Che and Kabanero Che tags to 7.3.1 and 0.6.0

### DIFF
--- a/config/orchestrations/che/0.1/codewind-cluster-role.yaml
+++ b/config/orchestrations/che/0.1/codewind-cluster-role.yaml
@@ -38,8 +38,8 @@ rules:
   verbs: ["get", "list", "create", "update", "delete", "patch"]
 
 - apiGroups: [""]
-  resources: ["persistentvolumeclaims"]
-  verbs: ["delete", "create", "patch", "get", "list"]
+  resources: ["persistentvolumeclaims", "persistentvolumeclaims/finalizers", "persistentvolumeclaims/status"]
+  verbs: ["*"]
 
 - apiGroups: ["icp.ibm.com"]
   resources: ["images"]

--- a/config/versions.yaml
+++ b/config/versions.yaml
@@ -36,12 +36,12 @@ related-software:
       tag: "0.3.0-rc.2"
 
   kabanero-che:
-  - version: "0.5.1"
+  - version: "0.6.0"
     orchestrations: "orchestrations/che/0.1"
     identifiers:
-      eclipseCheTag: "7.3.0"
+      eclipseCheTag: "7.3.1"
       repository: "kabanero/kabanero-che"
-      tag: "0.5.1"
+      tag: "0.6.0"
 
   webhook:
   - version: "0.1.0"


### PR DESCRIPTION
Codewind had to bump its minimally supported Che version to 7.3.1 in https://github.com/eclipse/codewind-che-plugin/pull/107, this PR updates the version.yaml to use 7.3.1 and Kabanero Che 0.6.0

I ran `make build` and `make build-image` to verify everything built fine, but I'm not sure how to fully properly test this.

@makandre FYI