### PR TITLE
Update codewind-che-cr.yaml

### DIFF
--- a/config/orchestrations/che/0.1/codewind-che-cr.yaml
+++ b/config/orchestrations/che/0.1/codewind-che-cr.yaml
@@ -38,6 +38,9 @@ spec:
     serverMemoryRequest: ''
     # sets mem limit for server deployment. Defaults to 1Gi
     serverMemoryLimit: ''
+    # additional custom Che properties
+    customCheProperties:
+      CHE_INFRA_KUBERNETES_WORKSPACE__START__TIMEOUT__MIN: "5"
   database:
     # when set to true, the operator skips deploying Postgres, and passes connection details of existing DB to Che server
     # otherwise a Postgres deployment is created


### PR DESCRIPTION
We've found sometimes it takes longer than the default 2 minute timeout for Codewind workspace to startup.  So adding this `CHE_INFRA_KUBERNETES_WORKSPACE__START__TIMEOUT__MIN` property helps.