### PR TITLE
Use etags to cache remote collection resources

### DIFF
--- a/pkg/controller/collection/archive.go
+++ b/pkg/controller/collection/archive.go
@@ -9,8 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
-	"net/http"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -40,13 +38,7 @@ type CollectionAsset struct {
 }
 
 func DownloadToByte(url string) ([]byte, error) {
-	r, err := http.Get(url)
-	if err != nil {
-		return nil, errors.New(fmt.Sprintf("Could not download file: %v", url))
-	}
-	defer r.Body.Close()
-	b, err := ioutil.ReadAll(r.Body)
-	return b, err
+	return getFromCache(url, false)
 }
 
 //Read the manifests from a tar.gz archive

--- a/pkg/controller/collection/httpcache.go
+++ b/pkg/controller/collection/httpcache.go
@@ -1,0 +1,149 @@
+package collection
+
+import (
+	"crypto/tls"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"sync"
+	"time"
+	rlog "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+var cachelog = rlog.Log.WithName("httpcache")
+
+// Value in the cache map.  This contains the etag returned from the remote
+// server, which is used on subsequent requests to use the cached data.
+type cacheValue struct {
+	etag string
+	date string
+	body []byte
+	lastUsed time.Time
+}
+
+// The cache is stored as a map.  We are storing the value as a struct
+// instead of a pointer because multiple threads will be using the values
+// concurrently.
+var httpCache = make(map[string]cacheValue)
+
+// Initialization mutex
+var startPurgeTicker sync.Once
+
+// The Duration at which a cache entry will be purged.
+const purgeDuration = 12 * time.Hour
+
+// The amount of time between cache purge ticker cycles
+const tickerDuration = 30 * time.Minute
+
+// Mutex for concurrent map access
+var cacheLock sync.Mutex
+
+// Returns the requested resource, either from the cache, or from the
+// remote server.  The cache is not meant to be a "high performance" or
+// "heavily concurrent" cache.
+func getFromCache(url string, skipCertVerify bool) ([]byte, error) {
+
+	// Build the request.
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// See if the object is in the cache.  Drop the lock after adding the
+	// header so we're not holding the lock around the HTTP request.
+	cacheLock.Lock()
+	cacheData, ok := httpCache[url]
+	cacheLock.Unlock()
+	if ok {
+		req.Header.Add("If-None-Match", cacheData.etag)
+		req.Header.Add("If-Modified-Since", cacheData.date)
+	}
+
+	// Drive the request. Certificate validation is not disabled by default.
+	client := http.DefaultClient
+	if skipCertVerify {
+		config := &tls.Config{InsecureSkipVerify: skipCertVerify}
+		transport := &http.Transport{TLSClientConfig: config}
+		client = &http.Client{Transport: transport}
+	}
+
+	resp, err := client.Do(req)
+
+	// If something went horribly wrong, tell the user.
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	// Check to see if we're going to use the cached data.
+	if resp.StatusCode == http.StatusNotModified {
+		cachelog.Info(fmt.Sprintf("Retrieved from cache: %v", url))
+
+		// Update the last used time so the entry does not get purged.
+		cacheData.lastUsed = time.Now()
+		cacheLock.Lock()
+		httpCache[url] = cacheData
+		cacheLock.Unlock()
+		
+		return cacheData.body, nil
+	} else if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf(fmt.Sprintf("Could not retrieve the resource: %v. Http status code: %v", url, resp.StatusCode))
+	}
+
+	// We got some new data back.  Read it, and then see if we can cache it.
+	r := resp.Body
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+
+	etag := resp.Header.Get("ETag")
+	date := resp.Header.Get("Date")
+
+	// Re-lock the cache before either adding or removing the response from it.
+	cacheLock.Lock()
+	defer cacheLock.Unlock()
+	if (len(etag) > 0) && (len(date) > 0) {
+		// Before adding an entry to the cache, make sure the purge task is running.
+		startPurgeTicker.Do(startCachePurgeTask)
+		httpCache[url] = cacheValue{etag: etag, date: date, body: b, lastUsed: time.Now()}
+		cachelog.Info(fmt.Sprintf("Stored to cache: %v", url))
+	} else {
+		// Take the entry out of the map if it's already there.
+		delete(httpCache, url)
+	}
+
+	return b, nil
+}
+
+// Starts the periodic purge task
+func startCachePurgeTask() {
+	// Start a ticker that will receive periodic requests to purge the cache.
+	purgeTicker := time.NewTicker(tickerDuration)
+
+	// This is the function that will purge the cache.  Note that this function
+	// never ends since we expect this to be running in a Kube pod which will
+	// never end on its own.
+	go func() {
+		for {
+			select {
+			case <-purgeTicker.C:
+				cachelog.Info("Started cache purge")
+				purgeCache(purgeDuration)
+				cachelog.Info("Finished cache purge")
+			}
+		}
+	}()
+}
+
+// Purges the cache
+func purgeCache(localPurgeDuration time.Duration) {
+	cacheLock.Lock()
+	defer cacheLock.Unlock()
+	for key, _ := range httpCache {
+		if time.Since(httpCache[key].lastUsed) > localPurgeDuration {
+			cachelog.Info("Purging from cache: " + key)
+			delete(httpCache, key)
+		}
+	}
+}

--- a/pkg/controller/collection/httpcache_test.go
+++ b/pkg/controller/collection/httpcache_test.go
@@ -1,0 +1,192 @@
+package collection
+
+import (
+	"testing"
+
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+)
+
+const theResponse = "The response."
+const theResponse2 = "The response2."
+
+// HTTP handler that lets us know if the caller asked for the etag.
+type CacheHandler struct {
+	etag string
+	cacheHits *int32
+}
+
+func (ch CacheHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	// Check to see if the request specified the If-None-Match header
+	etagHeader := req.Header.Get("If-None-Match")
+	if etagHeader == ch.etag {
+		// Indicate the resource has not changed.
+		rw.WriteHeader(http.StatusNotModified)
+		*(ch.cacheHits) += 1
+	} else {
+		// Just write the response
+		rw.Header().Add("ETag", ch.etag)
+		rw.Header().Add("Date", "GarbageDate")
+		rw.Write([]byte(theResponse))
+	}
+}
+
+// Show that the client is sending the correct etag on a subsequent request.
+func TestCachePage(t *testing.T) {
+	var cacheHits int32 = 0
+	handler := CacheHandler{etag: "ABCDE", cacheHits: &cacheHits}
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	// Get the page twice... the first time should not cache, the second should cache.
+	data, err := getFromCache(server.URL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Compare([]byte(theResponse), data) != 0 {
+		t.Fatal("Response 1 not correct")
+	}
+
+	data, err = getFromCache(server.URL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Compare([]byte(theResponse), data) != 0 {
+		t.Fatal("Response 2 not correct")
+	}
+
+	// Make sure that the cache hit one time.
+	if cacheHits != 1 {
+		t.Fatalf("Wrong number of cache hits: %v", cacheHits)
+	}
+}
+
+// HTTP handler that lets us know if the caller asked for the etag.
+type CacheChangeHandler struct {
+	etag1, etag2 string
+	cacheHits *int32
+}
+
+func (ch CacheChangeHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	// Check to see if the request specified the If-None-Match header
+	etagHeader := req.Header.Get("If-None-Match")
+	if etagHeader == ch.etag1 {
+		// Got back the first etag, change it up and return the second.
+		rw.Header().Add("ETag", ch.etag2)
+		rw.Header().Add("Date", "GarbageDate")
+		rw.Write([]byte(theResponse2))
+	} else if etagHeader == ch.etag2 {
+		// Indicate the resource has not changed.
+		rw.WriteHeader(http.StatusNotModified)
+		*(ch.cacheHits) += 1
+	} else {
+		// Just write the response
+		rw.Header().Add("ETag", ch.etag1)
+		rw.Header().Add("Date", "GarbageDate")
+		rw.Write([]byte(theResponse))
+	}
+}
+
+// Show that if the server changes the etag, the client will update it.
+func TestCacheChangePage(t *testing.T) {
+	var cacheHits int32 = 0
+	handler := CacheChangeHandler{etag1: "ABCDE", etag2: "EFGHI", cacheHits: &cacheHits}
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	// Get the page thrice... the first time and second time should not cache, the third should cache.
+	data, err := getFromCache(server.URL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Compare([]byte(theResponse), data) != 0 {
+		t.Fatal("Response 1 not correct")
+	}
+
+	data, err = getFromCache(server.URL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Compare([]byte(theResponse2), data) != 0 {
+		t.Fatal("Response 2 not correct")
+	}
+
+	data, err = getFromCache(server.URL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Compare([]byte(theResponse2), data) != 0 {
+		t.Fatal("Response 3 not correct")
+	}
+
+	// Make sure that the cache hit one time.
+	if cacheHits != 1 {
+		t.Fatalf("Wrong number of cache hits: %v", cacheHits)
+	}
+}
+
+// HTTP handler that does not cache
+type NoCacheHandler struct {}
+
+func (ch NoCacheHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	rw.Write([]byte(theResponse))
+}
+
+// Show that the cache doesn't care if the server does not send etags
+func TestNoCachePage(t *testing.T) {
+	handler := NoCacheHandler{}
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	// Get the page twice... 
+	data, err := getFromCache(server.URL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Compare([]byte(theResponse), data) != 0 {
+		t.Fatal("Response 1 not correct")
+	}
+
+	data, err = getFromCache(server.URL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Compare([]byte(theResponse), data) != 0 {
+		t.Fatal("Response 2 not correct")
+	}
+}
+
+// Test that we can purge an entry from the cache successfully.
+func TestCachePurge(t *testing.T) {
+	var cacheHits int32 = 0
+	handler := CacheHandler{etag: "ABCDE", cacheHits: &cacheHits}
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	// Get the page twice... the first time should not cache.
+	data, err := getFromCache(server.URL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Compare([]byte(theResponse), data) != 0 {
+		t.Fatal("Response 1 not correct")
+	}
+
+	// Now purge the cache
+	purgeCache(0)
+
+	// Get the page the second time... it should not be cached.
+	data, err = getFromCache(server.URL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Compare([]byte(theResponse), data) != 0 {
+		t.Fatal("Response 2 not correct")
+	}
+
+	// Make sure that the cache did not hit.
+	if cacheHits != 0 {
+		t.Fatalf("Wrong number of cache hits: %v", cacheHits)
+	}
+}


### PR DESCRIPTION
Fixes #147 
The collection controller will get the collection index and the pipeline zip for each collection.  The collection index is always going to be the same, and the pipeline zip is usually the same.  If there is an apply failure, this will happen every 60 seconds... if all of the collections have an apply failure this can happen a lot.  Eventually GitHub will throttle the cluster.  This PR caches the data using the `etag` that GitHub returns in the HTTP headers on each response.

There is one cache for the process.  Every 30 minutes, a task runs to purge the cache.  Any entry nt referenced in the past 12 hours will be purged.

There is no attempt to make this a high-performing cache.  There is a mutex that synchronizes access to the backing map, which is keyed by URL.  The mutex is not held around the HTTP request itself, to avoid holding the lock for an excessive period of time.  The trade-off is that the cache can change while the request is running, but there is not a lot of impact if the cache is not correct (it's possible two threads will add the same data after retrieving it from the host).

The test cases test for:
1) Data can be cached
2) Data can be changed (when GitHub sends a new etag)
3) Data can be read when there is no etag
4) Data can be purged from the cache