### PR TITLE
Update codewind-che-cr.yaml

### DIFF
--- a/config/orchestrations/che/0.1/codewind-che-cr.yaml
+++ b/config/orchestrations/che/0.1/codewind-che-cr.yaml
@@ -9,7 +9,7 @@ spec:
     # tag of an image used in Che deployment
     cheImageTag: {{ .tag }}
     # image:tag used in Devfile registry deployment
-    devfileRegistryImage: 'quay.io/eclipse/che-devfile-registry:{{ .eclipseCheTag }}'
+    devfileRegistryImage: 'kabanero/che-devfile-registry:{{ .tag }}'
     # image:tag used in plugin registry deployment
     pluginRegistryImage: 'quay.io/eclipse/che-plugin-registry:{{ .eclipseCheTag }}'
     # defaults to `che`. When set to `codeready`, CodeReady Workspaces is deployed


### PR DESCRIPTION
Update the Che cluster to use the `kabanero/che-devfile-registry` image which contains the Codewind devfile

(The image is built from https://github.com/kabanero-io/che-devfile-registry) 

cc: @johnmcollier 