### PR TITLE
kabanero admission webhook

### DIFF
--- a/cmd/admission-webhook/main.go
+++ b/cmd/admission-webhook/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/kabanero-io/kabanero-operator/pkg/apis"
 	collectionwebhook "github.com/kabanero-io/kabanero-operator/pkg/webhook/collection"
+	kabanerowebhook "github.com/kabanero-io/kabanero-operator/pkg/webhook/kabanero"
 
 	apitypes "k8s.io/apimachinery/pkg/types"
 
@@ -94,17 +95,31 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Create the validating webhook
-	validatingWebhook, err := collectionwebhook.BuildValidatingWebhook(&mgr)
+	// Create the collection validating webhook
+	collectionValidatingWebhook, err := collectionwebhook.BuildValidatingWebhook(&mgr)
 	if err != nil {
-		log.Error(err, "unable to setup validating webhook")
+		log.Error(err, "unable to setup collection validating webhook")
 		os.Exit(1)
 	}
 
-	// Create the mutating webhook
-	mutatingWebhook, err := collectionwebhook.BuildMutatingWebhook(&mgr)
+	// Create the collection mutating webhook
+	collectionMutatingWebhook, err := collectionwebhook.BuildMutatingWebhook(&mgr)
 	if err != nil {
-		log.Error(err, "unable to setup mutating webhook")
+		log.Error(err, "unable to setup collection mutating webhook")
+		os.Exit(1)
+	}
+
+	// Create the kabanero validating webhook
+	kabaneroValidatingWebhook, err := kabanerowebhook.BuildValidatingWebhook(&mgr)
+	if err != nil {
+		log.Error(err, "unable to setup kabanero validating webhook")
+		os.Exit(1)
+	}
+
+	// Create the kabanero mutating webhook
+	kabaneroMutatingWebhook, err := kabanerowebhook.BuildMutatingWebhook(&mgr)
+	if err != nil {
+		log.Error(err, "unable to setup kabanero mutating webhook")
 		os.Exit(1)
 	}
 
@@ -141,7 +156,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	err = admissionServer.Register(validatingWebhook, mutatingWebhook)
+	err = admissionServer.Register(collectionValidatingWebhook, collectionMutatingWebhook, kabaneroValidatingWebhook, kabaneroMutatingWebhook)
 	if err != nil {
 		log.Error(err, "unable to register webhooks in the admission server")
 		os.Exit(1)

--- a/pkg/webhook/kabanero/mutatingwebhook.go
+++ b/pkg/webhook/kabanero/mutatingwebhook.go
@@ -1,0 +1,85 @@
+package kabanero
+
+import (
+	"context"
+	"net/http"
+
+	kabanerov1alpha1 "github.com/kabanero-io/kabanero-operator/pkg/apis/kabanero/v1alpha1"
+
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
+)
+
+// Builds the webhook for the manager to register
+func BuildMutatingWebhook(mgr *manager.Manager) (webhook.Webhook, error) {
+	// Create the mutating webhook
+	return builder.NewWebhookBuilder().
+		Name("mutating.kabanero.kabanero.io").
+		Mutating().
+		Operations(admissionregistrationv1beta1.Create, admissionregistrationv1beta1.Update).
+		WithManager(*mgr).
+		ForType(&kabanerov1alpha1.Kabanero{}).
+		Handlers(&kabaneroMutator{}).
+		Build()
+}
+
+// kabaneroMutator mutates kabaneros
+type kabaneroMutator struct {
+	client  client.Client
+	decoder types.Decoder
+}
+
+// Implement admission.Handler so the controller can handle admission request.
+// This no-op assignment ensures that the struct implements the interface.
+var _ admission.Handler = &kabaneroMutator{}
+
+// kabaneroMutator verifies that the kabanero version singleton and array
+// are not in conflict.
+func (a *kabaneroMutator) Handle(ctx context.Context, req types.Request) types.Response {
+	kabanero := &kabanerov1alpha1.Kabanero{}
+
+	err := a.decoder.Decode(req, kabanero)
+	if err != nil {
+		return admission.ErrorResponse(http.StatusBadRequest, err)
+	}
+	copy := kabanero.DeepCopy()
+
+	err = a.mutatekabaneroFn(ctx, copy)
+	if err != nil {
+		return admission.ErrorResponse(http.StatusInternalServerError, err)
+	}
+	return admission.PatchResponse(kabanero, copy)
+}
+
+// mutatekabaneroFn add an annotation to the given pod
+func (a *kabaneroMutator) mutatekabaneroFn(ctx context.Context, kabanero *kabanerov1alpha1.Kabanero) error {
+	// TODO: Business logic
+	return nil
+}
+
+// kabaneroMutator implements inject.Client.
+// A client will be automatically injected.
+var _ inject.Client = &kabaneroMutator{}
+
+// InjectClient injects the client.
+func (v *kabaneroMutator) InjectClient(c client.Client) error {
+	v.client = c
+	return nil
+}
+
+// podAnnotator implements inject.Decoder.
+// A decoder will be automatically injected.
+var _ inject.Decoder = &kabaneroMutator{}
+
+// InjectDecoder injects the decoder.
+func (v *kabaneroMutator) InjectDecoder(d types.Decoder) error {
+	v.decoder = d
+	return nil
+}

--- a/pkg/webhook/kabanero/validatingwebhook.go
+++ b/pkg/webhook/kabanero/validatingwebhook.go
@@ -1,0 +1,114 @@
+package kabanero
+
+// The controller-runtime example webhook (v0.10) was used to build this
+// webhook implementation.
+
+import (
+	"context"
+	"net/http"
+	"fmt"
+
+	kabanerov1alpha1 "github.com/kabanero-io/kabanero-operator/pkg/apis/kabanero/v1alpha1"
+
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
+)
+
+// Builds the webhook for the manager to register
+func BuildValidatingWebhook(mgr *manager.Manager) (webhook.Webhook, error) {
+	// Create the validating webhook
+	return builder.NewWebhookBuilder().
+		Name("validating.kabanero.kabanero.io").
+		Validating().
+		Operations(admissionregistrationv1beta1.Create, admissionregistrationv1beta1.Update).
+		WithManager(*mgr).
+		ForType(&kabanerov1alpha1.Kabanero{}).
+		Handlers(&kabaneroValidator{}).
+		Build()
+}
+
+// kabaneroValidator validates kabaneros
+type kabaneroValidator struct {
+	client  client.Client
+	decoder types.Decoder
+}
+
+// Implement admission.Handler so the controller can handle admission request.
+// This no-op assignment ensures that the struct implements the interface.
+var _ admission.Handler = &kabaneroValidator{}
+
+// kabaneroValidator admits a kabanero if it passes validity checks
+func (v *kabaneroValidator) Handle(ctx context.Context, req types.Request) types.Response {
+	kabanero := &kabanerov1alpha1.Kabanero{}
+
+	err := v.decoder.Decode(req, kabanero)
+	if err != nil {
+		return admission.ErrorResponse(http.StatusBadRequest, err)
+	}
+
+	allowed, reason, err := v.validatekabaneroFn(ctx, kabanero)
+	if err != nil {
+		return admission.ErrorResponse(http.StatusInternalServerError, err)
+	}
+	return admission.ValidationResponse(allowed, reason)
+}
+
+func (v *kabaneroValidator) validatekabaneroFn(ctx context.Context, pod *kabanerov1alpha1.Kabanero) (bool, string, error) {
+	// For now, just reject everything.
+
+	name := pod.ObjectMeta.Name
+	namespace := pod.ObjectMeta.Namespace
+	kabaneroList := &kabanerov1alpha1.KabaneroList{}
+	options := &client.ListOptions{Namespace: namespace}
+
+	err := v.client.List(ctx, options, kabaneroList)
+	if err != nil {
+		return false, fmt.Sprintf("Failed to list Kabaneros in namespace: %s", namespace), err
+	}
+	
+	// If there is a Kabanero in this namespace other than a named match (update), reject. 
+	// Do not allow more than 1 Kabanero per namespace.
+	allow := true
+	for _, kabanero := range kabaneroList.Items {
+		if name == kabanero.Name {
+			// Matching name, allow Update
+			break
+		} else {
+			// This is an additional instance, reject
+			allow = false
+		}
+	}
+	
+	if allow {
+		return true, fmt.Sprintf("Kabanero %s in namespace %s approved", name, namespace), nil
+	} else {
+		return false, fmt.Sprintf("Rejecting additional Kabanero instance: %s in namespace: %s. Multiple Kabanero instances are not allowed.", name, namespace), nil
+	}
+}
+
+// kabaneroValidator implements inject.Client.
+// A client will be automatically injected.
+var _ inject.Client = &kabaneroValidator{}
+
+// InjectClient injects the client.
+func (v *kabaneroValidator) InjectClient(c client.Client) error {
+	v.client = c
+	return nil
+}
+
+// podValidator implements inject.Decoder.
+// A decoder will be automatically injected.
+var _ inject.Decoder = &kabaneroValidator{}
+
+// InjectDecoder injects the decoder.
+func (v *kabaneroValidator) InjectDecoder(d types.Decoder) error {
+	v.decoder = d
+	return nil
+}


### PR DESCRIPTION
The kabanero webhook was copied from collection webhook, which just looked like boilerplate for the time being? Hopefully there is not any unintended logic?

---

If the webhook is up, the second instance is rejected with

`Error from server (Rejecting additional Kabanero instance: kabanero2 in namespace: kabanero. Multiple Kabanero instances are not allowed.): error when creating "full2.yaml": admission webhook "validating.kabanero.kabanero.io" denied the request: Rejecting additional Kabanero instance: kabanero2 in namespace: kabanero. Multiple Kabanero instances are not allowed.`

If multiple kabaneros exist (because of creation while hook is down), updates can be applied to either.