### PR TITLE
Report HTTP error codes on collection activate

### DIFF
--- a/pkg/controller/collection/archive.go
+++ b/pkg/controller/collection/archive.go
@@ -45,6 +45,9 @@ func DownloadToByte(url string) ([]byte, error) {
 		return nil, errors.New(fmt.Sprintf("Could not download file: %v", url))
 	}
 	defer r.Body.Close()
+	if r.StatusCode != http.StatusOK {
+		return nil, errors.New(fmt.Sprintf("Could not retrieve the resource: %v. Http status code: %v", url, r.StatusCode))
+	}
 	b, err := ioutil.ReadAll(r.Body)
 	return b, err
 }

--- a/pkg/controller/collection/collection_controller.go
+++ b/pkg/controller/collection/collection_controller.go
@@ -617,6 +617,7 @@ func activate(collectionResource *kabanerov1alpha1.Collection, collection *Colle
 		// Retrieve manifests as unstructured
 		manifests, err := GetManifests(pipeline.Url, pipeline.Sha256, renderingContext, log)
 		if err != nil {
+			collectionResource.Status.StatusMessage = err.Error()
 			return err
 		}
 


### PR DESCRIPTION
Fixes #341 
We were not checking the HTTP error code when we tried to retrieve a pipeline zip.  The collection contained a bad URL to a pipeline zip.  GitHub helpfully returned a 404, but the body of the request contained the text "Not Found".  So we computed the SHA256 of "Not Found" and it was not the same SHA256 that the index had specified.  So the error the user got was "Digest mismatch".  A more helpful error would have been "Could not retrieve resource - HTTP 404".

This is only broken in Kabanero < 0.4.  This PR pulls this into Kabanero 0.3.