### PR TITLE
kabanero-0.5 serverless-operator.v1.2.0

### DIFF
--- a/deploy/kabanero-subscriptions.yaml
+++ b/deploy/kabanero-subscriptions.yaml
@@ -91,7 +91,7 @@ metadata:
   labels:
     kabanero.io/install: 12-subscription
 spec:
-  channel: kabanero-0.4
+  channel: kabanero-0.5
   installPlanApproval: Automatic
   name: serverless-operator
   source: kabanero-catalog

--- a/registry/manifests/serverless-operator/1.2.0/serverless-operator.v1.2.0.clusterserviceversion.yaml
+++ b/registry/manifests/serverless-operator/1.2.0/serverless-operator.v1.2.0.clusterserviceversion.yaml
@@ -1,0 +1,384 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "serving.knative.dev/v1alpha1",
+          "kind": "KnativeServing",
+          "metadata": {
+            "name": "knative-serving"
+          },
+          "spec": {
+            "config": {
+              "autoscaler": {
+                "container-concurrency-target-default": "100",
+                "container-concurrency-target-percentage": "1.0",
+                "enable-scale-to-zero": "true",
+                "max-scale-up-rate": "10",
+                "panic-threshold-percentage": "200.0",
+                "panic-window": "6s",
+                "panic-window-percentage": "10.0",
+                "scale-to-zero-grace-period": "30s",
+                "stable-window": "60s",
+                "tick-interval": "2s"
+              },
+              "defaults": {
+                "revision-cpu-limit": "1000m",
+                "revision-cpu-request": "400m",
+                "revision-memory-limit": "200M",
+                "revision-memory-request": "100M",
+                "revision-timeout-seconds": "300"
+              },
+              "deployment": {
+                "registriesSkippingTagResolving": "ko.local,dev.local"
+              },
+              "gc": {
+                "stale-revision-create-delay": "24h",
+                "stale-revision-lastpinned-debounce": "5h",
+                "stale-revision-minimum-generations": "1",
+                "stale-revision-timeout": "15h"
+              },
+              "logging": {
+                "loglevel.activator": "info",
+                "loglevel.autoscaler": "info",
+                "loglevel.controller": "info",
+                "loglevel.queueproxy": "info",
+                "loglevel.webhook": "info"
+              },
+              "observability": {
+                "logging.enable-var-log-collection": "false",
+                "metrics.backend-destination": "prometheus"
+              },
+              "tracing": {
+                "backend": "none",
+                "sample-rate": "0.1"
+              }
+            }
+          }
+        }
+      ]
+    capabilities: Seamless Upgrades
+    categories: Networking,Integration & Delivery,Cloud Provider,Developer Tools
+    certified: "false"
+    containerImage: registry.redhat.io/openshift-serverless-1-tech-preview/serverless-rhel8-operator:1.2.0-8
+    createdAt: "2019-07-27T17:00:00Z"
+    description: |-
+      Provides a collection of API's based on Knative to support deploying and serving
+      of serverless applications and functions.
+    repository: https://github.com/openshift-knative/serverless-operator
+    support: Red Hat, Inc.
+  name: serverless-operator.v1.2.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: Represents an installation of a particular version of Knative Serving
+      displayName: Knative Serving
+      kind: KnativeServing
+      name: knativeservings.serving.knative.dev
+      statusDescriptors:
+      - description: The version of Knative Serving installed
+        displayName: Version
+        path: version
+      - description: Conditions of Knative Serving installed
+        displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - 'urn:alm:descriptor:io.kubernetes.conditions'
+      version: v1alpha1
+    required:
+    - description: A list of namespaces in Service Mesh
+      displayName: Istio Service Mesh Member Roll
+      kind: ServiceMeshMemberRoll
+      name: servicemeshmemberrolls.maistra.io
+      version: v1
+    - description: An Istio control plane installation
+      displayName: Istio Service Mesh Control Plane
+      kind: ServiceMeshControlPlane
+      name: servicemeshcontrolplanes.maistra.io
+      version: v1
+  description: |-
+    The Red Hat Serverless Operator provides a collection of API's to
+    install various "serverless" services.
+
+    This is a **[Tech Preview release](https://access.redhat.com/support/offerings/techpreview)!**
+
+    # Knative Serving
+
+    Knative Serving builds on Kubernetes to support deploying and
+    serving of serverless applications and functions. Serving is easy
+    to get started with and scales to support advanced scenarios. The
+    Knative Serving project provides middleware primitives that
+    enable:
+
+    - Rapid deployment of serverless containers
+    - Automatic scaling up and down to zero
+    - Routing and network programming for Istio components
+    - Point-in-time snapshots of deployed code and configurations
+
+    ## Prerequisites
+
+    The Serverless Operator's provided APIs such as Knative Serving
+    have certain requirements with regards to the size of the underlying
+    cluster and a working installation of Service Mesh. See the [installation
+    section](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index#installing-openshift-serverless)
+    of the Serverless documentation for more info.
+
+    ## Further Information
+
+    For documentation on using Knative Serving, see the
+    [serving section](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index#knative-serving_serverless-architecture) of the
+    [Serverless documentation site](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index).
+
+  displayName: OpenShift Serverless Operator
+  icon:
+  - base64data: PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMzQwMDt9LmNscy0ye2ZpbGw6I2NlMmUwMDt9LmNscy0ze2ZpbGw6bm9uZTt9LmNscy00e2ZpbGw6I2ZmZjt9LmNscy01e2ZpbGw6I2RjZGNkYzt9LmNscy02e2ZpbGw6I2FhYTt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZF9IYXQtT3BlbnNoaWZ0NC1DYXRhbG9nX0ljb25zLVNlcnZlcmxlc3M8L3RpdGxlPjxjaXJjbGUgY2xhc3M9ImNscy0xIiBjeD0iNTAiIGN5PSI1MCIgcj0iNTAiLz48cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik04NS4zNiwxNC42NEE1MCw1MCwwLDAsMSwxNC42NCw4NS4zNloiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik00MC41Nyw0Ny40MmEzLjg5LDMuODksMCwxLDAsMy44OCwzLjg4QTMuODksMy44OSwwLDAsMCw0MC41Nyw0Ny40MloiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik0yMS40Miw0Ny40MkEzLjg5LDMuODksMCwxLDAsMjUuMyw1MS4zLDMuODksMy44OSwwLDAsMCwyMS40Miw0Ny40MloiLz48cGF0aCBjbGFzcz0iY2xzLTQiIGQ9Ik01MC4wOSw0OC44NmgtLjE4YTQuMTEsNC4xMSwwLDAsMS0zLjI2LTEuNjMsNy42OSw3LjY5LDAsMCwwLTEyLjE2LDAsNC4xMyw0LjEzLDAsMCwxLTMuMjYsMS42M0gzMWE0LjA5LDQuMDksMCwwLDEtMy4yNS0xLjYzQTcuNjksNy42OSwwLDAsMCwxNCw1MS45M2gwVjY0LjZhMi43OSwyLjc5LDAsMCwwLDIuNzksMi43OWgxNS44TDUxLjM0LDQ4LjY2QTQsNCwwLDAsMSw1MC4wOSw0OC44NloiLz48cGF0aCBjbGFzcz0iY2xzLTUiIGQ9Ik03OC4wNSw0NC4yNWE3LjY1LDcuNjUsMCwwLDAtNS44NSwzQTQuMSw0LjEsMCwwLDEsNjksNDguODZoLS4xOWE0LjEzLDQuMTMsMCwwLDEtMy4yNi0xLjYzLDcuNjksNy42OSwwLDAsMC0xMi4xNiwwLDQuMTYsNC4xNiwwLDAsMS0yLDEuNDNMMzIuNjEsNjcuMzlIODMuMTlBMi43OSwyLjc5LDAsMCwwLDg2LDY0LjZWNTIuMDdBNy43Nyw3Ljc3LDAsMCwwLDc4LjA1LDQ0LjI1WiIvPjxwYXRoIGNsYXNzPSJjbHMtNiIgZD0iTTIxLjEsNjNoMTBhMS44MywxLjgzLDAsMSwwLDAtMy42NmgtMTBhMS44MywxLjgzLDAsMCwwLDAsMy42NloiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjQwLjU3IiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjQwLjU3IiBjeT0iMjguMjMiIHI9IjEuMzUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjU5LjcyIiBjeT0iMjguMjMiIHI9IjEuMzUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjIxLjQyIiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjUwIiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjY4Ljg5IiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjMxLjA5IiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNiIgY3g9Ijc3Ljk0IiBjeT0iNTQuMzEiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNiIgY3g9IjY4LjkxIiBjeT0iNTQuMzEiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9Ijc3Ljk0IiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjU5LjcyIiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjUwIiBjeT0iMzMuMSIgcj0iMy4wMSIvPjxjaXJjbGUgY2xhc3M9ImNscy00IiBjeD0iMzEuMDkiIGN5PSIzMy4xIiByPSIzLjAxIi8+PGNpcmNsZSBjbGFzcz0iY2xzLTQiIGN4PSI2OC44OSIgY3k9IjMzLjEiIHI9IjMuMDEiLz48L3N2Zz4=
+    mediatype: image/svg+xml
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - '*'
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        serviceAccountName: knative-serving-operator
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - events
+          - configmaps
+          verbs:
+          - "*"
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - replicasets
+          verbs:
+          - "*"
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - "*"
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - "*"
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - networking.internal.knative.dev
+          resources:
+          - clusteringresses
+          - clusteringresses/status
+          - clusteringresses/finalizers
+          - ingresses
+          - ingresses/status
+          - ingresses/finalizers
+          verbs:
+          - "*"
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          - routes/custom-host
+          - routes/status
+          - routes/finalizers
+          verbs:
+          - "*"
+        - apiGroups:
+          - serving.knative.dev
+          resources:
+          - knativeservings
+          - knativeservings/finalizers
+          verbs:
+          - '*'
+        - apiGroups:
+          - maistra.io
+          resources:
+          - servicemeshmemberrolls
+          verbs:
+          - '*'
+        serviceAccountName: knative-openshift-ingress
+      deployments:
+      - name: knative-serving-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: knative-serving-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: knative-serving-operator
+            spec:
+              containers:
+              - command:
+                - knative-serving-operator
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: knative-serving-operator
+                - name: IMAGE_QUEUE
+                  value: registry.redhat.io/openshift-serverless-1-tech-preview/serving-queue-rhel8:0.9.0-6
+                - name: IMAGE_activator
+                  value: registry.redhat.io/openshift-serverless-1-tech-preview/serving-activator-rhel8:0.9.0-6
+                - name: IMAGE_autoscaler
+                  value: registry.redhat.io/openshift-serverless-1-tech-preview/serving-autoscaler-rhel8:0.9.0-6
+                - name: IMAGE_autoscaler-hpa
+                  value: registry.redhat.io/openshift-serverless-1-tech-preview/serving-autoscaler-hpa-rhel8:0.9.0-4
+                - name: IMAGE_controller
+                  value: registry.redhat.io/openshift-serverless-1-tech-preview/serving-controller-rhel8:0.9.0-6
+                - name: IMAGE_networking-istio
+                  value: registry.redhat.io/openshift-serverless-1-tech-preview/serving-networking-istio-rhel8:0.9.0-6
+                - name: IMAGE_webhook
+                  value: registry.redhat.io/openshift-serverless-1-tech-preview/serving-webhook-rhel8:0.9.0-6
+                image: registry.redhat.io/openshift-serverless-1-tech-preview/serving-rhel8-operator:0.9.0-8
+                imagePullPolicy: Always
+                name: knative-serving-operator
+                resources: {}
+              serviceAccountName: knative-serving-operator
+      - name: knative-openshift-ingress
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: knative-openshift-ingress
+          template:
+            metadata:
+              labels:
+                name: knative-openshift-ingress
+            spec:
+              serviceAccountName: knative-openshift-ingress
+              containers:
+                - name: knative-openshift-ingress
+                  image: registry.redhat.io/openshift-serverless-1-tech-preview/ingress-rhel8-operator:0.0.13-1
+                  command:
+                  - knative-openshift-ingress
+                  imagePullPolicy: Always
+                  env:
+                    - name: WATCH_NAMESPACE
+                      value: "" # watch all namespaces for ClusterIngress
+                    - name: POD_NAME
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.name
+                    - name: OPERATOR_NAME
+                      value: "knative-openshift-ingress"
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - apps
+          resourceNames:
+          - knative-serving-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - serving.knative.dev
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        serviceAccountName: knative-serving-operator
+    strategy: deployment
+  installModes:
+  - supported: false
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - serverless
+  - FaaS
+  - microservices
+  - scale to zero
+  - knative
+  - serving
+  links:
+  - name: Documentation
+    url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index
+  - name: Source Repository
+    url: https://github.com/openshift-knative/serverless-operator
+  maintainers:
+  - email: serverless-support@redhat.com
+    name: Serverless Team
+  maturity: alpha
+  provider:
+    name: Red Hat, Inc.
+  replaces: serverless-operator.v1.1.0
+  version: 1.2.0

--- a/registry/manifests/serverless-operator/1.2.0/serving_v1alpha1_knativeserving_crd.yaml
+++ b/registry/manifests/serverless-operator/1.2.0/serving_v1alpha1_knativeserving_crd.yaml
@@ -1,0 +1,99 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: knativeservings.serving.knative.dev
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.version
+    name: Version
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Ready")].status
+    name: Ready
+    type: string
+  - JSONPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+    name: Reason
+    type: string
+  group: serving.knative.dev
+  names:
+    kind: KnativeServing
+    listKind: KnativeServingList
+    plural: knativeservings
+    singular: knativeserving
+    shortNames:
+    - ks
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Schema for the knativeservings API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: Spec defines the desired state of KnativeServing
+          properties:
+            config:
+              additionalProperties:
+                additionalProperties:
+                  type: string
+                type: object
+              description: A means to override the corresponding entries in the upstream
+                configmaps
+              type: object
+          type: object
+        status:
+          description: Status defines the observed state of KnativeServing
+          properties:
+            conditions:
+              description: The latest available observations of a resource's current
+                state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: LastTransitionTime is the last time the condition
+                      transitioned from one status to another. We use VolatileTime
+                      in place of metav1.Time to exclude this from creating equality.Semantic
+                      differences (all other things held constant).
+                    type: string
+                  message:
+                    description: A human readable message indicating details about
+                      the transition.
+                    type: string
+                  reason:
+                    description: The reason for the condition's last transition.
+                    type: string
+                  severity:
+                    description: Severity with which to treat failures of this type
+                      of condition. When this is not specified, it defaults to Error.
+                    type: string
+                  status:
+                    description: Status of the condition, one of True, False, Unknown.
+                    type: string
+                  type:
+                    description: Type of condition.
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            version:
+              description: The version of the installed release
+              type: string
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/registry/manifests/serverless-operator/serverless-operator.package.yaml
+++ b/registry/manifests/serverless-operator/serverless-operator.package.yaml
@@ -4,4 +4,6 @@ channels:
   currentCSV: serverless-operator.v1.1.0
 - name: kabanero-0.4
   currentCSV: serverless-operator.v1.1.0
-defaultChannel: kabanero-0.4
+- name: kabanero-0.5
+  currentCSV: serverless-operator.v1.2.0
+defaultChannel: kabanero-0.5


### PR DESCRIPTION
Remove prior Kabanero CatalogSource during install/upgrade to ensure OLM reads new CSVs
Adjust sequence of Kabanero CatalogSource and catalog-operator recycle to continue to attempt to avoid ready state issue
Clean prior smmr before update/install to serverless-operator.v1.2.0, otherwise operator will fail to reconcile
Update to serverless-operator.v1.2.0