### PR TITLE
collection status err

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ dependency-report:
 # Requires jq
 
 # Install Test
-int-test-install: creds build-image push-image int-install
+int-test-install: creds build-image push-image int-install int-config
 
 creds:
 	tests/00-credentials.sh
@@ -207,10 +207,12 @@ endif
 
 	KABANERO_SUBSCRIPTIONS_YAML=/tmp/kabanero-subscriptions.yaml KABANERO_CUSTOMRESOURCES_YAML=deploy/kabanero-customresources.yaml deploy/install.sh
 
+int-config:
+# Update config to correct image
 ifdef INTERNAL_REGISTRY
-	sed -e "s!image: kabanero/kabanero-operator-admission-webhook:.*!image: ${WEBHOOK_IMAGE_SVC}!; s!image: kabanero-operator-collection-controller::.*!image: ${COLLECTION_CTRLR_IMAGE_SVC}!" config/samples/full.yaml | kubectl apply -f -
+	sed -e "s!image: kabanero/kabanero-operator-admission-webhook:.*!image: ${WEBHOOK_IMAGE_SVC}!; s!image: kabanero/kabanero-operator-collection-controller:.*!image: ${COLLECTION_CTRLR_IMAGE_SVC}!" config/samples/full.yaml | kubectl apply -f -
 else
-	sed -e "s!image: kabanero/kabanero-operator-admission-webhook:.*!image: ${WEBHOOK_IMAGE}!; s!image: kabanero-operator-collection-controller::.*!image: ${COLLECTION_CTRLR_IMAGE}!" config/samples/full.yaml | kubectl apply -f -
+	sed -e "s!image: kabanero/kabanero-operator-admission-webhook:.*!image: ${WEBHOOK_IMAGE}!; s!image: kabanero/kabanero-operator-collection-controller:.*!image: ${COLLECTION_CTRLR_IMAGE}!" config/samples/full.yaml | kubectl apply -f -
 endif
 
 # Uninstall Test

--- a/pkg/controller/collection/collection_controller.go
+++ b/pkg/controller/collection/collection_controller.go
@@ -539,8 +539,6 @@ func activate(collectionResource *kabanerov1alpha1.Collection, collection *Colle
 		"CollectionName": collection.Name,
 	}
 
-	errorMessage := "Error during version change from " + collectionResource.Status.ActiveVersion + " to " + collection.Version
-
 	// Detect if the version is changing from the active version.  If it is, we need to clean up the
 	// assets from the previous version.
 	if (collectionResource.Status.ActiveVersion != "") && (collectionResource.Status.ActiveVersion != collection.Version) {
@@ -554,6 +552,7 @@ func activate(collectionResource *kabanerov1alpha1.Collection, collection *Colle
 		}
 
 		var transformedManifests []transformedRemoteManifest
+		errorMessage := "Error during version change from " + collectionResource.Status.ActiveVersion + " to " + collection.Version
 
 		for _, pipeline := range collectionResource.Status.ActivePipelines {
 			// Add the Digest to the rendering context.
@@ -606,6 +605,7 @@ func activate(collectionResource *kabanerov1alpha1.Collection, collection *Colle
 	}
 
 	// Now apply the new version
+	errorMessage := "Error during version apply to " + collection.Version
 	for _, pipeline := range collection.Pipelines {
 		log.Info(fmt.Sprintf("Applying assets %v", pipeline.Url))
 		// Add the Digest to the rendering context.


### PR DESCRIPTION
Makefile
split install from CR apply, quicker to test operator change
fix sed for collection controller

Collection Controller
move errorMessage up in scope
GetManifests 1st instance, return err instead of nil
GetManifests 2nd instance, log & update status. This should address #311, as it will appear as below


```
apiVersion: kabanero.io/v1alpha1
kind: Collection
metadata:
  creationTimestamp: "2019-12-10T17:11:30Z"
  generation: 1
  name: java-microprofile
  namespace: kabanero
  ownerReferences:
  - apiVersion: kabanero.io/v1alpha1
    controller: true
    kind: Kabanero
    name: kabanero
    uid: 5657f16b-1a99-11ea-a07f-00000a100cb6
  resourceVersion: "20517833"
  selfLink: /apis/kabanero.io/v1alpha1/namespaces/kabanero/collections/java-microprofile
  uid: 1b8dd1ce-1b70-11ea-a07f-00000a100cb6
spec:
  desiredState: active
  name: java-microprofile
  repositoryUrl: https://github.com/mtamboli/collections/releases/download/v0.3.6/kabanero-index.yaml
  version: 0.2.19
status:
  statusMessage: 'Error during version change from  to 0.2.19: File ./._deploy-task.yaml
    was found in the archive, but not in the manifest.yaml'
```

@mtamboli 