### PR TITLE
Check minor version of kabanero-operator before attempting upgrade

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -35,6 +35,15 @@ if [ "$OCMIN" != "$OCHEAD" ]; then
   exit 1
 fi
 
+# Check to see if we're upgrading, and if so, that we're at N-1 or N.
+if [ `oc get subscription kabanero-operator -n kabanero --no-headers --ignore-not-found | wc -l` -gt 0 ] ; then
+		CSV=$(oc get subscription kabanero-operator -n kabanero --output=jsonpath={.status.installedCSV})
+    if ! [[ "$CSV" =~ ^kabanero-operator\.v0\.[45]\..* ]]; then
+        printf "Cannot upgrade kabanero-operator CSV version $CSV to $RELEASE.  Upgrade is supported from the previous minor release."
+        exit 1
+    fi
+fi
+
 # Check Subscriptions: subscription-name, namespace
 checksub () {
 	echo "Waiting for Subscription $1 InstallPlan to complete."


### PR DESCRIPTION
I will be upfront and say that I have no idea if it's safe to use `[[ ]]` instead of `[ ]` here.  I wanted to use bash regex matching.  Basically, I want to check to see if there is a subscription named `kabanero-operator`, and if there is, get the installed CSV name.  Then check to see if the installed CSV name is either the current minor release or the previous minor release (currently 0.3.x or 0.4.x) and if not, fail.  If there is no subscription then just continue with the install.