### PR TITLE
upgrade timing

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -39,6 +39,9 @@ fi
 checksub () {
 	echo "Waiting for Subscription $1 InstallPlan to complete."
 
+	# Wait 2 resync periods for OLM to emit new installplan
+	sleep 60
+
 	# Wait for the InstallPlan to be generated and available on status
 	unset INSTALL_PLAN
 	until oc get subscription $1 -n $2 --output=jsonpath={.status.installPlanRef.name}


### PR DESCRIPTION
This isn't a very elegant solution,

- The subscription doesn't know the end CSV we want, unless we start being directly specific about that, but that ruins a universal aspect of the script
- startingCSV in the Subscription caused to much churn for operators we don't directly maintain in our catalog, we abandoned that awhile ago
- For upgrade we just don't know if there is an action until OLM has made it through a reconcile loop to update the status, as opposed to an install where there is no initial status.