### PR TITLE
Use multiple versions in the collections CRD

### DIFF
--- a/pkg/controller/collection/archive.go
+++ b/pkg/controller/collection/archive.go
@@ -151,7 +151,7 @@ func decodeManifests(archive []byte, renderingContext map[string]interface{}, re
 		}
 	}
 
-	fmt.Println("Header names: ", strings.Join(headers, ","))
+	reqLogger.Info(fmt.Sprintf("Header names: %v", strings.Join(headers, ",")))
 
 	if foundManifest != true {
 		return nil, fmt.Errorf("Error reading archive, unable to read manifest.yaml")

--- a/pkg/controller/collection/collection_controller.go
+++ b/pkg/controller/collection/collection_controller.go
@@ -2,7 +2,6 @@ package collection
 
 import (
 	"context"
-	me "errors"
 	"fmt"
 	"strings"
 	"time"
@@ -171,21 +170,44 @@ func (r *ReconcileCollection) Reconcile(request reconcile.Request) (reconcile.Re
 	}
 	reqLogger.Info("Resolved Kabanero", "kabanero", k)
 
-	rr, err := r.ReconcileCollection(instance, k)
-
-	// Temporary. Copy the collection status for now since as of this update we only support only one collection version.
-	s := kabanerov1alpha1.CollectionVersionStatus{
-		Version:       instance.Status.ActiveVersion,
-		Location:      instance.Status.ActiveLocation,
-		Pipelines:     instance.Status.ActivePipelines,
-		Status:        instance.Status.Status,
-		StatusMessage: instance.Status.StatusMessage,
-		Images:        instance.Status.Images}
-	if len(instance.Status.Versions) < 1 {
-		instance.Status.Versions = append(instance.Status.Versions, s)
-	} else {
-		instance.Status.Versions[0] = s
+	// Collection objects which existed prior to the spec.versions array will not
+	// have the versions array filled in.  Try to fill it in if we can.  Nothing
+	// fancy here... if one or the other is empty, fill it in.  Then re-reconcile.
+	if (len(instance.Spec.Version) > 0) && (len(instance.Spec.Versions) == 0) {
+		instance.Spec.Versions = []kabanerov1alpha1.CollectionVersion{{RepositoryUrl: instance.Spec.RepositoryUrl, Version: instance.Spec.Version, DesiredState: instance.Spec.DesiredState}}
+		err = r.client.Update(context.Background(), instance)
+		if err != nil {
+			reqLogger.Error(err, "Unable to sync version and versions array")
+		}
+		return reconcile.Result{Requeue: true, RequeueAfter: 60 * time.Second}, err
 	}
+
+	if (len(instance.Spec.Version) == 0) && (len(instance.Spec.Versions) > 0) {
+		instance.Spec.Version = instance.Spec.Versions[0].Version
+		instance.Spec.DesiredState = instance.Spec.Versions[0].DesiredState
+		instance.Spec.RepositoryUrl = instance.Spec.Versions[0].RepositoryUrl
+		err = r.client.Update(context.Background(), instance)
+		if err != nil {
+			reqLogger.Error(err, "Unable to sync version and versions array")
+		}
+		return reconcile.Result{Requeue: true, RequeueAfter: 60 * time.Second}, err
+	}
+
+	// Similarly, collection objects which existed prior to the status.versions array
+	// will not have it filled in.  Pre-populate it with the singleton information so
+	// the reconciler can reference it.
+	if (len(instance.Status.Status) > 0) && (len(instance.Status.Versions) == 0) {
+		instance.Status.Versions = []kabanerov1alpha1.CollectionVersionStatus{{
+			Version: instance.Status.ActiveVersion,
+			Location: instance.Status.ActiveLocation,
+			Pipelines: instance.Status.ActivePipelines,
+			Status: instance.Status.Status,
+			StatusMessage: instance.Status.StatusMessage,
+			Images: instance.Status.Images,
+		}}
+	}
+	
+	rr, err := r.ReconcileCollection(instance, k)
 
 	r.client.Status().Update(ctx, instance)
 
@@ -320,32 +342,11 @@ func (r *ReconcileCollection) ReconcileCollection(c *kabanerov1alpha1.Collection
 		r_log.Error(err, "Could not make kabanero the owner of the collection")
 	}
 
-	// Process deactivates regardless of whether the collection is available in the remote
-	// repository.
-	if strings.EqualFold(c.Spec.DesiredState, kabanerov1alpha1.CollectionDesiredStateInactive) {
-		err := reconcileActiveVersions(c, nil, r.client)
-		if err != nil {
-			return reconcile.Result{Requeue: true, RequeueAfter: 60 * time.Second}, err
-		}
-
-		c.Status.Status = kabanerov1alpha1.CollectionDesiredStateInactive
-		return reconcile.Result{}, nil
-	}
-
-	// Retreive all matching collection names from all remote indexes.  If none were specified,
-	// build and log an error and return.
+	// Retreive all matching collection names from all remote indexes.
 	// TODO: Start using the URL in the Collection object so we don't need to reference the
 	//       parent Kabanero anymore.
 	var matchingCollections []resolvedCollection
 	repositories := k.Spec.Collections.Repositories
-	if len(repositories) == 0 {
-		err = me.New(fmt.Sprintf("No repositories were configured in the Kabanero instance"))
-		r_log.Error(err, "Could not continue without any repositories")
-
-		// Update the status message so the user knows that something needs to be done.
-		c.Status.StatusMessage = "Could not find any configured repositories."
-		return reconcile.Result{Requeue: false, RequeueAfter: 60 * time.Second}, err
-	}
 
 	for _, repo := range repositories {
 		index, err := r.indexResolver(repo)
@@ -404,37 +405,11 @@ func (r *ReconcileCollection) ReconcileCollection(c *kabanerov1alpha1.Collection
 		} else {
 			r_log.Error(semverErr, "Could not determine upgrade availability for collection "+collectionName)
 		}
-
-		// Search for the correct version.  The list may have duplicates, we're just searching for
-		// the first match.
-		for _, matchingCollection := range matchingCollections {
-			switch {
-			case matchingCollection.collection.Version == c.Spec.Version:
-				// Activate or deactivate the collection based on the collection's current desiredState.
-				// The activateDefaultCollections setting in the CR instance's collection repository entry has
-				// no influence here as that only sets a collection's initial state.
-				if !strings.EqualFold(c.Spec.DesiredState, kabanerov1alpha1.CollectionDesiredStateActive) {
-					c.Status.StatusMessage = "An invalid desiredState value of " + c.Spec.DesiredState + " was specified. The collection is activated by default."
-				}
-
-				// Activate the collection.
-				err := reconcileActiveVersions(c, &matchingCollection.collection, r.client)
-				if err != nil {
-					return reconcile.Result{Requeue: true, RequeueAfter: 60 * time.Second}, err
-				}
-				c.Status.ActiveLocation = matchingCollection.repositoryURL
-				c.Status.Status = kabanerov1alpha1.CollectionDesiredStateActive
-				return reconcile.Result{}, nil
-			}
-		}
-
-		// No collection with a matching version could be found. Update the status
-		// message so the user understands that the version they want is not available.
-		c.Status.StatusMessage = "The requested version of the collection (" + c.Spec.Version + ") is not available."
-
-		return reconcile.Result{}, nil
 	}
 
+	// Process the versions array and activate (or deactivate) the desired versions.
+	err = reconcileActiveVersions(c, matchingCollections, r.client)
+	
 	// No version of the collection could be found.  If there is no active version, update
 	// the status message so the user knows that something needs to be done.
 	if c.Status.ActiveVersion == "" {
@@ -463,18 +438,10 @@ type pipelineVersion struct {
 	version string
 }
 
-func reconcileActiveVersions(collectionResource *kabanerov1alpha1.Collection, collection *Collection, c client.Client) error {
-	// In practice right now there is one active version and one status.  But in preparation for the future we're going to
-	// pretend there can be more than one.
-	specList := []kabanerov1alpha1.CollectionSpec{collectionResource.Spec}
-	statusList := []kabanerov1alpha1.CollectionStatus{collectionResource.Status}
-	collectionList := []*Collection{}
-	if collection != nil {
-		collectionList = append(collectionList, collection)
-	}
-	
+func reconcileActiveVersions(collectionResource *kabanerov1alpha1.Collection, collections []resolvedCollection, c client.Client) error {
+
 	ownerIsController := false
-	newOwner := metav1.OwnerReference{
+	assetOwner := metav1.OwnerReference{
 		APIVersion: collectionResource.TypeMeta.APIVersion,
 		Kind:       collectionResource.TypeMeta.Kind,
 		Name:       collectionResource.ObjectMeta.Name,
@@ -482,34 +449,17 @@ func reconcileActiveVersions(collectionResource *kabanerov1alpha1.Collection, co
 		Controller: &ownerIsController,
 	}
 
-	newStatusList, err := reconcileActiveVersionsInternal(collectionResource.Namespace, newOwner, specList, statusList, collectionList, c)
-
-	// In practice there will only be one status, until the Collection CRD is updated to support a list.
-	if err == nil {
-		collectionResource.Status = newStatusList[0]
-	}
-
-	// Fix up the version if it's inactive.  The multiple versions support tries to tell us which version is inactive
-	// but the caller expects all versions to be inactive.
-	if collectionResource.Status.Status == kabanerov1alpha1.CollectionDesiredStateInactive {
-		collectionResource.Status.ActiveVersion = ""
-	}
-	
-	return err
-}
-
-func reconcileActiveVersionsInternal(namespace string, assetOwner metav1.OwnerReference, specs []kabanerov1alpha1.CollectionSpec, statuses []kabanerov1alpha1.CollectionStatus, collections []*Collection, c client.Client) ([]kabanerov1alpha1.CollectionStatus, error) {
 	renderingContext := make(map[string]interface{})
 	if len(collections) > 0 {
-		renderingContext["CollectionId"] = collections[0].Id
-		renderingContext["CollectionName"] = collections[0].Name
+		renderingContext["CollectionId"] = collections[0].collection.Id
+		renderingContext["CollectionName"] = collections[0].collection.Name
 	}
-	
+
 	// Multiple versions of the same collection, could be using the same pipeline zip.  Count how many
 	// times each pipeline has been used.
 	assetUseMap := make(map[pipelineUseMapKey]*pipelineUseMapValue)
-	for _, curStatus := range statuses {
-		for _, pipeline := range curStatus.ActivePipelines {
+	for _, curStatus := range collectionResource.Status.Versions {
+		for _, pipeline := range curStatus.Pipelines {
 			key := pipelineUseMapKey{url: pipeline.Url, digest: pipeline.Digest}
 			value := assetUseMap[key]
 			if value == nil {
@@ -525,25 +475,25 @@ func reconcileActiveVersionsInternal(namespace string, assetOwner metav1.OwnerRe
 	// sure to take into consideration the digest on the individual pipeline zips.
 	assetsToDecrement := make(map[pipelineVersion]bool)
 	assetsToIncrement := make(map[pipelineVersion]bool)
-	for _, curStatus := range statuses {
-		for _, pipeline := range curStatus.ActivePipelines {
-			cur := pipelineVersion{pipelineUseMapKey: pipelineUseMapKey{url: pipeline.Url, digest: pipeline.Digest}, version: curStatus.ActiveVersion}
+	for _, curStatus := range collectionResource.Status.Versions {
+		for _, pipeline := range curStatus.Pipelines {
+			cur := pipelineVersion{pipelineUseMapKey: pipelineUseMapKey{url: pipeline.Url, digest: pipeline.Digest}, version: curStatus.Version}
 			assetsToDecrement[cur] = true
 		}
 	}
 
-	for _, curSpec := range specs {
+	for _, curSpec := range collectionResource.Spec.Versions {
 		if !strings.EqualFold(curSpec.DesiredState, kabanerov1alpha1.CollectionDesiredStateInactive) {
 			collection := getCollectionForSpecVersion(curSpec, collections)
 			if collection == nil {
 				// This version of the collection was not found in the collection hub.  See if it's currently active.  
 				// If it is, we should continue to use what is active.
 				//activeMatch := false
-				for _, curStatus := range statuses {
-					if curStatus.ActiveVersion == curSpec.Version {
+				for _, curStatus := range collectionResource.Status.Versions {
+					if curStatus.Version == curSpec.Version {
 						//activeMatch = true
-						for _, pipeline := range curStatus.ActivePipelines {
-							cur := pipelineVersion{pipelineUseMapKey: pipelineUseMapKey{url: pipeline.Url, digest: pipeline.Digest}, version: curStatus.ActiveVersion}
+						for _, pipeline := range curStatus.Pipelines {
+							cur := pipelineVersion{pipelineUseMapKey: pipelineUseMapKey{url: pipeline.Url, digest: pipeline.Digest}, version: curStatus.Version}
 							if assetsToDecrement[cur] == true {
 								delete(assetsToDecrement, cur)
 							} else {
@@ -554,7 +504,7 @@ func reconcileActiveVersionsInternal(namespace string, assetOwner metav1.OwnerRe
 					}
 				}
 			} else {
-				for _, pipeline := range collection.Pipelines {
+				for _, pipeline := range collection.collection.Pipelines {
 					cur := pipelineVersion{pipelineUseMapKey: pipelineUseMapKey{url: pipeline.Url, digest: pipeline.Sha256}, version: curSpec.Version}
 					if assetsToDecrement[cur] == true {
 						delete(assetsToDecrement, cur)
@@ -570,7 +520,7 @@ func reconcileActiveVersionsInternal(namespace string, assetOwner metav1.OwnerRe
 	for cur, _ := range assetsToDecrement {
 		value := assetUseMap[cur.pipelineUseMapKey]
 		if value == nil {
-			return nil, fmt.Errorf("Pipeline version not found in use map: %v", cur)
+			return fmt.Errorf("Pipeline version not found in use map: %v", cur)
 		}
 
 		value.useCount--
@@ -602,14 +552,13 @@ func reconcileActiveVersionsInternal(namespace string, assetOwner metav1.OwnerRe
 				})
 
 				err := c.Get(context.Background(), client.ObjectKey{
-					Namespace: namespace,
+					Namespace: collectionResource.GetNamespace(),
 					Name:      asset.Name,
 				}, u)
 
 				if err != nil {
 					if errors.IsNotFound(err) == false {
 						log.Error(err, fmt.Sprintf("Unable to check asset name %v", asset.Name))
-						// TODO: Report in collection status somewhere?
 					}
 				} else {
 					// Get the owner references.  See if we're the last one.
@@ -625,14 +574,12 @@ func reconcileActiveVersionsInternal(namespace string, assetOwner metav1.OwnerRe
 						err = c.Delete(context.TODO(), u)
 						if err != nil {
 							log.Error(err, fmt.Sprintf("Unable to delete asset name %v", asset.Name))
-							// TODO: Report in collection status somewhere?
 						}
 					} else {
 						u.SetOwnerReferences(newOwnerRefs)
 						err = c.Update(context.TODO(), u)
 						if err != nil {
 							log.Error(err, fmt.Sprintf("Unable to delete owner reference from %v", asset.Name))
-							// TODO: Report in collection status somewhere?
 						}
 					}
 				}
@@ -685,14 +632,13 @@ func reconcileActiveVersionsInternal(namespace string, assetOwner metav1.OwnerRe
 				})
 
 				err := c.Get(context.Background(), client.ObjectKey{
-					Namespace: namespace,
+					Namespace: collectionResource.GetNamespace(),
 					Name:      asset.Name,
 				}, u)
 
 				if err != nil {
 					if errors.IsNotFound(err) == false {
 						log.Error(err, fmt.Sprintf("Unable to check asset name %v", asset.Name))
-						// TODO: Report in collection status somewhere?
 					} else {
 						// Make sure the manifests are loaded.
 						if len(value.manifests) == 0 {
@@ -721,7 +667,7 @@ func reconcileActiveVersionsInternal(namespace string, assetOwner metav1.OwnerRe
 
 								transforms := []mf.Transformer{
 									transforms.InjectOwnerReference(assetOwner), 
-									mf.InjectNamespace(namespace),
+									mf.InjectNamespace(collectionResource.GetNamespace()),
 								}
 
 								err = m.Transform(transforms...)
@@ -765,7 +711,6 @@ func reconcileActiveVersionsInternal(namespace string, assetOwner metav1.OwnerRe
 						err = c.Update(context.TODO(), u)
 						if err != nil {
 							log.Error(err, fmt.Sprintf("Unable to add owner reference to %v", asset.Name))
-							// TODO: Report in collection status somewhere?
 						}
 					}
 					
@@ -777,17 +722,17 @@ func reconcileActiveVersionsInternal(namespace string, assetOwner metav1.OwnerRe
 	}
 	
 	// Now update the CollectionStatus to reflect the current state of things.
-	newCollectionStatusList := []kabanerov1alpha1.CollectionStatus{}
-	for _, curSpec := range specs {
-		newCollectionStatus := kabanerov1alpha1.CollectionStatus{ActiveVersion: curSpec.Version}
+	newCollectionStatus := kabanerov1alpha1.CollectionStatus{}
+	for _, curSpec := range collectionResource.Spec.Versions {
+		newCollectionVersionStatus := kabanerov1alpha1.CollectionVersionStatus{Version: curSpec.Version}
 		if !strings.EqualFold(curSpec.DesiredState, kabanerov1alpha1.CollectionDesiredStateInactive) {
 			if !strings.EqualFold(curSpec.DesiredState, kabanerov1alpha1.CollectionDesiredStateActive) {
-				newCollectionStatus.StatusMessage = "An invalid desiredState value of " + curSpec.DesiredState + " was specified. The collection is activated by default."
+				newCollectionVersionStatus.StatusMessage = "An invalid desiredState value of " + curSpec.DesiredState + " was specified. The collection is activated by default."
 			}
-			newCollectionStatus.Status = kabanerov1alpha1.CollectionDesiredStateActive
+			newCollectionVersionStatus.Status = kabanerov1alpha1.CollectionDesiredStateActive
 			collection := getCollectionForSpecVersion(curSpec, collections)
 			if collection != nil {
-				for _, pipeline := range collection.Pipelines {
+				for _, pipeline := range collection.collection.Pipelines {
 					key := pipelineUseMapKey{url: pipeline.Url, digest: pipeline.Sha256}
 					value := assetUseMap[key]
 					if value == nil {
@@ -796,26 +741,26 @@ func reconcileActiveVersionsInternal(namespace string, assetOwner metav1.OwnerRe
 						newStatus := kabanerov1alpha1.PipelineStatus{}
 						value.DeepCopyInto(&newStatus)
 						newStatus.Name = pipeline.Id // This may vary by collection version
-						newCollectionStatus.ActivePipelines = append(newCollectionStatus.ActivePipelines, newStatus)
+						newCollectionVersionStatus.Pipelines = append(newCollectionVersionStatus.Pipelines, newStatus)
 						// If we had a problem loading the pipeline manifests, say so.
 						if value.manifestError != nil {
-							newCollectionStatus.StatusMessage = value.manifestError.Error()
+							newCollectionVersionStatus.StatusMessage = value.manifestError.Error()
 						}
 					}
 				}
 
 				// Update the status of the Collection object to reflect the images used
-				for _, image := range collection.Images {
-					newCollectionStatus.Images = append(newCollectionStatus.Images,
+				for _, image := range collection.collection.Images {
+					newCollectionVersionStatus.Images = append(newCollectionVersionStatus.Images,
 						kabanerov1alpha1.Image{Id: image.Id, Image: image.Image})
 				}
 			} else {
 				// Collection was not available, need to get pipeline information from previous status.
 				foundPrevStatus := false
-				for _, curStatus := range statuses {
-					if curStatus.ActiveVersion == curSpec.Version {
+				for _, curStatus := range collectionResource.Status.Versions {
+					if curStatus.Version == curSpec.Version {
 						foundPrevStatus = true
-						for _, pipeline := range curStatus.ActivePipelines {
+						for _, pipeline := range curStatus.Pipelines {
 							key := pipelineUseMapKey{url: pipeline.Url, digest: pipeline.Digest}
 							value := assetUseMap[key]
 							if value == nil {
@@ -824,44 +769,59 @@ func reconcileActiveVersionsInternal(namespace string, assetOwner metav1.OwnerRe
 								newStatus := kabanerov1alpha1.PipelineStatus{}
 								value.DeepCopyInto(&newStatus)
 								newStatus.Name = pipeline.Name
-								newCollectionStatus.ActivePipelines = append(newCollectionStatus.ActivePipelines, newStatus)
+								newCollectionVersionStatus.Pipelines = append(newCollectionVersionStatus.Pipelines, newStatus)
 								// If we had a problem loading the pipeline manifests, say so.
 								if value.manifestError != nil {
-									newCollectionStatus.StatusMessage = value.manifestError.Error()
+									newCollectionVersionStatus.StatusMessage = value.manifestError.Error()
 								}
 							}
 						}
-						newCollectionStatus.Status = curStatus.Status
-						newCollectionStatus.Images = curStatus.Images
+						newCollectionVersionStatus.Status = curStatus.Status
+						newCollectionVersionStatus.Images = curStatus.Images
 					}
 				}
 
 				// If there was no previous status, then the collection is inactive.
 				if foundPrevStatus == false {
-					newCollectionStatus.Status = kabanerov1alpha1.CollectionDesiredStateInactive
+					newCollectionVersionStatus.Status = kabanerov1alpha1.CollectionDesiredStateInactive
 				}
 				
 				// Tell the user that the collection was not in the hub, if no other errors
-				if newCollectionStatus.StatusMessage == "" {
-						newCollectionStatus.StatusMessage = fmt.Sprintf("The requested version of the collection (%v) is not available at %v", curSpec.Version, curSpec.RepositoryUrl)
+				if newCollectionVersionStatus.StatusMessage == "" {
+						newCollectionVersionStatus.StatusMessage = fmt.Sprintf("The requested version of the collection (%v) is not available at %v", curSpec.Version, curSpec.RepositoryUrl)
 				}
 			}
 		} else {
-			newCollectionStatus.Status = kabanerov1alpha1.CollectionDesiredStateInactive
-			newCollectionStatus.StatusMessage = "The collection has been deactivated."
+			newCollectionVersionStatus.Status = kabanerov1alpha1.CollectionDesiredStateInactive
+			newCollectionVersionStatus.StatusMessage = "The collection has been deactivated."
 		}
 
-		log.Info(fmt.Sprintf("Updated collection status: %#v", newCollectionStatus))
-		newCollectionStatusList = append(newCollectionStatusList, newCollectionStatus)
+		log.Info(fmt.Sprintf("Updated collection status: %#v", newCollectionVersionStatus))
+		newCollectionStatus.Versions = append(newCollectionStatus.Versions, newCollectionVersionStatus)
+	}
+
+	// Need to copy status version [0] to the singleton (for now)
+	if len(newCollectionStatus.Versions) > 0 {
+		newCollectionStatus.ActiveLocation = newCollectionStatus.Versions[0].Location
+		newCollectionStatus.ActivePipelines = newCollectionStatus.Versions[0].Pipelines
+		newCollectionStatus.Status = newCollectionStatus.Versions[0].Status
+		newCollectionStatus.StatusMessage = newCollectionStatus.Versions[0].StatusMessage
+		newCollectionStatus.Images = newCollectionStatus.Versions[0].Images
+
+		if newCollectionStatus.Versions[0].Status != kabanerov1alpha1.CollectionDesiredStateInactive {
+			newCollectionStatus.ActiveVersion = newCollectionStatus.Versions[0].Version
+		}
 	}
 	
-	return newCollectionStatusList, nil
+	collectionResource.Status = newCollectionStatus
+	
+	return nil
 }
 
-func getCollectionForSpecVersion(spec kabanerov1alpha1.CollectionSpec, collections []*Collection) *Collection {
+func getCollectionForSpecVersion(spec kabanerov1alpha1.CollectionVersion, collections []resolvedCollection) *resolvedCollection {
 	for _, collection := range collections {
-		if collection.Version == spec.Version {
-			return collection
+		if collection.collection.Version == spec.Version {
+			return &collection
 		}
 	}
 	return nil

--- a/pkg/controller/kabaneroplatform/featured_collections.go
+++ b/pkg/controller/kabaneroplatform/featured_collections.go
@@ -3,7 +3,6 @@ package kabaneroplatform
 import (
 	"context"
 
-	"github.com/blang/semver"
 	kabanerov1alpha1 "github.com/kabanero-io/kabanero-operator/pkg/apis/kabanero/v1alpha1"
 	"github.com/kabanero-io/kabanero-operator/pkg/controller/collection"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -12,92 +11,80 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// Finds the highest version (semver) of the collection with the given id, in the provided
-// list of collections.  The caller has verified that the list contains at least one collection
-// with the given id.
-func findMaxVersionCollectionWithId(collections []*collection.Collection, id string) string {
-
-	highestVersion, _ := semver.Make("0.0.0")
-
-	for _, candidate := range collections {
-		if candidate.Id == id {
-			candidateVersion, err := semver.ParseTolerant(candidate.Version)
-			if err == nil { // TODO: log error?
-				if candidateVersion.Compare(highestVersion) > 0 {
-					highestVersion = candidateVersion
-				}
-			}
-		}
-	}
-	return highestVersion.String()
-}
-
 func reconcileFeaturedCollections(ctx context.Context, k *kabanerov1alpha1.Kabanero, cl client.Client) error {
 	// Resolve the collections which are currently featured across the various indexes.
-	featuredCollectionData, err := featuredCollections(k)
+	collectionMap, err := featuredCollections(k)
 	if err != nil {
 		return err
 	}
 
-	for _, data := range featuredCollectionData {
-		ownerIsController := true
+	// Each key is a collection id.  Get that Collection CR instance and see if the versions are set correctly.
+	for key, value := range collectionMap {
+		updateCollection := cl.Update
+		name := types.NamespacedName{
+			Name:      key,
+			Namespace: k.GetNamespace(),
+		}
 
-		featured := data.Collections
-		for _, c := range featured {
-			// For each collection, assure that a corresponding resource exists and it is at
-			// the highest level found among the repositories.
-			updateCollection := cl.Update
-			name := types.NamespacedName{
-				Name:      c.Id,
-				Namespace: k.GetNamespace(),
-			}
-
-			collectionResource := &kabanerov1alpha1.Collection{}
-			err := cl.Get(ctx, name, collectionResource)
-			if err != nil {
-				if errors.IsNotFound(err) {
-					// Not found. Need to create it at the highest supported version found
-					// in the repositories. At the same time, set the collection's desiredState
-					// based on the value of the activateDefaultCollections setting specified in the
-					// collection repo section of the kabanero CR instance.
-					desiredState := kabanerov1alpha1.CollectionDesiredStateActive
-					if !data.repositoryConfig.ActivateDefaultCollections {
-						desiredState = kabanerov1alpha1.CollectionDesiredStateInactive
-					}
-
-					updateCollection = cl.Create
-					collectionResource = &kabanerov1alpha1.Collection{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      c.Id,
-							Namespace: k.GetNamespace(),
-							OwnerReferences: []metav1.OwnerReference{
-								metav1.OwnerReference{
-									APIVersion: k.TypeMeta.APIVersion,
-									Kind:       k.TypeMeta.Kind,
-									Name:       k.ObjectMeta.Name,
-									UID:        k.ObjectMeta.UID,
-									Controller: &ownerIsController,
-								},
+		collectionResource := &kabanerov1alpha1.Collection{}
+		err := cl.Get(ctx, name, collectionResource)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				// Not found. Need to create it.
+				updateCollection = cl.Create
+				ownerIsController := true
+				collectionResource = &kabanerov1alpha1.Collection{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      key,
+						Namespace: k.GetNamespace(),
+						OwnerReferences: []metav1.OwnerReference{
+							metav1.OwnerReference{
+								APIVersion: k.TypeMeta.APIVersion,
+								Kind:       k.TypeMeta.Kind,
+								Name:       k.ObjectMeta.Name,
+								UID:        k.ObjectMeta.UID,
+								Controller: &ownerIsController,
 							},
 						},
-						Spec: kabanerov1alpha1.CollectionSpec{
-							Name:         c.Id,
-							DesiredState: desiredState,
-						},
-					}
-				} else {
-					return err
+					},
+					Spec: kabanerov1alpha1.CollectionSpec{
+						Name:         key,
+					},
+				}
+			} else {
+				return err
+			}
+		} else {
+			// Handle the case where the collection existed before the versions array was added to the Collection CRD.
+			// If the versions array is empty, sync it up.
+			if (len(collectionResource.Spec.Versions) == 0) && (len(collectionResource.Spec.Version) != 0) {
+				collectionResource.Spec.Versions = []kabanerov1alpha1.CollectionVersion{{RepositoryUrl: collectionResource.Spec.RepositoryUrl, Version: collectionResource.Spec.Version, DesiredState: collectionResource.Spec.DesiredState}}
+			}
+		}
+
+		// Add each version to the versions array if it's not already there.  If it's already there, just
+		// update the repository URL, don't touch the desired state.
+		for _, collection := range value {
+			foundVersion := false
+			for _, collectionVersion := range collectionResource.Spec.Versions {
+				if collectionVersion.Version == collection.Version {
+					foundVersion = true
+					collectionVersion.RepositoryUrl = collection.RepositoryUrl
 				}
 			}
 
-			collectionResource.Spec.Version = findMaxVersionCollectionWithId(featured, c.Id)
-			collectionResource.Spec.RepositoryUrl = data.repositoryConfig.Url
-			err = updateCollection(ctx, collectionResource)
-			if err != nil {
-				return err
+			if foundVersion == false {
+				collectionResource.Spec.Versions = append(collectionResource.Spec.Versions, collection)
 			}
 		}
+
+		// Update the CR instance with the new version information.
+		err = updateCollection(ctx, collectionResource)
+		if err != nil {
+			return err
+		}
 	}
+
 	return nil
 }
 
@@ -107,27 +94,24 @@ type collectionData struct {
 	repositoryConfig kabanerov1alpha1.RepositoryConfig
 }
 
-// Resolves all featured collections for the given Kabanero instance
-func featuredCollections(k *kabanerov1alpha1.Kabanero) ([]*collectionData, error) {
-
-	var cData []*collectionData
-	var collections []*collection.Collection
-
+// Resolves all collections for the given Kabanero instance
+func featuredCollections(k *kabanerov1alpha1.Kabanero) (map[string][]kabanerov1alpha1.CollectionVersion, error) {
+	collectionMap := make(map[string][]kabanerov1alpha1.CollectionVersion)
 	for _, r := range k.Spec.Collections.Repositories {
 		index, err := collection.ResolveIndex(r)
 		if err != nil {
 			return nil, err
 		}
 
-		for _, c := range index.Collections {
-			//forced to re-declare the variable on the stack, thereby giving it a new unique memory address.
-			var col collection.Collection
-			col = c
-			collections = append(collections, &col)
+		desiredState := kabanerov1alpha1.CollectionDesiredStateActive
+		if r.ActivateDefaultCollections == false {
+			desiredState = kabanerov1alpha1.CollectionDesiredStateInactive
 		}
-
-		cData = append(cData, &collectionData{repositoryConfig: r, Collections: collections})
+		
+		for _, c := range index.Collections {
+			collectionMap[c.Id] = append(collectionMap[c.Id], kabanerov1alpha1.CollectionVersion{RepositoryUrl: r.Url, Version: c.Version, DesiredState: desiredState})
+		}		
 	}
 
-	return cData, nil
+	return collectionMap, nil
 }

--- a/pkg/controller/kabaneroplatform/featured_collections_test.go
+++ b/pkg/controller/kabaneroplatform/featured_collections_test.go
@@ -1,54 +1,112 @@
-// +build integration
-
 package kabaneroplatform
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	
 	kabanerov1alpha1 "github.com/kabanero-io/kabanero-operator/pkg/apis/kabanero/v1alpha1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
 	"testing"
 )
 
-func destroyCollection(ctx context.Context, cl client.Client, name string, namespace string) error {
-	//Cleanup any prior test
-	collectionResource := &kabanerov1alpha1.Collection{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-	}
-	err := cl.Delete(ctx, collectionResource)
-	if err != nil && !errors.IsNotFound(err) {
-		return err
-	}
-
-	return nil
+// -----------------------------------------------------------------------------------------------
+// Client that creates/deletes collections.
+// -----------------------------------------------------------------------------------------------
+type unitTestClient struct {
+	objs map[string]*kabanerov1alpha1.Collection
 }
 
-func TestReconcileFeaturedCollections(t *testing.T) {
-	ctx := context.Background()
-
-	scheme, _ := kabanerov1alpha1.SchemeBuilder.Build()
-	cl, err := client.New(config.GetConfigOrDie(), client.Options{Scheme: scheme})
-	if err != nil {
-		t.Fatal("Could not create a client", err)
+func (c unitTestClient) Get(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+	fmt.Printf("Received Get() for %v\n", key.Name)
+	u, ok := obj.(*kabanerov1alpha1.Collection)
+	if !ok {
+		fmt.Printf("Received invalid target object for get: %v\n", obj)
+		return errors.New("Get only supports Collections")
+	}
+	collection := c.objs[key.Name]
+	if collection == nil {
+		return apierrors.NewNotFound(schema.GroupResource{}, key.Name)
+	}
+	collection.DeepCopyInto(u)
+	return nil
+}
+func (c unitTestClient) List(ctx context.Context, opts *client.ListOptions, list runtime.Object) error {
+	return errors.New("List is not supported")
+}
+func (c unitTestClient) Create(ctx context.Context, obj runtime.Object) error {
+	u, ok := obj.(*kabanerov1alpha1.Collection)
+	if !ok {
+		fmt.Printf("Received invalid create: %v\n", obj)
+		return errors.New("Create only supports Collections")
 	}
 
-	//Cleanup any prior run
-	err = destroyCollection(ctx, cl, "java-microprofile", "default")
-	if err != nil {
-		t.Fatal(err)
+	fmt.Printf("Received Create() for %v\n", u.Name)
+	collection := c.objs[u.Name]
+	if collection != nil {
+		fmt.Printf("Receive create object already exists: %v\n", u.Name)
+		return apierrors.NewAlreadyExists(schema.GroupResource{}, u.Name)
 	}
-	//Cleanup after run
-	defer destroyCollection(ctx, cl, "java-microprofile", "default")
 
-	collection_index_url := "https://raw.githubusercontent.com/kabanero-io/kabanero-collection/master/experimental/index.yaml"
+	c.objs[u.Name] = u
+	return nil
+}
+func (c unitTestClient)	Delete(ctx context.Context, obj runtime.Object, opts ...client.DeleteOptionFunc) error {
+	return errors.New("Delete is not supported")
+}
+func (c unitTestClient) Update(ctx context.Context, obj runtime.Object) error {
+	u, ok := obj.(*kabanerov1alpha1.Collection)
+	if !ok {
+		fmt.Printf("Received invalid update: %v\n", obj)
+		return errors.New("Update only supports Collections")
+	}
 
-	k := &kabanerov1alpha1.Kabanero{
+	fmt.Printf("Received Update() for %v\n", u.Name)
+	collection := c.objs[u.Name]
+	if collection == nil {
+		fmt.Printf("Received update for object that does not exist: %v\n", obj)
+		return apierrors.NewNotFound(schema.GroupResource{}, u.Name)
+	}
+	c.objs[u.Name] = u
+	return nil
+}
+func (c unitTestClient) Status() client.StatusWriter { return c }
+
+
+// -----------------------------------------------------------------------------------------------
+// HTTP handler that serves pipeline zips
+// -----------------------------------------------------------------------------------------------
+type collectionIndexHandler struct {
+}
+
+func (ch collectionIndexHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	filename := fmt.Sprintf("testdata/%v", req.URL.String())
+	fmt.Printf("Serving %v\n", filename)
+	d, err := ioutil.ReadFile(filename)
+	if err != nil {
+		rw.WriteHeader(http.StatusNotFound)
+	} else {
+		rw.Write(d)
+	}
+}
+
+var defaultIndexName = "/kabanero-index.yaml"
+var secondIndexName = "/kabanero-index-two.yaml"
+
+// -----------------------------------------------------------------------------------------------
+// Test cases
+// -----------------------------------------------------------------------------------------------
+func createKabanero(repositoryUrl string, activateDefaultCollections bool) *kabanerov1alpha1.Kabanero {
+	return &kabanerov1alpha1.Kabanero{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "kabanero.io/v1alpha1",
 			Kind:       "Kabanero",
@@ -63,159 +121,277 @@ func TestReconcileFeaturedCollections(t *testing.T) {
 				Repositories: []kabanerov1alpha1.RepositoryConfig{
 					kabanerov1alpha1.RepositoryConfig{
 						Name:                       "default",
-						Url:                        collection_index_url,
-						ActivateDefaultCollections: true,
+						Url:                        repositoryUrl,
+						ActivateDefaultCollections: activateDefaultCollections,
 					},
 				},
 			},
 		},
-	}
-
-	err = reconcileFeaturedCollections(context.Background(), k, cl)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	//Verify the collection was created
-	collectionResource := &kabanerov1alpha1.Collection{}
-	err = cl.Get(ctx, types.NamespacedName{Name: "java-microprofile", Namespace: "default"}, collectionResource)
-	if err != nil {
-		t.Fatal("Could not resolve the automatically created collection", err)
 	}
 }
 
-// specify  ActivateDefaultCollections: true
-func TestReconcileFeaturedCollectionsActivateDefaultCollectionsTrue(t *testing.T) {
+func TestReconcileFeaturedCollections(t *testing.T) {
+	// The server that will host the pipeline zip
+	server := httptest.NewServer(collectionIndexHandler{})
+	defer server.Close()
+
 	ctx := context.Background()
+	cl := unitTestClient{make(map[string]*kabanerov1alpha1.Collection)}
+	collectionUrl := server.URL + defaultIndexName
+	k := createKabanero(collectionUrl, true)
 
-	scheme, _ := kabanerov1alpha1.SchemeBuilder.Build()
-	cl, err := client.New(config.GetConfigOrDie(), client.Options{Scheme: scheme})
-	if err != nil {
-		t.Fatal("Could not create a client", err)
-	}
-
-	//Cleanup any prior run
-	err = destroyCollection(ctx, cl, "java-microprofile", "default")
-	if err != nil {
-		t.Fatal(err)
-	}
-	//Cleanup after run
-	defer destroyCollection(ctx, cl, "java-microprofile", "default")
-
-	collection_index_url := "https://raw.githubusercontent.com/kabanero-io/kabanero-collection/master/experimental/index.yaml"
-
-	k := &kabanerov1alpha1.Kabanero{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Kabanero",
-			APIVersion: "v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
-			Name:      "k",
-			UID:       "1",
-		},
-		Spec: kabanerov1alpha1.KabaneroSpec{
-			Collections: kabanerov1alpha1.InstanceCollectionConfig{
-				Repositories: []kabanerov1alpha1.RepositoryConfig{
-					kabanerov1alpha1.RepositoryConfig{
-						Name:                       "default",
-						Url:                        collection_index_url,
-						ActivateDefaultCollections: true,
-					},
-				},
-			},
-		},
-	}
-
-	err = reconcileFeaturedCollections(context.Background(), k, cl)
+	err := reconcileFeaturedCollections(ctx, k, cl)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	//Verify the collection was created
-	collectionResource := &kabanerov1alpha1.Collection{}
-	err = cl.Get(ctx, types.NamespacedName{Name: "java-microprofile", Namespace: "default"}, collectionResource)
+	// Should have been two collections created
+	javaMicroprofileCollection := &kabanerov1alpha1.Collection{}
+	err = cl.Get(ctx, types.NamespacedName{Name: "java-microprofile"}, javaMicroprofileCollection)
 	if err != nil {
-		t.Fatal("Could not resolve the automatically created collection", err)
+		t.Fatal("Could not resolve the java-microprofile collection", err)
+	}
+
+	nodejsCollection := &kabanerov1alpha1.Collection{}
+	err = cl.Get(ctx, types.NamespacedName{Name: "nodejs"}, nodejsCollection)
+	if err != nil {
+		t.Fatal("Could not resolve the nodejs collection", err)
+	}
+
+	// Make sure the collection has an owner set
+	if len(nodejsCollection.OwnerReferences) != 1 {
+		t.Fatal(fmt.Sprintf("Expected 1 owner, but found %v: %v", len(nodejsCollection.OwnerReferences), nodejsCollection))
+	}
+
+	if nodejsCollection.OwnerReferences[0].UID != k.UID {
+		t.Fatal(fmt.Sprintf("Expected owner UID to be %v, but was %v", k.UID, nodejsCollection.OwnerReferences[0].UID))
+	}
+
+	// Make sure the collection is active
+	if len(nodejsCollection.Spec.Versions) != 1 {
+		t.Fatal(fmt.Sprintf("Expected 1 collection version, but found %v: %v", len(nodejsCollection.Spec.Versions), nodejsCollection.Spec.Versions))
+	}
+
+	if nodejsCollection.Spec.Versions[0].Version != "0.2.6" {
+		t.Fatal(fmt.Sprintf("Expected nodejs collection version \"0.2.6\", but found %v", nodejsCollection.Spec.Versions[0].Version))
+	}
+
+	if nodejsCollection.Spec.Versions[0].DesiredState != kabanerov1alpha1.CollectionDesiredStateActive {
+		t.Fatal(fmt.Sprintf("Expected nodejs collection to be active, but was %v", nodejsCollection.Spec.Versions[0].DesiredState))
+	}
+
+	if nodejsCollection.Spec.Versions[0].RepositoryUrl != collectionUrl {
+		t.Fatal(fmt.Sprintf("Expected nodejs URL to be %v, but was %v", collectionUrl, nodejsCollection.Spec.Versions[0].RepositoryUrl))
 	}
 }
 
 // specify ActivateDefaultCollections: false
 func TestReconcileFeaturedCollectionsActivateDefaultCollectionsFalse(t *testing.T) {
+	// The server that will host the pipeline zip
+	server := httptest.NewServer(collectionIndexHandler{})
+	defer server.Close()
+
 	ctx := context.Background()
+	cl := unitTestClient{make(map[string]*kabanerov1alpha1.Collection)}
+	collectionUrl := server.URL + defaultIndexName
+	k := createKabanero(collectionUrl, false)
 
-	scheme, _ := kabanerov1alpha1.SchemeBuilder.Build()
-	cl, err := client.New(config.GetConfigOrDie(), client.Options{Scheme: scheme})
-	if err != nil {
-		t.Fatal("Could not create a client", err)
-	}
-
-	//Cleanup any prior run
-	err = destroyCollection(ctx, cl, "java-microprofile", "default")
-	if err != nil {
-		t.Fatal(err)
-	}
-	//Cleanup after run
-	defer destroyCollection(ctx, cl, "java-microprofile", "default")
-
-	collection_index_url := "https://raw.githubusercontent.com/kabanero-io/kabanero-collection/master/experimental/index.yaml"
-
-	k := &kabanerov1alpha1.Kabanero{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
-		},
-		Spec: kabanerov1alpha1.KabaneroSpec{
-			Collections: kabanerov1alpha1.InstanceCollectionConfig{
-				Repositories: []kabanerov1alpha1.RepositoryConfig{
-					kabanerov1alpha1.RepositoryConfig{
-						Name:                       "default",
-						Url:                        collection_index_url,
-						ActivateDefaultCollections: false,
-					},
-				},
-			},
-		},
-	}
-
-	err = reconcileFeaturedCollections(context.Background(), k, cl)
+	err := reconcileFeaturedCollections(ctx, k, cl)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	//Verify the collection was created
-	collectionResource := &kabanerov1alpha1.Collection{}
-	err = cl.Get(ctx, types.NamespacedName{Name: "java-microprofile", Namespace: "default"}, collectionResource)
-	if err == nil {
-		t.Fatal("Collection created when it should not have been created", err)
+	// Should have been two collections created
+	javaMicroprofileCollection := &kabanerov1alpha1.Collection{}
+	err = cl.Get(ctx, types.NamespacedName{Name: "java-microprofile"}, javaMicroprofileCollection)
+	if err != nil {
+		t.Fatal("Could not resolve the java-microprofile collection", err)
+	}
+
+	nodejsCollection := &kabanerov1alpha1.Collection{}
+	err = cl.Get(ctx, types.NamespacedName{Name: "nodejs"}, nodejsCollection)
+	if err != nil {
+		t.Fatal("Could not resolve the nodejs collection", err)
+	}
+
+	// Make sure the collection has an owner set
+	if len(nodejsCollection.OwnerReferences) != 1 {
+		t.Fatal(fmt.Sprintf("Expected 1 owner, but found %v: %v", len(nodejsCollection.OwnerReferences), nodejsCollection))
+	}
+
+	if nodejsCollection.OwnerReferences[0].UID != k.UID {
+		t.Fatal(fmt.Sprintf("Expected owner UID to be %v, but was %v", k.UID, nodejsCollection.OwnerReferences[0].UID))
+	}
+
+	// Make sure the collection is active
+	if len(nodejsCollection.Spec.Versions) != 1 {
+		t.Fatal(fmt.Sprintf("Expected 1 collection version, but found %v: %v", len(nodejsCollection.Spec.Versions), nodejsCollection.Spec.Versions))
+	}
+
+	if nodejsCollection.Spec.Versions[0].Version != "0.2.6" {
+		t.Fatal(fmt.Sprintf("Expected nodejs collection version \"0.2.6\", but found %v", nodejsCollection.Spec.Versions[0].Version))
+	}
+
+	if nodejsCollection.Spec.Versions[0].DesiredState != kabanerov1alpha1.CollectionDesiredStateInactive {
+		t.Fatal(fmt.Sprintf("Expected nodejs collection to be inactive, but was %v", nodejsCollection.Spec.Versions[0].DesiredState))
+	}
+
+	if nodejsCollection.Spec.Versions[0].RepositoryUrl != collectionUrl {
+		t.Fatal(fmt.Sprintf("Expected nodejs URL to be %v, but was %v", collectionUrl, nodejsCollection.Spec.Versions[0].RepositoryUrl))
+	}
+}
+
+func TestReconcileFeaturedCollectionsTwoRepositories(t *testing.T) {
+	// The server that will host the pipeline zip
+	server := httptest.NewServer(collectionIndexHandler{})
+	defer server.Close()
+
+	ctx := context.Background()
+	cl := unitTestClient{make(map[string]*kabanerov1alpha1.Collection)}
+	collectionUrl := server.URL + defaultIndexName
+	collectionUrlTwo := server.URL + secondIndexName
+	k := createKabanero(collectionUrl, true)
+	k.Spec.Collections.Repositories = append(k.Spec.Collections.Repositories, kabanerov1alpha1.RepositoryConfig{Name: "two", Url: collectionUrlTwo, ActivateDefaultCollections: false})
+
+	err := reconcileFeaturedCollections(ctx, k, cl)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Should have been two collections created
+	javaMicroprofileCollection := &kabanerov1alpha1.Collection{}
+	err = cl.Get(ctx, types.NamespacedName{Name: "java-microprofile"}, javaMicroprofileCollection)
+	if err != nil {
+		t.Fatal("Could not resolve the java-microprofile collection", err)
+	}
+
+	nodejsCollection := &kabanerov1alpha1.Collection{}
+	err = cl.Get(ctx, types.NamespacedName{Name: "nodejs"}, nodejsCollection)
+	if err != nil {
+		t.Fatal("Could not resolve the nodejs collection", err)
+	}
+
+	// Make sure the collection has an owner set
+	if len(nodejsCollection.OwnerReferences) != 1 {
+		t.Fatal(fmt.Sprintf("Expected 1 owner, but found %v: %v", len(nodejsCollection.OwnerReferences), nodejsCollection))
+	}
+
+	if nodejsCollection.OwnerReferences[0].UID != k.UID {
+		t.Fatal(fmt.Sprintf("Expected owner UID to be %v, but was %v", k.UID, nodejsCollection.OwnerReferences[0].UID))
+	}
+
+	// Make sure the collection is in the correct state
+	if len(nodejsCollection.Spec.Versions) != 2 {
+		t.Fatal(fmt.Sprintf("Expected 2 collection versions, but found %v: %v", len(nodejsCollection.Spec.Versions), nodejsCollection.Spec.Versions))
+	}
+
+	foundVersions := make(map[string]bool)
+	for _, cur := range nodejsCollection.Spec.Versions {
+		foundVersions[cur.Version] = true
+		if cur.Version == "0.2.6" {
+			if cur.DesiredState != kabanerov1alpha1.CollectionDesiredStateActive {
+				t.Fatal(fmt.Sprintf("Expected version \"0.2.6\" to be active, but was %v", cur.DesiredState))
+			}
+			if cur.RepositoryUrl != collectionUrl {
+				t.Fatal(fmt.Sprintf("Expected version \"0.2.6\" URL to be %v, but was %v", collectionUrl, cur.RepositoryUrl))
+			}
+		} else if cur.Version == "0.4.1" {
+			if cur.DesiredState != kabanerov1alpha1.CollectionDesiredStateInactive {
+				t.Fatal(fmt.Sprintf("Expected version \"0.4.1\" to be inactive, but was %v", cur.DesiredState))
+			}
+			if cur.RepositoryUrl != collectionUrlTwo {
+				t.Fatal(fmt.Sprintf("Expected version \"0.4.1\" URL to be %v, but was %v", collectionUrlTwo, cur.RepositoryUrl))
+			}
+		} else {
+			t.Fatal(fmt.Sprintf("Found unexpected version %v", cur.Version))
+		}
+	}
+
+	if foundVersions["0.2.6"] != true {
+		t.Fatal("Did not find collection version \"0.2.6\"")
+	}
+
+	if foundVersions["0.4.1"] != true {
+		t.Fatal("Did not find collection version \"0.4.1\"")
 	}
 }
 
 // Attempts to resolve the featured collections from the default repository
-// Note that this test is fragile since it relies on connectivity to the central example index
-// and the presence of specific collections
 func TestResolveFeaturedCollections(t *testing.T) {
-	collection_index_url := "https://raw.githubusercontent.com/kabanero-io/kabanero-collection/master/experimental/index.yaml"
+	// The server that will host the pipeline zip
+	server := httptest.NewServer(collectionIndexHandler{})
+	defer server.Close()
 
-	k := &kabanerov1alpha1.Kabanero{
-		Spec: kabanerov1alpha1.KabaneroSpec{
-			Collections: kabanerov1alpha1.InstanceCollectionConfig{
-				Repositories: []kabanerov1alpha1.RepositoryConfig{
-					kabanerov1alpha1.RepositoryConfig{
-						Name:                       "default",
-						Url:                        collection_index_url,
-						ActivateDefaultCollections: true,
-					},
-				},
-			},
-		},
-	}
+	collection_index_url := server.URL + defaultIndexName
+	k := createKabanero(collection_index_url, true)
 
 	collections, err := featuredCollections(k)
 	if err != nil {
 		t.Fatal("Could not resolve the featured collections from the default index", err)
 	}
 
-	if len(collections) < 1 {
-		t.Fatal("Was expecting at least one collection to be found in the default repository: ", collection_index_url)
+	// Should be two collections
+	if len(collections) != 2 {
+		t.Fatal(fmt.Sprintf("Was expecting 2 collections to be found, but found %v: %v", len(collections), collections))
+	}
+
+	javaMicroprofileCollectionVersions, ok := collections["java-microprofile"]
+	if !ok {
+		t.Fatal(fmt.Sprintf("Could not find java-microprofile collection: %v", collections))
+	}
+
+	nodejsCollectionVersions, ok := collections["nodejs"]
+	if !ok {
+		t.Fatal(fmt.Sprintf("Could not find nodejs collection: %v", collections))
+	}
+
+	// Make sure each collection has one version
+	if len(javaMicroprofileCollectionVersions) != 1 {
+		t.Fatal(fmt.Sprintf("Expected one version of java-microprofile collection, but found %v: %v", len(javaMicroprofileCollectionVersions), javaMicroprofileCollectionVersions))
+	}
+
+	if len(nodejsCollectionVersions) != 1 {
+		t.Fatal(fmt.Sprintf("Expected one version of nodejs collection, but found %v: %v", len(nodejsCollectionVersions), nodejsCollectionVersions))
+	}
+}
+
+// Attempts to resolve the featured collections from two repositories
+func TestResolveFeaturedCollectionsTwoRepositories(t *testing.T) {
+	// The server that will host the pipeline zip
+	server := httptest.NewServer(collectionIndexHandler{})
+	defer server.Close()
+
+	collection_index_url := server.URL + defaultIndexName
+	collection_index_url_two := server.URL + secondIndexName
+	k := createKabanero(collection_index_url, true)
+	k.Spec.Collections.Repositories = append(k.Spec.Collections.Repositories, kabanerov1alpha1.RepositoryConfig{Name: "two", Url: collection_index_url_two})
+
+	collections, err := featuredCollections(k)
+	if err != nil {
+		t.Fatal("Could not resolve the featured collections from the default index", err)
+	}
+
+	// Should be two collections
+	if len(collections) != 2 {
+		t.Fatal(fmt.Sprintf("Was expecting 2 collections to be found, but found %v: %v", len(collections), collections))
+	}
+
+	javaMicroprofileCollectionVersions, ok := collections["java-microprofile"]
+	if !ok {
+		t.Fatal(fmt.Sprintf("Could not find java-microprofile collection: %v", collections))
+	}
+
+	nodejsCollectionVersions, ok := collections["nodejs"]
+	if !ok {
+		t.Fatal(fmt.Sprintf("Could not find nodejs collection: %v", collections))
+	}
+
+	// Make sure each collection has two versions
+	if len(javaMicroprofileCollectionVersions) != 2 {
+		t.Fatal(fmt.Sprintf("Expected two versions of java-microprofile collection, but found %v: %v", len(javaMicroprofileCollectionVersions), javaMicroprofileCollectionVersions))
+	}
+
+	if len(nodejsCollectionVersions) != 2 {
+		t.Fatal(fmt.Sprintf("Expected two versions of nodejs collection, but found %v: %v", len(nodejsCollectionVersions), nodejsCollectionVersions))
 	}
 }

--- a/pkg/controller/kabaneroplatform/testdata/kabanero-index-two.yaml
+++ b/pkg/controller/kabaneroplatform/testdata/kabanero-index-two.yaml
@@ -1,0 +1,61 @@
+apiVersion: v2
+stacks:
+- default-image: java-microprofile
+  default-pipeline: default
+  default-template: default
+  description: Eclipse MicroProfile on Open Liberty & OpenJ9 using Maven
+  id: java-microprofile
+  images:
+  - id: java-microprofile
+    image: kabanero/java-microprofile:0.2
+  language: java
+  license: Apache-2.0
+  maintainers:
+  - email: emijiang6@googlemail.com
+    github-id: Emily-Jiang
+    name: Emily Jiang
+  - email: neeraj.laad@gmail.com
+    github-id: neeraj-laad
+    name: Neeraj Laad
+  - email: ozzy@ca.ibm.com
+    github-id: BarDweller
+    name: Ozzy
+  name: Eclipse MicroProfile®
+  pipelines:
+  - id: default
+    sha256: b8bc0ea8890285733346c77b1c47fd3391d468af7d4b6557557be17ec91e696f
+    url: https://github.com/kabanero-io/collections/releases/download/0.4.0/incubator.common.pipeline.default.tar.gz
+  templates:
+  - id: default
+    url: https://github.com/kabanero-io/collections/releases/download/0.4.0/incubator.java-microprofile.v0.2.19.templates.default.tar.gz
+  version: 0.4.0
+- default-image: nodejs
+  default-pipeline: default
+  default-template: simple
+  description: Runtime for Node.js applications
+  id: nodejs
+  images:
+  - id: nodejs
+    image: kabanero/nodejs:0.2
+  language: nodejs
+  license: Apache-2.0
+  maintainers:
+  - email: cnbailey@gmail.com
+    github-id: seabaylea
+    name: Chris Bailey
+  - email: neeraj.laad@gmail.com
+    github-id: neeraj-laad
+    name: Neeraj Laad
+  name: Node.js
+  pipelines:
+  - id: default
+    sha256: b8bc0ea8890285733346c77b1c47fd3391d468af7d4b6557557be17ec91e696f
+    url: https://github.com/kabanero-io/collections/releases/download/0.4.0/incubator.common.pipeline.default.tar.gz
+  templates:
+  - id: simple
+    url: https://github.com/kabanero-io/collections/releases/download/0.4.0/incubator.nodejs.v0.2.6.templates.simple.tar.gz
+  version: 0.4.1
+triggers:
+- id: incubator
+  url: https://github.com/kabanero-io/collections/releases/download/0.4.0/incubator.trigger.tar.gz
+  sha256: 5f22ef2867c21d2caed04a0f4a3bf98b718cf0edff1d90861a294e1204a23403

--- a/pkg/controller/kabaneroplatform/testdata/kabanero-index.yaml
+++ b/pkg/controller/kabaneroplatform/testdata/kabanero-index.yaml
@@ -1,0 +1,61 @@
+apiVersion: v2
+stacks:
+- default-image: java-microprofile
+  default-pipeline: default
+  default-template: default
+  description: Eclipse MicroProfile on Open Liberty & OpenJ9 using Maven
+  id: java-microprofile
+  images:
+  - id: java-microprofile
+    image: kabanero/java-microprofile:0.2
+  language: java
+  license: Apache-2.0
+  maintainers:
+  - email: emijiang6@googlemail.com
+    github-id: Emily-Jiang
+    name: Emily Jiang
+  - email: neeraj.laad@gmail.com
+    github-id: neeraj-laad
+    name: Neeraj Laad
+  - email: ozzy@ca.ibm.com
+    github-id: BarDweller
+    name: Ozzy
+  name: Eclipse MicroProfile®
+  pipelines:
+  - id: default
+    sha256: b8bc0ea8890285733346c77b1c47fd3391d468af7d4b6557557be17ec91e696f
+    url: https://github.com/kabanero-io/collections/releases/download/0.4.0/incubator.common.pipeline.default.tar.gz
+  templates:
+  - id: default
+    url: https://github.com/kabanero-io/collections/releases/download/0.4.0/incubator.java-microprofile.v0.2.19.templates.default.tar.gz
+  version: 0.2.19
+- default-image: nodejs
+  default-pipeline: default
+  default-template: simple
+  description: Runtime for Node.js applications
+  id: nodejs
+  images:
+  - id: nodejs
+    image: kabanero/nodejs:0.2
+  language: nodejs
+  license: Apache-2.0
+  maintainers:
+  - email: cnbailey@gmail.com
+    github-id: seabaylea
+    name: Chris Bailey
+  - email: neeraj.laad@gmail.com
+    github-id: neeraj-laad
+    name: Neeraj Laad
+  name: Node.js
+  pipelines:
+  - id: default
+    sha256: b8bc0ea8890285733346c77b1c47fd3391d468af7d4b6557557be17ec91e696f
+    url: https://github.com/kabanero-io/collections/releases/download/0.4.0/incubator.common.pipeline.default.tar.gz
+  templates:
+  - id: simple
+    url: https://github.com/kabanero-io/collections/releases/download/0.4.0/incubator.nodejs.v0.2.6.templates.simple.tar.gz
+  version: 0.2.6
+triggers:
+- id: incubator
+  url: https://github.com/kabanero-io/collections/releases/download/0.4.0/incubator.trigger.tar.gz
+  sha256: 5f22ef2867c21d2caed04a0f4a3bf98b718cf0edff1d90861a294e1204a23403


### PR DESCRIPTION
* Kabanero controller creates collections using the versions array instead of the singleton version
* Tested Kabanero CR instance with two repositories (multiple versions of same collection)
* Collection Controller parses versions array and can activate multiple versions
* Updated featured collection tests, and started using local files
* Updated collection controller tests