### PR TITLE
Fix pipelinerun tests

### DIFF
--- a/tests/10-java-microprofile.sh
+++ b/tests/10-java-microprofile.sh
@@ -3,7 +3,7 @@
 set -Eeuox pipefail
 
 COLLECTION="java-microprofile"
-APP="sample-java-microprofile"
+APP="sample-java-microprofile" \
 DOCKER_IMAGE="image-registry.openshift-image-registry.svc:5000/kabanero/${APP}" \
 APP_REPO="https://github.com/kabanero-io/${APP}/" \
 PIPELINE_RUN="${APP}-build-deploy-pipeline-run-kabanero" \

--- a/tests/11-java-spring-boot2.sh
+++ b/tests/11-java-spring-boot2.sh
@@ -3,7 +3,7 @@
 set -Eeuox pipefail
 
 COLLECTION="java-spring-boot2"
-APP="sample-java-spring-boot2"
+APP="sample-java-spring-boot2" \
 DOCKER_IMAGE="image-registry.openshift-image-registry.svc:5000/kabanero/${APP}" \
 APP_REPO="https://github.com/kabanero-io/${APP}/" \
 PIPELINE_RUN="${APP}-build-deploy-pipeline-run-kabanero" \

--- a/tests/12-nodejs.sh
+++ b/tests/12-nodejs.sh
@@ -3,7 +3,7 @@
 set -Eeuox pipefail
 
 COLLECTION="nodejs"
-APP="sample-nodejs"
+APP="sample-nodejs" \
 DOCKER_IMAGE="image-registry.openshift-image-registry.svc:5000/kabanero/${APP}" \
 APP_REPO="https://github.com/kabanero-io/${APP}/" \
 PIPELINE_RUN="${APP}-build-deploy-pipeline-run-kabanero" \

--- a/tests/13-nodejs-express.sh
+++ b/tests/13-nodejs-express.sh
@@ -3,7 +3,7 @@
 set -Eeuox pipefail
 
 COLLECTION="nodejs-express"
-APP="sample-nodejs-express"
+APP="sample-nodejs-express" \
 DOCKER_IMAGE="image-registry.openshift-image-registry.svc:5000/kabanero/${APP}" \
 APP_REPO="https://github.com/kabanero-io/${APP}/" \
 PIPELINE_RUN="${APP}-build-deploy-pipeline-run-kabanero" \

--- a/tests/14-nodejs-loopback.sh
+++ b/tests/14-nodejs-loopback.sh
@@ -3,7 +3,7 @@
 set -Eeuox pipefail
 
 COLLECTION="nodejs-loopback"
-APP="sample-nodejs-loopback"
+APP="sample-nodejs-loopback" \
 DOCKER_IMAGE="image-registry.openshift-image-registry.svc:5000/kabanero/${APP}" \
 APP_REPO="https://github.com/kabanero-io/${APP}/" \
 PIPELINE_RUN="${APP}-build-deploy-pipeline-run-kabanero" \

--- a/tests/pipelinerun.sh
+++ b/tests/pipelinerun.sh
@@ -13,8 +13,7 @@ DOCKER_IMAGE="${DOCKER_IMAGE:-image-registry.openshift-image-registry.svc:5000/k
 # Appsody project GitHub repository #
 APP_REPO="${APP_REPO:-https://github.com/kabanero-io/sample-java-microprofile/}"
 
-COLLECTION="java-microprofile"
-APP="sample-java-microprofile"
+APP="${APP:-sample-java-microprofile}"
 PIPELINE_RUN="${PIPELINE_RUN:-java-microprofile-build-deploy-pipeline-run-kabanero}"
 PIPELINE_REF="${PIPELINE_REF:-java-microprofile-build-push-deploy-pipeline}"
 DOCKER_IMAGE_REF="${DOCKER_IMAGE_REF:-java-microprofile-docker-image}"


### PR DESCRIPTION
Wrong `APP` name was used when validating AppsodyApplication and KnativeService.
