### PR TITLE
update kabanero landing/console to 0.5.0-rc.1

### DIFF
--- a/config/versions.yaml
+++ b/config/versions.yaml
@@ -16,7 +16,7 @@ kabanero:
 - version: "0.5.0"
   related-versions: 
     cli-services: "0.4.0"
-    landing: "0.4.0"
+    landing: "0.5.0-rc.1"
     kabanero-che: "0.6.0"
     events: "0.1.0"
     collection-controller: "0.4.0"
@@ -72,6 +72,11 @@ kabanero:
 
 related-software:
   landing:
+  - version: "0.5.0-rc.1"
+    orchestrations: "orchestrations/landing/0.1"
+    identifiers:
+      repository: "kabanero/landing"
+      tag: "0.5.0-rc.1"
   - version: "0.4.0"
     orchestrations: "orchestrations/landing/0.1"
     identifiers:


### PR DESCRIPTION
adding kabanero landing 0.5.0-rc.1 to the Kabanero 0.5.0-rc.1 release