### PR TITLE
Default the sha256 for a pipeline that is missing one

### DIFF
--- a/pkg/controller/collection/collection_controller.go
+++ b/pkg/controller/collection/collection_controller.go
@@ -835,7 +835,7 @@ func getCollectionForSpecVersion(spec kabanerov1alpha1.CollectionVersion, collec
 				if len(pipeline.Sha256) != 64 {
 					err := fmt.Errorf("Sha256 length %v is not valid", len(pipeline.Sha256))
 					log.Error(err, fmt.Sprintf("Collection ID %v version %v pipeline ID %v has an invalid Sha256 %v", collection.collection.Id, collection.collection.Version, pipeline.Id, pipeline.Sha256))
-					collection.collection.Pipelines[index].Sha256 = "0000000000000000000000000000000000000000000000000000000000000000"
+					collection.collection.Pipelines[index].Sha256 = strings.Repeat("0", 64)
 				}
 			}
 			return &collection

--- a/pkg/controller/collection/collection_controller_test.go
+++ b/pkg/controller/collection/collection_controller_test.go
@@ -993,7 +993,7 @@ func TestReconcileActiveVersionsRecreatedDeletedAssetsNoManifest(t *testing.T) {
 
 	deletedPipeline := fileInfo{
 		name: "/deleted.pipeline.tar.gz",
-		sha256: "aaaabbbbccccdddd"}
+		sha256: "ABCD000000000000000000000000000000000000000000000000000000000000"}
 	
 	pipelineZipUrl := server.URL + deletedPipeline.name
 	collectionResource := kabanerov1alpha1.Collection{


### PR DESCRIPTION
Fixes #379 
The Kabanero collection hub 0.5.0-rc.1 is missing the Sha256 for the pipelines.  The kabanero operator will panic trying to slice first 8 characters of the Sha256.  If there isn't a Sha256, print an error, and then default it.  Later, when we try to download the pipeline zip, we'll fail because the Sha256 does not match.  This is much better than a panic.