### PR TITLE
Try to cache the mods directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,4 +51,4 @@ deploy:
 
 cache:
   directories:
-    - vendor 
+    - ${HOME}/gopath/pkg/mod


### PR DESCRIPTION
We had previously cached the `vendor` directory so that we wouldn't have to pull down all of the vendored code from github on every build.  Now that we are using go modules instead of the vendor directory, it makes more sense for us to cache the `$GOPATH/pkg/mods` directory instead.

This cut 5-6 minutes off of the build time for the one test build that I ran, after the cache was repopulated.  The cache is rather large now - gigabytes instead of megabytes.  I was not able to find a size limit for cache, although the build machine does have a disk limit of ~18 GB (however all of this data will need to be obtained in any case, either from the cache, or from github).