### PR TITLE
uninstall deletes tekton-pipelines ns

### DIFF
--- a/deploy/uninstall.sh
+++ b/deploy/uninstall.sh
@@ -251,3 +251,6 @@ do
   fi
 done
 
+
+# Delete tekton-pipelines namespace to clean up loose artifacts from dashboard that cause problems on reinstall
+oc delete namespace tekton-pipelines --ignore-not-found


### PR DESCRIPTION
This is not only a problem with a stale webhook object, but in dashboard 0.3+ an old route can prevent a new webhook from being created.

