### PR TITLE
402

### DIFF
--- a/pkg/controller/kabaneroplatform/cli.go
+++ b/pkg/controller/kabaneroplatform/cli.go
@@ -93,7 +93,7 @@ func reconcileKabaneroCli(ctx context.Context, k *kabanerov1alpha1.Kabanero, cl 
 			reqLogger.Error(err, "Could not parse Github API url %v, assuming api.github.com", apiUrlString)
 			apiUrl, _ = url.Parse("https://api.github.com")
 		}
-		transforms = append(transforms, kabTransforms.AddEnvVariable("github.api.url", apiUrlString))
+		transforms = append(transforms, kabTransforms.AddEnvVariable("github.api.url", apiUrl.String()))
 	}
 
 	// Set JwtExpiration for login duration/timeout

--- a/pkg/controller/kabaneroplatform/cli.go
+++ b/pkg/controller/kabaneroplatform/cli.go
@@ -86,12 +86,12 @@ func reconcileKabaneroCli(ctx context.Context, k *kabanerov1alpha1.Kabanero, cl 
 	if len(k.Spec.Github.ApiUrl) > 0 {
 		apiUrlString := k.Spec.Github.ApiUrl
 		apiUrl, err := url.Parse(apiUrlString)
-		if len(apiUrl.Scheme) == 0 {
-			apiUrl.Scheme = "https"
-		}
+
 		if err != nil {
 			reqLogger.Error(err, "Could not parse Github API url %v, assuming api.github.com", apiUrlString)
 			apiUrl, _ = url.Parse("https://api.github.com")
+		} else if len(apiUrl.Scheme) == 0 {
+			apiUrl.Scheme = "https"
 		}
 		transforms = append(transforms, kabTransforms.AddEnvVariable("github.api.url", apiUrl.String()))
 	}

--- a/pkg/controller/kabaneroplatform/landing.go
+++ b/pkg/controller/kabaneroplatform/landing.go
@@ -120,14 +120,12 @@ func deployLandingPage(k *kabanerov1alpha1.Kabanero, c client.Client) error {
 		}
 
 		apiUrl, err := url.Parse(apiUrlString)
-		if len(apiUrl.Scheme) == 0 {
-			apiUrl.Scheme = "https"
-		}
 		if err != nil {
 			kllog.Error(err, "Could not parse Github API url %v, assuming api.github.com", apiUrlString)
 			apiUrl, _ = url.Parse("https://api.github.com")
+		} else if len(apiUrl.Scheme) == 0 {
+			apiUrl.Scheme = "https"
 		}
-
 		hostname := apiUrl.Hostname()
 		if hostname == "api.github.com" {
 			transforms = append(transforms, kabTransforms.AddEnvVariable("USER_API", "https://api.github.com/user"))

--- a/pkg/controller/kabaneroplatform/landing.go
+++ b/pkg/controller/kabaneroplatform/landing.go
@@ -120,6 +120,9 @@ func deployLandingPage(k *kabanerov1alpha1.Kabanero, c client.Client) error {
 		}
 
 		apiUrl, err := url.Parse(apiUrlString)
+		if len(apiUrl.Scheme) == 0 {
+			apiUrl.Scheme = "https"
+		}
 		if err != nil {
 			kllog.Error(err, "Could not parse Github API url %v, assuming api.github.com", apiUrlString)
 			apiUrl, _ = url.Parse("https://api.github.com")


### PR DESCRIPTION
- Landing: ensure URL.Scheme is at least defaulted to https
- CLI: process as net/url as per Landing
  - Will now set a url if the parse fails, but behavior still does not set if empty
