### PR TITLE
420

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -121,18 +121,27 @@ oc delete -f $KABANERO_SUBSCRIPTIONS_YAML  --ignore-not-found --selector kabaner
 
 ### CatalogSource
 
+# Install Kabanero CatalogSource
+oc apply -f $KABANERO_SUBSCRIPTIONS_YAML --selector kabanero.io/install=00-catalogsource
+
+# Check the kabanero-catalog CatalogSource pod is Running
+unset STATUS
+until [ "$STATUS" == "Running" ]
+do
+  echo "Waiting for CatalogSource kabanero-catalog pod to be ready."
+  STATUS=$(oc -n openshift-marketplace get pod -l olm.catalogSource=kabanero-catalog --output=jsonpath={.items[0].status.phase})
+  sleep $SLEEP_SHORT
+done
+
 # Stop the catalog-operator pod to avoid ready state bug
 oc -n openshift-operator-lifecycle-manager scale deploy catalog-operator --replicas=0
 sleep $SLEEP_LONG
-
-# Install Kabanero CatalogSource
-oc apply -f $KABANERO_SUBSCRIPTIONS_YAML --selector kabanero.io/install=00-catalogsource
 
 # Restart the catalog-operator pod to avoid ready state bug
 sleep $SLEEP_LONG
 oc -n openshift-operator-lifecycle-manager scale deploy catalog-operator --replicas=1
 
-# Check the CatalogSource is ready
+# Check the kabanero-catalog CatalogSource is ready
 unset LASTOBSERVEDSTATE
 until [ "$LASTOBSERVEDSTATE" == "READY" ]
 do

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -107,6 +107,11 @@ checksub () {
 # serverless-operator.v1.2.0+ manages smmr, clean up
 oc delete -f $KABANERO_CUSTOMRESOURCES_YAML --ignore-not-found --selector kabanero.io/install=21-cr-servicemeshmemberrole || true
 
+# ServiceMeshControlPlane
+# serverless-operator.v1.3.0+ manages smmr & smcp, cleanup
+oc delete -f $KABANERO_CUSTOMRESOURCES_YAML --ignore-not-found --selector kabanero.io/install=20-cr-servicemeshcontrolplane || true
+
+
 # CatalogSource
 # Delete previous CatalogSource to ensure visibility of updated catalog CSVs
 oc delete -f $KABANERO_SUBSCRIPTIONS_YAML  --ignore-not-found --selector kabanero.io/install=00-catalogsource
@@ -127,9 +132,6 @@ oc apply -f $KABANERO_SUBSCRIPTIONS_YAML --selector kabanero.io/install=00-catal
 sleep $SLEEP_LONG
 oc -n openshift-operator-lifecycle-manager scale deploy catalog-operator --replicas=1
 
-
-
-
 # Check the CatalogSource is ready
 unset LASTOBSERVEDSTATE
 until [ "$LASTOBSERVEDSTATE" == "READY" ]
@@ -138,6 +140,7 @@ do
 	LASTOBSERVEDSTATE=$(oc get catalogsource kabanero-catalog -n openshift-marketplace --output=jsonpath={.status.connectionState.lastObservedState})
 	sleep $SLEEP_SHORT
 done
+
 
 ### Subscriptions
 
@@ -178,21 +181,6 @@ checksub kabanero-operator kabanero
 
 
 ### CustomResources
-
-# ServiceMeshControlplane
-oc apply -f $KABANERO_CUSTOMRESOURCES_YAML --selector kabanero.io/install=20-cr-servicemeshcontrolplane
-
-# Check the ServiceMeshControlPlane is ready, last condition should reflect readiness
-unset STATUS
-unset TYPE
-until [ "$STATUS" == "True" ] && [ "$TYPE" == "Ready" ]
-do
-	echo "Waiting for ServiceMeshControlPlane basic-install to be ready."
-	TYPE=$(oc get servicemeshcontrolplane -n istio-system basic-install --output=jsonpath={.status.conditions[-1:].type})
-	STATUS=$(oc get servicemeshcontrolplane -n istio-system basic-install --output=jsonpath={.status.conditions[-1:].status})
-	sleep $SLEEP_SHORT
-done
-
 
 # Serving
 oc apply -f $KABANERO_CUSTOMRESOURCES_YAML --selector kabanero.io/install=22-cr-knative-serving

--- a/deploy/kabanero-subscriptions.yaml
+++ b/deploy/kabanero-subscriptions.yaml
@@ -61,7 +61,7 @@ metadata:
   labels:
     kabanero.io/install: 11-subscription
 spec:
-  channel: kabanero-0.4
+  channel: kabanero-0.6
   installPlanApproval: Automatic
   name: servicemeshoperator
   source: kabanero-catalog
@@ -91,7 +91,7 @@ metadata:
   labels:
     kabanero.io/install: 12-subscription
 spec:
-  channel: kabanero-0.5
+  channel: kabanero-0.6
   installPlanApproval: Automatic
   name: serverless-operator
   source: kabanero-catalog

--- a/registry/manifests/serverless-operator/1.3.0/serverless-operator.v1.3.0.clusterserviceversion.yaml
+++ b/registry/manifests/serverless-operator/1.3.0/serverless-operator.v1.3.0.clusterserviceversion.yaml
@@ -1,0 +1,385 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "serving.knative.dev/v1alpha1",
+          "kind": "KnativeServing",
+          "metadata": {
+            "name": "knative-serving"
+          },
+          "spec": {
+            "config": {
+              "autoscaler": {
+                "container-concurrency-target-default": "100",
+                "container-concurrency-target-percentage": "1.0",
+                "enable-scale-to-zero": "true",
+                "max-scale-up-rate": "10",
+                "panic-threshold-percentage": "200.0",
+                "panic-window": "6s",
+                "panic-window-percentage": "10.0",
+                "scale-to-zero-grace-period": "30s",
+                "stable-window": "60s",
+                "tick-interval": "2s"
+              },
+              "defaults": {
+                "revision-cpu-limit": "1000m",
+                "revision-cpu-request": "400m",
+                "revision-memory-limit": "200M",
+                "revision-memory-request": "100M",
+                "revision-timeout-seconds": "300"
+              },
+              "deployment": {
+                "registriesSkippingTagResolving": "ko.local,dev.local"
+              },
+              "gc": {
+                "stale-revision-create-delay": "24h",
+                "stale-revision-lastpinned-debounce": "5h",
+                "stale-revision-minimum-generations": "1",
+                "stale-revision-timeout": "15h"
+              },
+              "logging": {
+                "loglevel.activator": "info",
+                "loglevel.autoscaler": "info",
+                "loglevel.controller": "info",
+                "loglevel.queueproxy": "info",
+                "loglevel.webhook": "info"
+              },
+              "observability": {
+                "logging.enable-var-log-collection": "false",
+                "metrics.backend-destination": "prometheus"
+              },
+              "tracing": {
+                "backend": "none",
+                "sample-rate": "0.1"
+              }
+            }
+          }
+        }
+      ]
+    capabilities: Seamless Upgrades
+    categories: Networking,Integration & Delivery,Cloud Provider,Developer Tools
+    certified: "false"
+    containerImage: registry.redhat.io/openshift-serverless-1-tech-preview/serving-rhel8-operator@sha256:990ff0bea65dd28ad8bf3e72c6785013b79f5ba1ff19458ca38e22ffd56736a1
+    createdAt: "2019-07-27T17:00:00Z"
+    description: |-
+      Provides a collection of API's based on Knative to support deploying and serving
+      of serverless applications and functions.
+    repository: https://github.com/openshift-knative/serverless-operator
+    support: Red Hat, Inc.
+  name: serverless-operator.v1.3.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: Represents an installation of a particular version of Knative Serving
+      displayName: Knative Serving
+      kind: KnativeServing
+      name: knativeservings.serving.knative.dev
+      statusDescriptors:
+      - description: The version of Knative Serving installed
+        displayName: Version
+        path: version
+      - description: Conditions of Knative Serving installed
+        displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - 'urn:alm:descriptor:io.kubernetes.conditions'
+      version: v1alpha1
+    required:
+    - description: A list of namespaces in Service Mesh
+      displayName: Istio Service Mesh Member Roll
+      kind: ServiceMeshMemberRoll
+      name: servicemeshmemberrolls.maistra.io
+      version: v1
+    - description: An Istio control plane installation
+      displayName: Istio Service Mesh Control Plane
+      kind: ServiceMeshControlPlane
+      name: servicemeshcontrolplanes.maistra.io
+      version: v1
+  minKubeVersion: 1.14.0
+  description: |-
+    The Red Hat Serverless Operator provides a collection of API's to
+    install various "serverless" services.
+
+    This is a **[Tech Preview release](https://access.redhat.com/support/offerings/techpreview)!**
+
+    # Knative Serving
+
+    Knative Serving builds on Kubernetes to support deploying and
+    serving of serverless applications and functions. Serving is easy
+    to get started with and scales to support advanced scenarios. The
+    Knative Serving project provides middleware primitives that
+    enable:
+
+    - Rapid deployment of serverless containers
+    - Automatic scaling up and down to zero
+    - Routing and network programming for Istio components
+    - Point-in-time snapshots of deployed code and configurations
+
+    ## Prerequisites
+
+    The Serverless Operator's provided APIs such as Knative Serving
+    have certain requirements with regards to the size of the underlying
+    cluster and a working installation of Service Mesh. See the [installation
+    section](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index#installing-openshift-serverless)
+    of the Serverless documentation for more info.
+
+    ## Further Information
+
+    For documentation on using Knative Serving, see the
+    [serving section](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index#knative-serving_serverless-architecture) of the
+    [Serverless documentation site](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index).
+
+  displayName: OpenShift Serverless Operator
+  icon:
+  - base64data: PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMzQwMDt9LmNscy0ye2ZpbGw6I2NlMmUwMDt9LmNscy0ze2ZpbGw6bm9uZTt9LmNscy00e2ZpbGw6I2ZmZjt9LmNscy01e2ZpbGw6I2RjZGNkYzt9LmNscy02e2ZpbGw6I2FhYTt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZF9IYXQtT3BlbnNoaWZ0NC1DYXRhbG9nX0ljb25zLVNlcnZlcmxlc3M8L3RpdGxlPjxjaXJjbGUgY2xhc3M9ImNscy0xIiBjeD0iNTAiIGN5PSI1MCIgcj0iNTAiLz48cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik04NS4zNiwxNC42NEE1MCw1MCwwLDAsMSwxNC42NCw4NS4zNloiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik00MC41Nyw0Ny40MmEzLjg5LDMuODksMCwxLDAsMy44OCwzLjg4QTMuODksMy44OSwwLDAsMCw0MC41Nyw0Ny40MloiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik0yMS40Miw0Ny40MkEzLjg5LDMuODksMCwxLDAsMjUuMyw1MS4zLDMuODksMy44OSwwLDAsMCwyMS40Miw0Ny40MloiLz48cGF0aCBjbGFzcz0iY2xzLTQiIGQ9Ik01MC4wOSw0OC44NmgtLjE4YTQuMTEsNC4xMSwwLDAsMS0zLjI2LTEuNjMsNy42OSw3LjY5LDAsMCwwLTEyLjE2LDAsNC4xMyw0LjEzLDAsMCwxLTMuMjYsMS42M0gzMWE0LjA5LDQuMDksMCwwLDEtMy4yNS0xLjYzQTcuNjksNy42OSwwLDAsMCwxNCw1MS45M2gwVjY0LjZhMi43OSwyLjc5LDAsMCwwLDIuNzksMi43OWgxNS44TDUxLjM0LDQ4LjY2QTQsNCwwLDAsMSw1MC4wOSw0OC44NloiLz48cGF0aCBjbGFzcz0iY2xzLTUiIGQ9Ik03OC4wNSw0NC4yNWE3LjY1LDcuNjUsMCwwLDAtNS44NSwzQTQuMSw0LjEsMCwwLDEsNjksNDguODZoLS4xOWE0LjEzLDQuMTMsMCwwLDEtMy4yNi0xLjYzLDcuNjksNy42OSwwLDAsMC0xMi4xNiwwLDQuMTYsNC4xNiwwLDAsMS0yLDEuNDNMMzIuNjEsNjcuMzlIODMuMTlBMi43OSwyLjc5LDAsMCwwLDg2LDY0LjZWNTIuMDdBNy43Nyw3Ljc3LDAsMCwwLDc4LjA1LDQ0LjI1WiIvPjxwYXRoIGNsYXNzPSJjbHMtNiIgZD0iTTIxLjEsNjNoMTBhMS44MywxLjgzLDAsMSwwLDAtMy42NmgtMTBhMS44MywxLjgzLDAsMCwwLDAsMy42NloiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjQwLjU3IiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjQwLjU3IiBjeT0iMjguMjMiIHI9IjEuMzUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjU5LjcyIiBjeT0iMjguMjMiIHI9IjEuMzUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjIxLjQyIiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjUwIiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjY4Ljg5IiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjMxLjA5IiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNiIgY3g9Ijc3Ljk0IiBjeT0iNTQuMzEiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNiIgY3g9IjY4LjkxIiBjeT0iNTQuMzEiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9Ijc3Ljk0IiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjU5LjcyIiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjUwIiBjeT0iMzMuMSIgcj0iMy4wMSIvPjxjaXJjbGUgY2xhc3M9ImNscy00IiBjeD0iMzEuMDkiIGN5PSIzMy4xIiByPSIzLjAxIi8+PGNpcmNsZSBjbGFzcz0iY2xzLTQiIGN4PSI2OC44OSIgY3k9IjMzLjEiIHI9IjMuMDEiLz48L3N2Zz4=
+    mediatype: image/svg+xml
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - '*'
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        serviceAccountName: knative-serving-operator
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - events
+          - configmaps
+          verbs:
+          - "*"
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - replicasets
+          verbs:
+          - "*"
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - "*"
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - "*"
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - networking.internal.knative.dev
+          resources:
+          - clusteringresses
+          - clusteringresses/status
+          - clusteringresses/finalizers
+          - ingresses
+          - ingresses/status
+          - ingresses/finalizers
+          verbs:
+          - "*"
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          - routes/custom-host
+          - routes/status
+          - routes/finalizers
+          verbs:
+          - "*"
+        - apiGroups:
+          - serving.knative.dev
+          resources:
+          - knativeservings
+          - knativeservings/finalizers
+          verbs:
+          - '*'
+        - apiGroups:
+          - maistra.io
+          resources:
+          - servicemeshmemberrolls
+          verbs:
+          - '*'
+        serviceAccountName: knative-openshift-ingress
+      deployments:
+      - name: knative-serving-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: knative-serving-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: knative-serving-operator
+            spec:
+              containers:
+              - command:
+                - knative-serving-operator
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: knative-serving-operator
+                - name: IMAGE_QUEUE
+                  value: registry.redhat.io/openshift-serverless-1-tech-preview/serving-queue-rhel8@sha256:cd177f6cfadf6eebec93a60986db147957dec27b59902dee0eabba97a709a3ed
+                - name: IMAGE_activator
+                  value: registry.redhat.io/openshift-serverless-1-tech-preview/serving-activator-rhel8@sha256:f5be68c245b6cd2cae3bd4bb45d2558c79f92c114993163d6b970652939643b2
+                - name: IMAGE_autoscaler
+                  value: registry.redhat.io/openshift-serverless-1-tech-preview/serving-autoscaler-rhel8@sha256:158a2fbc608b1144489fc982cd6eaa7238a9096f12e072bf994118ae27d95397
+                - name: IMAGE_autoscaler-hpa
+                  value: registry.redhat.io/openshift-serverless-1-tech-preview/serving-autoscaler-hpa-rhel8@sha256:a63460626c9a8d133451f608acf6322ac86e9c9833ea9c19febfd5d9f70844e4
+                - name: IMAGE_controller
+                  value: registry.redhat.io/openshift-serverless-1-tech-preview/serving-controller-rhel8@sha256:8fb61cd826145f6a47aaaa63af6c9fa7aac55238ddfccb0b82037e9baf94b3fa
+                - name: IMAGE_networking-istio
+                  value: registry.redhat.io/openshift-serverless-1-tech-preview/serving-networking-istio-rhel8@sha256:3a0d30bc84ad0906e02b78af501ab604b576cd10b5578ec2eb741f9040b6b153
+                - name: IMAGE_webhook
+                  value: registry.redhat.io/openshift-serverless-1-tech-preview/serving-webhook-rhel8@sha256:933b772212e13824e26a475d79d1383714b14f954816ca84cf830b324eaa8ada
+                image: registry.redhat.io/openshift-serverless-1-tech-preview/serving-rhel8-operator@sha256:990ff0bea65dd28ad8bf3e72c6785013b79f5ba1ff19458ca38e22ffd56736a1
+                imagePullPolicy: Always
+                name: knative-serving-operator
+                resources: {}
+              serviceAccountName: knative-serving-operator
+      - name: knative-openshift-ingress
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: knative-openshift-ingress
+          template:
+            metadata:
+              labels:
+                name: knative-openshift-ingress
+            spec:
+              serviceAccountName: knative-openshift-ingress
+              containers:
+                - name: knative-openshift-ingress
+                  image: registry.redhat.io/openshift-serverless-1-tech-preview/ingress-rhel8-operator@sha256:46932bef2b7ccd657e00080000abbdbb9cb1f20ed6de587dd2a7efd67804be52
+                  command:
+                  - knative-openshift-ingress
+                  imagePullPolicy: Always
+                  env:
+                    - name: WATCH_NAMESPACE
+                      value: "" # watch all namespaces for ClusterIngress
+                    - name: POD_NAME
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.name
+                    - name: OPERATOR_NAME
+                      value: "knative-openshift-ingress"
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - apps
+          resourceNames:
+          - knative-serving-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - serving.knative.dev
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        serviceAccountName: knative-serving-operator
+    strategy: deployment
+  installModes:
+  - supported: false
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - serverless
+  - FaaS
+  - microservices
+  - scale to zero
+  - knative
+  - serving
+  links:
+  - name: Documentation
+    url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index
+  - name: Source Repository
+    url: https://github.com/openshift-knative/serverless-operator
+  maintainers:
+  - email: serverless-support@redhat.com
+    name: Serverless Team
+  maturity: alpha
+  provider:
+    name: Red Hat, Inc.
+  replaces: serverless-operator.v1.2.0
+  version: 1.3.0

--- a/registry/manifests/serverless-operator/1.3.0/serving_v1alpha1_knativeserving_crd.yaml
+++ b/registry/manifests/serverless-operator/1.3.0/serving_v1alpha1_knativeserving_crd.yaml
@@ -1,0 +1,99 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: knativeservings.serving.knative.dev
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.version
+    name: Version
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Ready")].status
+    name: Ready
+    type: string
+  - JSONPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+    name: Reason
+    type: string
+  group: serving.knative.dev
+  names:
+    kind: KnativeServing
+    listKind: KnativeServingList
+    plural: knativeservings
+    singular: knativeserving
+    shortNames:
+    - ks
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Schema for the knativeservings API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: Spec defines the desired state of KnativeServing
+          properties:
+            config:
+              additionalProperties:
+                additionalProperties:
+                  type: string
+                type: object
+              description: A means to override the corresponding entries in the upstream
+                configmaps
+              type: object
+          type: object
+        status:
+          description: Status defines the observed state of KnativeServing
+          properties:
+            conditions:
+              description: The latest available observations of a resource's current
+                state.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: LastTransitionTime is the last time the condition
+                      transitioned from one status to another. We use VolatileTime
+                      in place of metav1.Time to exclude this from creating equality.Semantic
+                      differences (all other things held constant).
+                    type: string
+                  message:
+                    description: A human readable message indicating details about
+                      the transition.
+                    type: string
+                  reason:
+                    description: The reason for the condition's last transition.
+                    type: string
+                  severity:
+                    description: Severity with which to treat failures of this type
+                      of condition. When this is not specified, it defaults to Error.
+                    type: string
+                  status:
+                    description: Status of the condition, one of True, False, Unknown.
+                    type: string
+                  type:
+                    description: Type of condition.
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            version:
+              description: The version of the installed release
+              type: string
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/registry/manifests/serverless-operator/serverless-operator.package.yaml
+++ b/registry/manifests/serverless-operator/serverless-operator.package.yaml
@@ -6,4 +6,6 @@ channels:
   currentCSV: serverless-operator.v1.1.0
 - name: kabanero-0.5
   currentCSV: serverless-operator.v1.2.0
-defaultChannel: kabanero-0.5
+- name: kabanero-0.6
+  currentCSV: serverless-operator.v1.3.0
+defaultChannel: kabanero-0.6

--- a/registry/manifests/servicemeshoperator/1.0.3/servicemeshcontrolplanes.crd.yaml
+++ b/registry/manifests/servicemeshoperator/1.0.3/servicemeshcontrolplanes.crd.yaml
@@ -1,0 +1,40 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: servicemeshcontrolplanes.maistra.io
+spec:
+  group: maistra.io
+  names:
+    kind: ServiceMeshControlPlane
+    listKind: ServiceMeshControlPlaneList
+    plural: servicemeshcontrolplanes
+    singular: servicemeshcontrolplane
+    shortNames:
+      - smcp
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1
+  additionalPrinterColumns:
+    - JSONPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      description: Whether or not the control plane installation is up to date and
+        ready to handle requests.
+      type: string
+    - JSONPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      description: The status of the control plane installation.
+      type: string
+      priority: 1
+    - JSONPath: .status.conditions[?(@.type=="Reconciled")].status
+      name: Reconciled
+      description: Whether or not the control plane installation is up to date with
+        the latest version of this resource.
+      type: string
+      priority: 1
+    - JSONPath: .status.conditions[?(@.type=="Reconciled")].message
+      name: Reconciliation Status
+      description: The status of the reconciliation process, if the control plane
+        is not up to date with the latest version this resource.
+      type: string
+      priority: 1

--- a/registry/manifests/servicemeshoperator/1.0.3/servicemeshmemberrolls.crd.yaml
+++ b/registry/manifests/servicemeshoperator/1.0.3/servicemeshmemberrolls.crd.yaml
@@ -1,0 +1,22 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: servicemeshmemberrolls.maistra.io
+spec:
+  group: maistra.io
+  names:
+    kind: ServiceMeshMemberRoll
+    listKind: ServiceMeshMemberRollList
+    plural: servicemeshmemberrolls
+    singular: servicemeshmemberroll
+    shortNames:
+      - smmr
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1
+  additionalPrinterColumns:
+    - JSONPath: .spec.members
+      description: Namespaces that are members of this Control Plane
+      name: Members
+      type: string

--- a/registry/manifests/servicemeshoperator/1.0.3/servicemeshoperator.v1.0.3.clusterserviceversion.yaml
+++ b/registry/manifests/servicemeshoperator/1.0.3/servicemeshoperator.v1.0.3.clusterserviceversion.yaml
@@ -1,0 +1,397 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: servicemeshoperator.v1.0.3
+  namespace: placeholder
+  annotations:
+    categories: "OpenShift Optional, Integration & Delivery"
+    capabilities: "Seamless Upgrades"
+    certified: "false"
+    repository: https://github.com/maistra/istio-operator
+    description: |-
+      The OpenShift Service Mesh Operator enables you to install, configure, and manage an instance of Red Hat OpenShift Service Mesh. OpenShift Service Mesh is based on the open source Istio project.
+
+    containerImage: registry.redhat.io/openshift-service-mesh/istio-rhel8-operator:1.0.3
+    createdAt: 2019-12-05T14:21:42UTC
+    support: Red Hat, Inc. 
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "maistra.io/v1",
+          "kind": "ServiceMeshControlPlane",
+          "metadata": {
+            "name": "basic-install"
+          },
+          "spec": {
+            "istio": {
+              "gateways": {
+                "istio-egressgateway": {
+                  "autoscaleEnabled": false
+                },
+                "istio-ingressgateway": {
+                  "autoscaleEnabled": false
+                }
+              },
+              "mixer": {
+                "policy": {
+                  "autoscaleEnabled": false
+                },
+                "telemetry": {
+                  "autoscaleEnabled": false
+                }
+              },
+              "pilot": {
+                "autoscaleEnabled": false,
+                "traceSampling": 100.0
+              },
+              "kiali": {
+                "enabled": true
+              },
+              "grafana": {
+                "enabled": true
+              },
+              "tracing": {
+                "enabled": true,
+                "jaeger": {
+                  "template": "all-in-one"
+                }
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "maistra.io/v1",
+          "kind": "ServiceMeshMemberRoll",
+          "metadata": {
+            "name": "default"
+          },
+          "spec": {
+            "members": [
+              "your-project",
+              "another-of-your-projects" 
+            ]
+          }
+        }
+      ]
+spec:
+  version: 1.0.3
+  maturity: alpha
+  displayName: Red Hat OpenShift Service Mesh
+  description: |-
+    Red Hat OpenShift Service Mesh is a platform that provides behavioral insight and operational control over the service mesh, providing a uniform way to connect, secure, and monitor microservice applications. 
+  keywords: [ 'istio', 'maistra', 'servicemesh' ]
+  maintainers:
+  - name: Red Hat, OpenShift Service Mesh
+    email: istio-feedback@redhat.com
+  provider:
+    name: Red Hat, Inc.
+  links:
+  - name: Service Mesh Operator
+    url: https://github.com/Maistra/istio-operator
+  - name: Istio
+    url: https://istio.io/
+  replaces: servicemeshoperator.v1.0.2
+  installModes:
+  - type: OwnNamespace
+    supported: true
+  - type: SingleNamespace
+    supported: false
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: true
+  install:
+    strategy: deployment
+    spec:
+      clusterPermissions:
+      - serviceAccountName: istio-operator
+        rules:
+
+        - apiGroups:
+            - ''
+          resources:
+            - configmaps
+            - endpoints
+            - namespaces
+            - persistentvolumeclaims
+            - pods
+            - replicationcontrollers
+            - secrets
+            - serviceaccounts
+            - services
+            - events
+          verbs:
+            - '*'
+        - apiGroups:
+            - apps
+            - extensions
+          resources:
+            - daemonsets
+            - deployments
+            - deployments/finalizers
+            - ingresses
+            - ingresses/status
+            - replicasets
+            - statefulsets
+          verbs:
+            - '*'
+        - apiGroups:
+            - autoscaling
+          resources:
+            - horizontalpodautoscalers
+          verbs:
+            - '*'
+        - apiGroups:
+            - policy
+          resources:
+            - poddisruptionbudgets
+          verbs:
+            - '*'
+        - apiGroups:
+            - admissionregistration.k8s.io
+          resources:
+            - mutatingwebhookconfigurations
+            - validatingwebhookconfigurations
+          verbs:
+            - '*'
+        - apiGroups:
+            - apiextensions.k8s.io
+          resources:
+            - customresourcedefinitions
+          verbs:
+            - '*'
+        - apiGroups:
+            - certmanager.k8s.io
+          resources:
+            - clusterissuers
+          verbs:
+            - '*'
+        - apiGroups:
+            - networking.k8s.io
+          resources:
+            - networkpolicies
+          verbs:
+            - '*'
+        - apiGroups:
+            - rbac.authorization.k8s.io
+          resources:
+            - clusterrolebindings
+            - clusterroles
+            - rolebindings
+            - roles
+          verbs:
+            - '*'
+        - apiGroups:
+            - authentication.istio.io
+          resources:
+            - '*'
+          verbs:
+            - '*'
+        - apiGroups:
+            - config.istio.io
+          resources:
+            - '*'
+          verbs:
+            - '*'
+        - apiGroups:
+            - networking.istio.io
+          resources:
+            - '*'
+          verbs:
+            - '*'
+        - apiGroups:
+            - rbac.istio.io
+          resources:
+            - '*'
+          verbs:
+            - '*'
+        - apiGroups:
+            - jaegertracing.io
+          resources:
+            - jaegers
+          verbs:
+            - '*'
+        - apiGroups:
+            - kiali.io
+          resources:
+            - kialis
+          verbs:
+            - '*'
+        - apiGroups:
+            - maistra.io
+          resources:
+            - '*'
+          verbs:
+            - '*'
+        - apiGroups:
+            - authentication.maistra.io
+          resources:
+            - '*'
+          verbs:
+            - '*'
+        - apiGroups:
+            - rbac.maistra.io
+          resources:
+            - '*'
+          verbs:
+            - '*'
+        - apiGroups:
+            - route.openshift.io
+          resources:
+            - routes
+            - routes/custom-host
+          verbs:
+            - '*'
+        - apiGroups:
+            - authorization.k8s.io
+          resources:
+            - subjectaccessreviews
+          verbs:
+            - create
+        - apiGroups:
+            - network.openshift.io
+          resources:
+            - clusternetworks
+          verbs:
+            - get
+        - apiGroups:
+            - network.openshift.io
+          resources:
+            - netnamespaces
+          verbs:
+            - get
+            - list
+            - watch
+            - update
+        - apiGroups:
+            - k8s.cni.cncf.io
+          resources:
+            - network-attachment-definitions
+          verbs:
+            - create
+            - delete
+            - get
+            - list
+            - patch
+            - watch
+        - apiGroups:
+            - security.openshift.io
+          resources:
+            - securitycontextconstraints
+          resourceNames:
+            - privileged
+          verbs:
+            - use
+        - apiGroups:
+            - ''
+          resources:
+            - nodes
+            - nodes/proxy
+          verbs:
+            - get
+            - list
+            - watch
+        - apiGroups:
+            - authentication.k8s.io
+          resources:
+            - tokenreviews
+          verbs:
+            - create
+        - nonResourceURLs:
+            - /metrics
+          verbs:
+            - get
+      deployments:
+      - name: istio-operator
+        spec:
+
+          replicas: 1
+          selector:
+            matchLabels:
+              name: istio-operator
+          template:
+            metadata:
+              labels:
+                name: istio-operator
+            spec:
+              serviceAccountName: istio-operator
+              volumes:
+                - name: discovery-cache
+                  emptyDir:
+                    medium: Memory
+              containers:
+                - name: istio-operator
+                  image: registry.redhat.io/openshift-service-mesh/istio-rhel8-operator:1.0.3
+                  ports:
+                    - containerPort: 11999
+                      name: validation
+                    - containerPort: 60000
+                      name: metrics
+                  command:
+                    - istio-operator
+                    - --discoveryCacheDir
+                    - /home/istio-operator/.kube/cache/discovery
+                  imagePullPolicy: Always
+                  env:
+                    - name: WATCH_NAMESPACE
+                      value: ''
+                    - name: POD_NAME
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.name
+                    - name: OPERATOR_NAME
+                      value: istio-operator
+                    - name: ISTIO_CNI_IMAGE
+                      value: registry.redhat.io/openshift-service-mesh/istio-cni-rhel8:1.0.3
+                  volumeMounts:
+                    - name: discovery-cache
+                      mountPath: /home/istio-operator/.kube/cache/discovery
+  customresourcedefinitions:
+    required:
+    - name: kialis.kiali.io
+      version: v1alpha1
+      kind: Kiali
+      displayName: Kiali
+      description:  A configuration file for a Kiali installation.
+    - name: jaegers.jaegertracing.io
+      version: v1
+      kind: Jaeger
+      displayName: Jaeger
+      description: A configuration file for a Jaeger installation.  
+    owned:
+    - name: servicemeshmemberrolls.maistra.io
+      version: v1
+      kind: ServiceMeshMemberRoll
+      displayName: Istio Service Mesh Member Roll
+      description: A list of namespaces in Service Mesh
+    - name: servicemeshcontrolplanes.maistra.io
+      version: v1
+      kind: ServiceMeshControlPlane
+      displayName: Istio Service Mesh Control Plane
+      description: An Istio control plane installation
+      specDescriptors:
+      - description: Set to true to install Kiali
+        displayName: Install Kiali
+        path: istio.kiali.enabled
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - description: Set to true to install Grafana
+        displayName: Install Grafana
+        path: istio.grafana.enabled
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - description: Set to false to disable tracing
+        displayName: Enable tracing
+        path: istio.tracing.enabled
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - description: Set to true to install the Istio 3Scale adapter
+        displayName: Install 3Scale Adapter
+        path: threeScale.enabled
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - description: Limits describes the minimum/maximum amount of compute resources required/allowed
+        displayName: Default Resource Requirements
+        path: istio.global.defaultResources
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'

--- a/registry/manifests/servicemeshoperator/1.0.4/servicemeshcontrolplanes.crd.yaml
+++ b/registry/manifests/servicemeshoperator/1.0.4/servicemeshcontrolplanes.crd.yaml
@@ -1,0 +1,40 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: servicemeshcontrolplanes.maistra.io
+spec:
+  group: maistra.io
+  names:
+    kind: ServiceMeshControlPlane
+    listKind: ServiceMeshControlPlaneList
+    plural: servicemeshcontrolplanes
+    singular: servicemeshcontrolplane
+    shortNames:
+      - smcp
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1
+  additionalPrinterColumns:
+    - JSONPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      description: Whether or not the control plane installation is up to date and
+        ready to handle requests.
+      type: string
+    - JSONPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      description: The status of the control plane installation.
+      type: string
+      priority: 1
+    - JSONPath: .status.conditions[?(@.type=="Reconciled")].status
+      name: Reconciled
+      description: Whether or not the control plane installation is up to date with
+        the latest version of this resource.
+      type: string
+      priority: 1
+    - JSONPath: .status.conditions[?(@.type=="Reconciled")].message
+      name: Reconciliation Status
+      description: The status of the reconciliation process, if the control plane
+        is not up to date with the latest version this resource.
+      type: string
+      priority: 1

--- a/registry/manifests/servicemeshoperator/1.0.4/servicemeshmemberrolls.crd.yaml
+++ b/registry/manifests/servicemeshoperator/1.0.4/servicemeshmemberrolls.crd.yaml
@@ -1,0 +1,22 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: servicemeshmemberrolls.maistra.io
+spec:
+  group: maistra.io
+  names:
+    kind: ServiceMeshMemberRoll
+    listKind: ServiceMeshMemberRollList
+    plural: servicemeshmemberrolls
+    singular: servicemeshmemberroll
+    shortNames:
+      - smmr
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1
+  additionalPrinterColumns:
+    - JSONPath: .spec.members
+      description: Namespaces that are members of this Control Plane
+      name: Members
+      type: string

--- a/registry/manifests/servicemeshoperator/1.0.4/servicemeshoperator.v1.0.4.clusterserviceversion.yaml
+++ b/registry/manifests/servicemeshoperator/1.0.4/servicemeshoperator.v1.0.4.clusterserviceversion.yaml
@@ -1,0 +1,397 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: servicemeshoperator.v1.0.4
+  namespace: placeholder
+  annotations:
+    categories: "OpenShift Optional, Integration & Delivery"
+    capabilities: "Seamless Upgrades"
+    certified: "false"
+    repository: https://github.com/maistra/istio-operator
+    description: |-
+      The OpenShift Service Mesh Operator enables you to install, configure, and manage an instance of Red Hat OpenShift Service Mesh. OpenShift Service Mesh is based on the open source Istio project.
+
+    containerImage: registry.redhat.io/openshift-service-mesh/istio-rhel8-operator:1.0.4
+    createdAt: 2020-01-07T17:54:30UTC
+    support: Red Hat, Inc. 
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "maistra.io/v1",
+          "kind": "ServiceMeshControlPlane",
+          "metadata": {
+            "name": "basic-install"
+          },
+          "spec": {
+            "istio": {
+              "gateways": {
+                "istio-egressgateway": {
+                  "autoscaleEnabled": false
+                },
+                "istio-ingressgateway": {
+                  "autoscaleEnabled": false
+                }
+              },
+              "mixer": {
+                "policy": {
+                  "autoscaleEnabled": false
+                },
+                "telemetry": {
+                  "autoscaleEnabled": false
+                }
+              },
+              "pilot": {
+                "autoscaleEnabled": false,
+                "traceSampling": 100.0
+              },
+              "kiali": {
+                "enabled": true
+              },
+              "grafana": {
+                "enabled": true
+              },
+              "tracing": {
+                "enabled": true,
+                "jaeger": {
+                  "template": "all-in-one"
+                }
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "maistra.io/v1",
+          "kind": "ServiceMeshMemberRoll",
+          "metadata": {
+            "name": "default"
+          },
+          "spec": {
+            "members": [
+              "your-project",
+              "another-of-your-projects" 
+            ]
+          }
+        }
+      ]
+spec:
+  version: 1.0.4
+  maturity: alpha
+  displayName: Red Hat OpenShift Service Mesh
+  description: |-
+    Red Hat OpenShift Service Mesh is a platform that provides behavioral insight and operational control over the service mesh, providing a uniform way to connect, secure, and monitor microservice applications. 
+  keywords: [ 'istio', 'maistra', 'servicemesh' ]
+  maintainers:
+  - name: Red Hat, OpenShift Service Mesh
+    email: istio-feedback@redhat.com
+  provider:
+    name: Red Hat, Inc.
+  links:
+  - name: Service Mesh Operator
+    url: https://github.com/Maistra/istio-operator
+  - name: Istio
+    url: https://istio.io/
+  replaces: servicemeshoperator.v1.0.3
+  installModes:
+  - type: OwnNamespace
+    supported: true
+  - type: SingleNamespace
+    supported: false
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: true
+  install:
+    strategy: deployment
+    spec:
+      clusterPermissions:
+      - serviceAccountName: istio-operator
+        rules:
+
+        - apiGroups:
+            - ''
+          resources:
+            - configmaps
+            - endpoints
+            - namespaces
+            - persistentvolumeclaims
+            - pods
+            - replicationcontrollers
+            - secrets
+            - serviceaccounts
+            - services
+            - events
+          verbs:
+            - '*'
+        - apiGroups:
+            - apps
+            - extensions
+          resources:
+            - daemonsets
+            - deployments
+            - deployments/finalizers
+            - ingresses
+            - ingresses/status
+            - replicasets
+            - statefulsets
+          verbs:
+            - '*'
+        - apiGroups:
+            - autoscaling
+          resources:
+            - horizontalpodautoscalers
+          verbs:
+            - '*'
+        - apiGroups:
+            - policy
+          resources:
+            - poddisruptionbudgets
+          verbs:
+            - '*'
+        - apiGroups:
+            - admissionregistration.k8s.io
+          resources:
+            - mutatingwebhookconfigurations
+            - validatingwebhookconfigurations
+          verbs:
+            - '*'
+        - apiGroups:
+            - apiextensions.k8s.io
+          resources:
+            - customresourcedefinitions
+          verbs:
+            - '*'
+        - apiGroups:
+            - certmanager.k8s.io
+          resources:
+            - clusterissuers
+          verbs:
+            - '*'
+        - apiGroups:
+            - networking.k8s.io
+          resources:
+            - networkpolicies
+          verbs:
+            - '*'
+        - apiGroups:
+            - rbac.authorization.k8s.io
+          resources:
+            - clusterrolebindings
+            - clusterroles
+            - rolebindings
+            - roles
+          verbs:
+            - '*'
+        - apiGroups:
+            - authentication.istio.io
+          resources:
+            - '*'
+          verbs:
+            - '*'
+        - apiGroups:
+            - config.istio.io
+          resources:
+            - '*'
+          verbs:
+            - '*'
+        - apiGroups:
+            - networking.istio.io
+          resources:
+            - '*'
+          verbs:
+            - '*'
+        - apiGroups:
+            - rbac.istio.io
+          resources:
+            - '*'
+          verbs:
+            - '*'
+        - apiGroups:
+            - jaegertracing.io
+          resources:
+            - jaegers
+          verbs:
+            - '*'
+        - apiGroups:
+            - kiali.io
+          resources:
+            - kialis
+          verbs:
+            - '*'
+        - apiGroups:
+            - maistra.io
+          resources:
+            - '*'
+          verbs:
+            - '*'
+        - apiGroups:
+            - authentication.maistra.io
+          resources:
+            - '*'
+          verbs:
+            - '*'
+        - apiGroups:
+            - rbac.maistra.io
+          resources:
+            - '*'
+          verbs:
+            - '*'
+        - apiGroups:
+            - route.openshift.io
+          resources:
+            - routes
+            - routes/custom-host
+          verbs:
+            - '*'
+        - apiGroups:
+            - authorization.k8s.io
+          resources:
+            - subjectaccessreviews
+          verbs:
+            - create
+        - apiGroups:
+            - network.openshift.io
+          resources:
+            - clusternetworks
+          verbs:
+            - get
+        - apiGroups:
+            - network.openshift.io
+          resources:
+            - netnamespaces
+          verbs:
+            - get
+            - list
+            - watch
+            - update
+        - apiGroups:
+            - k8s.cni.cncf.io
+          resources:
+            - network-attachment-definitions
+          verbs:
+            - create
+            - delete
+            - get
+            - list
+            - patch
+            - watch
+        - apiGroups:
+            - security.openshift.io
+          resources:
+            - securitycontextconstraints
+          resourceNames:
+            - privileged
+          verbs:
+            - use
+        - apiGroups:
+            - ''
+          resources:
+            - nodes
+            - nodes/proxy
+          verbs:
+            - get
+            - list
+            - watch
+        - apiGroups:
+            - authentication.k8s.io
+          resources:
+            - tokenreviews
+          verbs:
+            - create
+        - nonResourceURLs:
+            - /metrics
+          verbs:
+            - get
+      deployments:
+      - name: istio-operator
+        spec:
+
+          replicas: 1
+          selector:
+            matchLabels:
+              name: istio-operator
+          template:
+            metadata:
+              labels:
+                name: istio-operator
+            spec:
+              serviceAccountName: istio-operator
+              volumes:
+                - name: discovery-cache
+                  emptyDir:
+                    medium: Memory
+              containers:
+                - name: istio-operator
+                  image: registry.redhat.io/openshift-service-mesh/istio-rhel8-operator:1.0.4
+                  ports:
+                    - containerPort: 11999
+                      name: validation
+                    - containerPort: 60000
+                      name: metrics
+                  command:
+                    - istio-operator
+                    - --discoveryCacheDir
+                    - /home/istio-operator/.kube/cache/discovery
+                  imagePullPolicy: Always
+                  env:
+                    - name: WATCH_NAMESPACE
+                      value: ''
+                    - name: POD_NAME
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.name
+                    - name: OPERATOR_NAME
+                      value: istio-operator
+                    - name: ISTIO_CNI_IMAGE
+                      value: registry.redhat.io/openshift-service-mesh/istio-cni-rhel8:1.0.4
+                  volumeMounts:
+                    - name: discovery-cache
+                      mountPath: /home/istio-operator/.kube/cache/discovery
+  customresourcedefinitions:
+    required:
+    - name: kialis.kiali.io
+      version: v1alpha1
+      kind: Kiali
+      displayName: Kiali
+      description:  A configuration file for a Kiali installation.
+    - name: jaegers.jaegertracing.io
+      version: v1
+      kind: Jaeger
+      displayName: Jaeger
+      description: A configuration file for a Jaeger installation.  
+    owned:
+    - name: servicemeshmemberrolls.maistra.io
+      version: v1
+      kind: ServiceMeshMemberRoll
+      displayName: Istio Service Mesh Member Roll
+      description: A list of namespaces in Service Mesh
+    - name: servicemeshcontrolplanes.maistra.io
+      version: v1
+      kind: ServiceMeshControlPlane
+      displayName: Istio Service Mesh Control Plane
+      description: An Istio control plane installation
+      specDescriptors:
+      - description: Set to true to install Kiali
+        displayName: Install Kiali
+        path: istio.kiali.enabled
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - description: Set to true to install Grafana
+        displayName: Install Grafana
+        path: istio.grafana.enabled
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - description: Set to false to disable tracing
+        displayName: Enable tracing
+        path: istio.tracing.enabled
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - description: Set to true to install the Istio 3Scale adapter
+        displayName: Install 3Scale Adapter
+        path: threeScale.enabled
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - description: Limits describes the minimum/maximum amount of compute resources required/allowed
+        displayName: Default Resource Requirements
+        path: istio.global.defaultResources
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'

--- a/registry/manifests/servicemeshoperator/servicemesh.package.yaml
+++ b/registry/manifests/servicemeshoperator/servicemesh.package.yaml
@@ -4,4 +4,6 @@ channels:
   currentCSV: servicemeshoperator.v1.0.2
 - name: kabanero-0.4
   currentCSV: servicemeshoperator.v1.0.2
-defaultChannel: kabanero-0.4
+- name: kabanero-0.6
+  currentCSV: servicemeshoperator.v1.0.4
+defaultChannel: kabanero-0.6


### PR DESCRIPTION
Install
 - Tweak CatalogSource status workaround
 - Remove smcp cr.  Required smcp & smmr crs are created & owned by knative

```
NAMESPACE                 NAME      MEMBERS
knative-serving-ingress   default   [knative-serving]
---
NAMESPACE                 NAME            READY
knative-serving-ingress   basic-install   True
```

Update kabanero registry to include servicemesh 1.0.4, serverless 1.3.0
Update subscriptions to 0.6

