### PR TITLE
trim smcp

### DIFF
--- a/deploy/kabanero-customresources.yaml
+++ b/deploy/kabanero-customresources.yaml
@@ -16,44 +16,16 @@ metadata:
 spec:
   istio:
     global:
-      multitenant: true
-      proxy:
-        autoInject: disabled
-      omitSidecarInjectorConfigMap: true
       disablePolicyChecks: false
-      defaultPodDisruptionBudget:
-        enabled: false
-    istio_cni:
-      enabled: true
     gateways:
       istio-ingressgateway:
         autoscaleEnabled: false
-        type: LoadBalancer
       istio-egressgateway:
         enabled: false
-      cluster-local-gateway:
-        autoscaleEnabled: false
-        enabled: true
-        labels:
-          app: cluster-local-gateway
-          istio: cluster-local-gateway
-        ports:
-          - name: status-port
-            port: 15020
-          - name: http2
-            port: 80
-            targetPort: 8080
-          - name: https
-            port: 443
     mixer:
       enabled: false
-      policy:
-        enabled: false
-      telemetry:
-        enabled: false
     pilot:
       autoscaleEnabled: false
-      sidecar: false
     kiali:
       enabled: false
     tracing:
@@ -61,8 +33,6 @@ spec:
     prometheus:
       enabled: false
     grafana:
-      enabled: false
-    sidecarInjectorWebhook:
       enabled: false
 ---
 apiVersion: maistra.io/v1


### PR DESCRIPTION
Trim (most) of the unsupported/undocumented options that were used in our SMCP CR.
A user presumed certain options were supported, though they appear to have been deprecated.

As per either

https://docs.openshift.com/container-platform/4.3/service_mesh/service_mesh_install/customizing-installation-ossm.html#ossm-cr-parameters_customizing-installation-ossm

https://maistra.io/docs/installation/installation-options/

Prometheus is left disabled, as it is functional, yet unsupported/undocumented

We are not applying the SMCP in release-0.6, but this could be picked for prior releases.
