### PR TITLE
temporary support for images from collection hub

### DIFF
--- a/pkg/controller/kabaneroplatform/featured_collections.go
+++ b/pkg/controller/kabaneroplatform/featured_collections.go
@@ -66,6 +66,7 @@ func reconcileFeaturedStacks(ctx context.Context, k *kabanerov1alpha2.Kabanero, 
 					foundVersion = true
 					stackVersion.Pipelines = stack.Pipelines
 					stackVersion.SkipCertVerification = stack.SkipCertVerification
+					stackVersion.Images = stack.Images
 					stackResource.Spec.Versions[j] = stackVersion
 				}
 			}
@@ -109,13 +110,20 @@ func featuredStacks(k *kabanerov1alpha2.Kabanero) (map[string][]kabanerov1alpha2
 
 		// Create the stack versions
 		for _, c := range index.Stacks {
+			// The pipeline information will be in the stack, either because this is a legacy hub and the information was already there, or
+			// because we provided it at the time we read the appsody stack index (in ResolveIndex).
 			pipelines := []kabanerov1alpha2.PipelineSpec{}
 			for _, pipeline := range c.Pipelines {
 				pipelineUrl := kabanerov1alpha2.HttpsProtocolFile{Url: pipeline.Url, SkipCertVerification: pipeline.SkipCertVerification}
 				pipelines = append(pipelines, kabanerov1alpha2.PipelineSpec{Id: pipeline.Id, Sha256: pipeline.Sha256, Https: pipelineUrl})
 			}
+			// The image information will be in the stack.  Today we just support reading the legacy field from the collection hub.
+			images := []kabanerov1alpha2.Image{}
+			for _, image := range c.Images {
+				images = append(images, kabanerov1alpha2.Image{Id: image.Id, Image: image.Image})
+			}
 
-			stackMap[c.Id] = append(stackMap[c.Id], kabanerov1alpha2.StackVersion{Pipelines: pipelines, Version: c.Version})
+			stackMap[c.Id] = append(stackMap[c.Id], kabanerov1alpha2.StackVersion{Pipelines: pipelines, Version: c.Version, Images: images})
 		}
 	}
 

--- a/pkg/controller/kabaneroplatform/featured_collections_test.go
+++ b/pkg/controller/kabaneroplatform/featured_collections_test.go
@@ -138,7 +138,7 @@ func createKabanero(repositoryUrl string) *kabanerov1alpha2.Kabanero {
 }
 
 // Test that we can read a legacy CollectionHub that contains embedded
-// pipeline data.
+// pipeline and image data.
 func TestReconcileFeaturedStacks(t *testing.T) {
 	// The server that will host the pipeline zip
 	server := httptest.NewServer(stackIndexHandler{})
@@ -195,6 +195,15 @@ func TestReconcileFeaturedStacks(t *testing.T) {
 
 	if nodejsStack.Spec.Versions[0].Pipelines[0].Https.Url != defaultIndexPipeline {
 		t.Fatal(fmt.Sprintf("Expected nodejs stack pipeline zip name to be %v, but was %v", defaultIndexPipeline, nodejsStack.Spec.Versions[0].Pipelines[0].Https.Url))
+	}
+
+	if len(nodejsStack.Spec.Versions[0].Images) != 1 {
+		t.Fatal(fmt.Sprintf("Expected nodejs stack to have one image, but has %v", len(nodejsStack.Spec.Versions[0].Images)))
+	}
+
+	expectedImage := "kabanero/nodejs:0.2"
+	if nodejsStack.Spec.Versions[0].Images[0].Image != expectedImage {
+		t.Fatal(fmt.Sprintf("Expected nodejs stack image of %v, but was %v", expectedImage, nodejsStack.Spec.Versions[0].Images[0].Image))
 	}
 }
 
@@ -272,6 +281,8 @@ func TestReconcileFeaturedStacksTwoRepositories(t *testing.T) {
 		t.Fatal("Did not find stack version \"0.4.1\"")
 	}
 }
+
+// TODO: Tests where we specify the pipeline zips in the Kabanero CR instance.
 
 // Attempts to resolve the featured stacks from the default repository
 func TestResolveFeaturedStacks(t *testing.T) {
@@ -352,3 +363,5 @@ func TestResolveFeaturedStacksTwoRepositories(t *testing.T) {
 		t.Fatal(fmt.Sprintf("Expected two versions of nodejs stack, but found %v: %v", len(nodejsStackVersions), nodejsStackVersions))
 	}
 }
+
+


### PR DESCRIPTION
I'd like to temporarily support reading the image tags from a collection hub, so that users can temporarily point to a v0.5.0 collection hub and still have the image tags get set in the stack CR instance.