### PR TITLE
Fully qualify 'knativeserving' in shell scripts.

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -226,8 +226,8 @@ unset TYPE
 until [ "$STATUS" == "True" ] && [ "$TYPE" == "Ready" ]
 do
 	echo "Waiting for KnativeServing knative-serving to be ready."
-	TYPE=$(oc get knativeserving knative-serving -n knative-serving --output=jsonpath={.status.conditions[-1:].type})
-	STATUS=$(oc get knativeserving knative-serving -n knative-serving --output=jsonpath={.status.conditions[-1:].status})
+	TYPE=$(oc get knativeserving.serving.knative.dev knative-serving -n knative-serving --output=jsonpath={.status.conditions[-1:].type})
+	STATUS=$(oc get knativeserving.serving.knative.dev knative-serving -n knative-serving --output=jsonpath={.status.conditions[-1:].status})
 	sleep $SLEEP_SHORT
 done
 


### PR DESCRIPTION
The upcoming Openshift Serverless 1.4.0 release will introduce a new KnativeServing CRD under the 'operator.knative.dev' API group to align the operators with the upstream operator. To enable a smooth as possible migration, 1.4.0 will work with both the old ('serving.knative.dev') and the new API group.

This PR is to make sure Kabanero's scripts work as intended after upgrading into 1.4.0. Please refer to the docs once 1.4.0 is out on how to fully migrate an existing KnativeServing deployment to the new API group without reinstalling the entire system (if needed).