### PR TITLE
Config status

### DIFF
--- a/config/orchestrations/sso/0.1/sso.yaml
+++ b/config/orchestrations/sso/0.1/sso.yaml
@@ -143,7 +143,7 @@ spec:
           value: ""
         - name: SSO_SERVICE_PASSWORD
           value: ""
-        image: sso
+        image: {{ .ssoImage }}
         imagePullPolicy: Always
         livenessProbe:
           exec:
@@ -237,7 +237,7 @@ spec:
           value: ""
         - name: POSTGRESQL_SHARED_BUFFERS
           value: ""
-        image: postgresql
+        image: {{ .postgreImage }}
         imagePullPolicy: Always
         livenessProbe:
           initialDelaySeconds: 30

--- a/pkg/controller/kabaneroplatform/collection-operator.go
+++ b/pkg/controller/kabaneroplatform/collection-operator.go
@@ -7,6 +7,7 @@ import (
 
 	kabanerov1alpha1 "github.com/kabanero-io/kabanero-operator/pkg/apis/kabanero/v1alpha1"
 	kabanerov1alpha2 "github.com/kabanero-io/kabanero-operator/pkg/apis/kabanero/v1alpha2"
+	"github.com/go-logr/logr"
 	mf "github.com/kabanero-io/manifestival"
 	appsv1 "k8s.io/api/apps/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -23,7 +24,7 @@ const (
 )
 
 // Installs the Kabanero collection controller.
-func reconcileCollectionController(ctx context.Context, k *kabanerov1alpha2.Kabanero, c client.Client) error {
+func reconcileCollectionController(ctx context.Context, k *kabanerov1alpha2.Kabanero, c client.Client, _ logr.Logger) error {
 	logger := cclog.WithValues("Kabanero instance namespace", k.Namespace, "Kabanero instance Name", k.Name)
 	logger.Info("Reconciling Kabanero collection controller installation.")
 

--- a/pkg/controller/kabaneroplatform/landing.go
+++ b/pkg/controller/kabaneroplatform/landing.go
@@ -10,6 +10,7 @@ import (
 	kabanerov1alpha2 "github.com/kabanero-io/kabanero-operator/pkg/apis/kabanero/v1alpha2"
 	"github.com/kabanero-io/kabanero-operator/pkg/controller/kabaneroplatform/utils"
 	kabTransforms "github.com/kabanero-io/kabanero-operator/pkg/controller/transforms"
+	"github.com/go-logr/logr"
 	mf "github.com/kabanero-io/manifestival"
 	consolev1 "github.com/openshift/api/console/v1"
 	routev1 "github.com/openshift/api/route/v1"
@@ -26,7 +27,7 @@ import (
 var kllog = rlog.Log.WithName("kabanero-landing")
 
 // Deploys resources and customizes to the Openshift web console.
-func deployLandingPage(k *kabanerov1alpha2.Kabanero, c client.Client) error {
+func deployLandingPage(_ context.Context, k *kabanerov1alpha2.Kabanero, c client.Client, _ logr.Logger) error {
 	// if enable is false do not deploy the landing page
 	if k.Spec.Landing.Enable != nil && *(k.Spec.Landing.Enable) == false {
 		err := cleanupLandingPage(k, c)

--- a/pkg/controller/kabaneroplatform/sso.go
+++ b/pkg/controller/kabaneroplatform/sso.go
@@ -33,44 +33,15 @@ func reconcileSso(ctx context.Context, k *kabanerov1alpha2.Kabanero, c client.Cl
 	if err != nil {
 		return err
 	}
+
+	// Go make sure that the necessary secret has been created.
+	err = checkSecret(ctx, k, c, reqLogger)
+	if err != nil {
+		return err
+	}
 	
 	//The context which will be used to render any templates
 	templateContext := make(map[string]interface{})
-
-	// Go make sure that the necessary secret has been created.
-	if len(k.Spec.Sso.AdminSecretName) == 0 {
-		return errors.New("The SSO admin secret name must be specified in the Kabanero CR instance")
-	}
-	
-	secretInstance := &corev1.Secret{}
-	err = c.Get(context.Background(), types.NamespacedName{
-		Name:      k.Spec.Sso.AdminSecretName,
-		Namespace: k.ObjectMeta.Namespace}, secretInstance)
-
-	if err != nil {
-		if kerrors.IsNotFound(err) == false {
-			return fmt.Errorf("The SSO admin secret was not found: %v", err.Error())
-		}
-
-		return fmt.Errorf("Could not retrieve the SSO admin secret: %v", err.Error())
-	}
-
-	// Make sure the required keys are assigned.
-	ssoAdminUserName, ok := secretInstance.Data["username"]
-	if (!ok) || (len(ssoAdminUserName) == 0) {
-		return fmt.Errorf("The SSO admin secret %v does not contain key 'username'", k.Spec.Sso.AdminSecretName)
-	}
-
-	ssoAdminPassword, ok := secretInstance.Data["password"]
-	if (!ok) || (len(ssoAdminPassword) == 0) {
-		return fmt.Errorf("The SSO admin secret %v does not contain key 'password'", k.Spec.Sso.AdminSecretName)
-	}
-
-	ssoRealm, ok := secretInstance.Data["realm"]
-	if (!ok) || (len(ssoRealm) == 0) {
-		return fmt.Errorf("The SSO admin secret %v does not contain key 'realm'", k.Spec.Sso.AdminSecretName)
-	}
-	
 	templateContext["ssoAdminSecretName"] = k.Spec.Sso.AdminSecretName
 	
 	f, err := rev.OpenOrchestration("sso.yaml")
@@ -106,6 +77,46 @@ func reconcileSso(ctx context.Context, k *kabanerov1alpha2.Kabanero, c client.Cl
 	return nil
 }
 
+// Checks to make sure the secret required by the SSO configuration has
+// been created and contains the required keys.
+func checkSecret(ctx context.Context, k *kabanerov1alpha2.Kabanero, c client.Client, reqLogger logr.Logger) error {
+
+	if len(k.Spec.Sso.AdminSecretName) == 0 {
+		return errors.New("The SSO admin secret name must be specified in the Kabanero CR instance")
+	}
+	
+	secretInstance := &corev1.Secret{}
+	err := c.Get(context.Background(), types.NamespacedName{
+		Name:      k.Spec.Sso.AdminSecretName,
+		Namespace: k.ObjectMeta.Namespace}, secretInstance)
+
+	if err != nil {
+		if kerrors.IsNotFound(err) == false {
+			return fmt.Errorf("The SSO admin secret was not found: %v", err.Error())
+		}
+
+		return fmt.Errorf("Could not retrieve the SSO admin secret: %v", err.Error())
+	}
+
+	// Make sure the required keys are assigned.
+	ssoAdminUserName, ok := secretInstance.Data["username"]
+	if (!ok) || (len(ssoAdminUserName) == 0) {
+		return fmt.Errorf("The SSO admin secret %v does not contain key 'username'", k.Spec.Sso.AdminSecretName)
+	}
+
+	ssoAdminPassword, ok := secretInstance.Data["password"]
+	if (!ok) || (len(ssoAdminPassword) == 0) {
+		return fmt.Errorf("The SSO admin secret %v does not contain key 'password'", k.Spec.Sso.AdminSecretName)
+	}
+
+	ssoRealm, ok := secretInstance.Data["realm"]
+	if (!ok) || (len(ssoRealm) == 0) {
+		return fmt.Errorf("The SSO admin secret %v does not contain key 'realm'", k.Spec.Sso.AdminSecretName)
+	}
+
+	return nil
+}
+
 func disableSso(ctx context.Context, k *kabanerov1alpha2.Kabanero, c client.Client, reqLogger logr.Logger) error {
 	// Figure out what version of the orchestration we are going to use.
 	noOverrideVersion := ""
@@ -116,7 +127,7 @@ func disableSso(ctx context.Context, k *kabanerov1alpha2.Kabanero, c client.Clie
 	
 	// The context which will be used to render any templates.  Note that
 	// since we're just going to delete things, these values don't matter
-	// to much.
+	// too much.
 	templateContext := make(map[string]interface{})
 	templateContext["ssoAdminSecretName"] = "default"
 	
@@ -158,13 +169,74 @@ func getSsoStatus(k *kabanerov1alpha2.Kabanero, c client.Client, reqLogger logr.
 		return true, nil
 	}
 
-	// Determine if the SSO components are available.
+	// Make sure the configuration is correct
 	k.Status.Sso.Configured = sso_true
 	k.Status.Sso.Ready = sso_false
 	k.Status.Sso.Message = ""
 
+	err := checkSecret(context.Background(), k, c, reqLogger)
+	if err != nil {
+		k.Status.Sso.Message = err.Error()
+		return false, err
+	}
+
+	// Before checking the deployment configs, check specifically if the
+	// postgresql pod is waiting for a persistent volume (PV).
+	podList := &corev1.PodList{}
+	err = c.List(context.Background(), podList, client.InNamespace(k.GetNamespace()), client.MatchingLabels{"application": "sso", "deploymentConfig": "sso-postgresql"})
+	if err == nil {
+		reqLogger.Info(fmt.Sprintf("TDK SSO Pod list returned %v entries", len(podList.Items)))
+		for _, pod := range podList.Items {
+			reqLogger.Info(fmt.Sprintf("TDK pod name %v phase %v", pod.Name, pod.Status.Phase))
+			if pod.Status.Phase == corev1.PodPending {
+				reqLogger.Info(fmt.Sprintf("TDK condition list %v entries", len(pod.Status.Conditions)))
+				for _, condition := range pod.Status.Conditions {
+					reqLogger.Info(fmt.Sprintf("TDK condition type %v status %v reason %v", condition.Type, condition.Status, condition.Reason))
+					if (condition.Type == corev1.PodScheduled) && (condition.Status == corev1.ConditionFalse) && (condition.Reason == corev1.PodReasonUnschedulable) {
+						// There is a reason the pod cannot be scheduled.  Lets tell the user what it is.
+						err = fmt.Errorf("SSO-postgre pod %v cannot be scheduled: %v", pod.Name, condition.Message)
+						k.Status.Sso.Message = err.Error()
+						return false, err
+					}
+				}
+			}
+		}
+	} else {
+		reqLogger.Error(err, fmt.Sprintf("TDK pod list error"))
+	}
+	
+	// Determine if the postgressl SSO components are available.
+	postgreDeploymentConfigInstance := &appsv1.DeploymentConfig{}
+	err = c.Get(context.Background(), types.NamespacedName{
+		Name:      "sso-postgresql",
+		Namespace: k.ObjectMeta.Namespace}, postgreDeploymentConfigInstance)
+
+	if err != nil {
+		k.Status.Sso.Message = err.Error()
+		return false, err
+	}
+
+	foundAvailableCondition := false
+	for _, condition := range postgreDeploymentConfigInstance.Status.Conditions {
+		if condition.Type == appsv1.DeploymentAvailable {
+			if condition.Status != corev1.ConditionTrue {
+				err = fmt.Errorf("The SSO-Postgre DeploymentConfig reported that it is not available: %v", condition.Message)
+				k.Status.Sso.Message = err.Error()
+				return false, err
+			}
+			foundAvailableCondition = true
+		}
+	}
+
+	if foundAvailableCondition == false {
+		err = errors.New("The SSO-Postgre DeploymentConfig did not contain an 'Available' condition")
+		k.Status.Sso.Message = err.Error()
+		return false, err
+	}
+
+	// Check if the SSO components are available
 	ssoDeploymentConfigInstance := &appsv1.DeploymentConfig{}
-	err := c.Get(context.Background(), types.NamespacedName{
+	err = c.Get(context.Background(), types.NamespacedName{
 		Name:      "sso",
 		Namespace: k.ObjectMeta.Namespace}, ssoDeploymentConfigInstance)
 
@@ -173,7 +245,7 @@ func getSsoStatus(k *kabanerov1alpha2.Kabanero, c client.Client, reqLogger logr.
 		return false, err
 	}
 
-	foundAvailableCondition := false
+	foundAvailableCondition = false
 	for _, condition := range ssoDeploymentConfigInstance.Status.Conditions {
 		if condition.Type == appsv1.DeploymentAvailable {
 			if condition.Status != corev1.ConditionTrue {
@@ -191,34 +263,6 @@ func getSsoStatus(k *kabanerov1alpha2.Kabanero, c client.Client, reqLogger logr.
 		return false, err
 	}
 
-	// Now check the postgresql DeploymentConfig in the same way.
-	postgreDeploymentConfigInstance := &appsv1.DeploymentConfig{}
-	err = c.Get(context.Background(), types.NamespacedName{
-		Name:      "sso-postgresql",
-		Namespace: k.ObjectMeta.Namespace}, postgreDeploymentConfigInstance)
-
-	if err != nil {
-		k.Status.Sso.Message = err.Error()
-		return false, err
-	}
-
-	foundAvailableCondition = false
-	for _, condition := range postgreDeploymentConfigInstance.Status.Conditions {
-		if condition.Type == appsv1.DeploymentAvailable {
-			if condition.Status != corev1.ConditionTrue {
-				err = fmt.Errorf("The SSO-Postgre DeploymentConfig reported that it is not available: %v", condition.Message)
-				k.Status.Sso.Message = err.Error()
-				return false, err
-			}
-			foundAvailableCondition = true
-		}
-	}
-
-	if foundAvailableCondition == false {
-		err = errors.New("The SSO-Postgre DeploymentConfig did not contain an 'Available' condition")
-		k.Status.Sso.Message = err.Error()
-		return false, err
-	}
 
 	k.Status.Sso.Ready = sso_true
 	return true, nil

--- a/pkg/controller/kabaneroplatform/stack-controller.go
+++ b/pkg/controller/kabaneroplatform/stack-controller.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	kabanerov1alpha2 "github.com/kabanero-io/kabanero-operator/pkg/apis/kabanero/v1alpha2"
+	"github.com/go-logr/logr"
 	mf "github.com/kabanero-io/manifestival"
 	appsv1 "k8s.io/api/apps/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -22,7 +23,7 @@ const (
 )
 
 // Installs the Kabanero stack controller.
-func reconcileStackController(ctx context.Context, k *kabanerov1alpha2.Kabanero, c client.Client) error {
+func reconcileStackController(ctx context.Context, k *kabanerov1alpha2.Kabanero, c client.Client, _ logr.Logger) error {
 	logger := sclog.WithValues("Kabanero instance namespace", k.Namespace, "Kabanero instance Name", k.Name)
 	logger.Info("Reconciling Kabanero stack controller installation.")
 


### PR DESCRIPTION
Fixes #447 
A few things here:
* Standardized the component startup function so that we can make a list of startup functions
* Update the status on any component startup failure
* Specific error for SSO when the PVC can't be bound
* Hack to stop the SSO DeploymentConfig objects from constantly regenerating their configuration.  The image field is over-written by whatever controller is watching DeploymentConfig, and the Kab operator puts it back.  etc etc etc