### PR TITLE
check stack index has image defined

### DIFF
--- a/pkg/controller/kabaneroplatform/testdata/appsody-index.yaml
+++ b/pkg/controller/kabaneroplatform/testdata/appsody-index.yaml
@@ -20,6 +20,7 @@ stacks:
   templates:
   - id: default
     url: https://github.com/appsody/stacks/releases/download/java-microprofile-v0.2.21/incubator.java-microprofile.v0.2.21.templates.default.tar.gz
+  image: docker.io/appsody/java-microprofile:0.2.21
 - id: nodejs
   name: Node.js
   version: 0.3.2
@@ -37,3 +38,4 @@ stacks:
   requirements:
     docker-version: '>= 17.09.0'
     appsody-version: '>= 0.2.7'
+  image: docker.io/appsody/nodejs:0.3.2

--- a/pkg/controller/stack/resolver.go
+++ b/pkg/controller/stack/resolver.go
@@ -33,7 +33,7 @@ func ResolveIndex(repoConf kabanerov1alpha2.RepositoryConfig, pipelines []Pipeli
 		return nil, err
 	}
 
-	processIndexPostRead(&index, pipelines, triggers, imagePrefix)
+	processIndexPostRead(&index, pipelines, triggers)
 
 	index.URL = url
 
@@ -41,7 +41,7 @@ func ResolveIndex(repoConf kabanerov1alpha2.RepositoryConfig, pipelines []Pipeli
 }
 
 // Updates the loaded stack index structure for compliance with the current implementation.
-func processIndexPostRead(index *Index, pipelines []Pipelines, triggers []Trigger, imagePrefix string) error {
+func processIndexPostRead(index *Index, pipelines []Pipelines, triggers []Trigger) error {
 	// Add common pipelines and image.
 	
 	tmpstack := index.Stacks[:0]

--- a/pkg/controller/stack/resolver_test.go
+++ b/pkg/controller/stack/resolver_test.go
@@ -32,7 +32,7 @@ func TestResolveIndex(t *testing.T) {
 func TestResolveIndexForStacks(t *testing.T) {
 	repoConfig := kabanerov1alpha2.RepositoryConfig{
 		Name:  "openLibertyTest",
-		Https: kabanerov1alpha2.HttpsProtocolFile{Url: "https://github.com/appsody/stacks/releases/download/java-openliberty-v0.1.2/incubator-index.yaml"},
+		Https: kabanerov1alpha2.HttpsProtocolFile{Url: "https://github.com/appsody/stacks/releases/download/java-spring-boot2-v0.3.23/incubator-index.yaml"},
 	}
 
 	pipelines := []Pipelines{{Id: "testPipeline", Sha256: "1234567890", Url: "https://github.com/kabanero-io/collections/releases/download/0.5.0-rc.2/incubator.common.pipeline.default.tar.gz"}}
@@ -49,8 +49,9 @@ func TestResolveIndexForStacks(t *testing.T) {
 
 	// Validate pipeline entries.
 	numStacks := len(index.Stacks)
+	
 	if len(index.Stacks[numStacks-numStacks].Pipelines) == 0 {
-		t.Fatal("Index.Stacks[0].Pipelines is empty. An entry was expected")
+		t.Fatal("Index.Stacks[0].Pipelines is empty. An entry was expected.")
 	}
 
 	c0p0 := index.Stacks[numStacks-numStacks].Pipelines[0]

--- a/pkg/controller/stack/stack.go
+++ b/pkg/controller/stack/stack.go
@@ -8,6 +8,7 @@ type Stack struct {
 	DefaultTemplate  string        `yaml:"default-template,omitempty"`
 	Description      string        `yaml:"description,omitempty"`
 	Id               string        `yaml:"id,omitempty"`
+	Image            string        `yaml:"image,omitempty"`
 	Images           []Images      `yaml:"images,omitempty"`
 	License          string        `yaml:"license,omitempty"`
 	Maintainers      []Maintainers `yaml:"maintainers,omitempty"`


### PR DESCRIPTION
Add `Image` to the stack type, the singleton is a difference between some collections and stack indexes.

Update the target URL for the resolver test to a more recent appsody/stack release

If the index contains a stack without Image or Images[] defined, remove it from the index.
If the index contains a stack with a singleton, assign it to the Images list
If the index contains and Images list, but does not defined Images[].Image, remove it from the index

The stack admission webhook can or could deal with rejecting incomplete stacks as well.

