### PR TITLE
fix db volume mount

### DIFF
--- a/config/orchestrations/sso/0.1/sso.yaml
+++ b/config/orchestrations/sso/0.1/sso.yaml
@@ -273,7 +273,7 @@ spec:
           initialDelaySeconds: 5
           timeoutSeconds: 1
         volumeMounts:
-        - mountPath: /var/lib/pgsql/data:z
+        - mountPath: /var/lib/pgsql/data
           name: sso-postgresql-pvol
       terminationGracePeriodSeconds: 60
       volumes:
@@ -287,7 +287,7 @@ spec:
       - sso-postgresql
       from:
         kind: ImageStreamTag
-        name: postgresql:10
+        name: postgresql:9.6
         namespace: openshift
     type: ImageChange
   - type: ConfigChange


### PR DESCRIPTION
fixes a bug where the db is writing to /var/lib/pgsql/data but pv is mounted to /var/lib/pgsql/data:z which prevents data from being persisted across pod restarts.