### PR TITLE
v0.6.0-rc.1

### DIFF
--- a/config/samples/default.yaml
+++ b/config/samples/default.yaml
@@ -4,8 +4,13 @@ metadata:
   name: kabanero
 spec:
   version: "0.6.0"
-  collections: 
+  stacks: 
     repositories: 
     - name: central
-      url: https://github.com/kabanero-io/collections/releases/download/0.5.0/kabanero-index.yaml
-      activateDefaultCollections: true
+      https:
+        url: https://github.com/kabanero-io/collections/releases/download/0.5.0/kabanero-index.yaml
+    pipelines:
+    - id: default
+      sha256: 14d59b7ebae113c18fb815c2ccfd8a846c5fbf91d926ae92e0017ca5caf67c95
+      https:
+        url: https://github.com/kabanero-io/kabanero-pipelines/releases/download/0.6.0-rc1/default-kabanero-pipelines.tar.gz

--- a/config/samples/full.yaml
+++ b/config/samples/full.yaml
@@ -21,10 +21,10 @@ spec:
 
     # Overrides the image as a separate repository or tag
     repository: kabanero/kabanero-command-line-services
-    tag: "0.6.0-rc.2"
+    tag: "0.6.0-rc.3"
 
     # Overrides the image uri
-    image: kabanero/kabanero-command-line-services:0.6.0-rc.2
+    image: kabanero/kabanero-command-line-services:0.6.0-rc.3
 
     # Indicates the token expiration time 
     # Specify a positive integer followed by a unit of time, which can be hours (h), minutes (m), or seconds (s). 
@@ -34,25 +34,25 @@ spec:
 
   collectionController:
     # Overrides the setting for version on this component
-    version: "0.6.0-alpha.5"
+    version: "0.6.0-rc.1"
 
     # Overrides the image as a separate repository or tag
     repository: kabanero/kabaner-operator-collection-controller
-    tag: "0.6.0-alpha.5"
+    tag: "0.6.0-rc.1"
 
     # Overrides the image uri
-    image: kabanero/kabanero-operator-collection-controller:0.6.0-alpha.5
+    image: kabanero/kabanero-operator-collection-controller:0.6.0-rc.1
 
   stackController:
     # Overrides the setting for version on this component
-    version: "0.6.0-alpha.5"
+    version: "0.6.0-rc.1"
 
     # Overrides the image as a separate repository or tag
     repository: kabanero/kabaner-operator-stack-controller
-    tag: "0.6.0-alpha.5"
+    tag: "0.6.0-rc.1"
 
     # Overrides the image uri
-    image: kabanero/kabanero-operator-stack-controller:0.6.0-alpha.5
+    image: kabanero/kabanero-operator-stack-controller:0.6.0-rc.1
 
   landing:
     # The landing page is enabled by default. To disable specify false.
@@ -60,14 +60,14 @@ spec:
 
   admissionControllerWebhook:
     # Overrides the setting for version on this component
-    version: "0.6.0-alpha.5"
+    version: "0.6.0-rc.1"
 
     # Overrides the image as a separate repository or tag
     repository: kabanero/kabanero-operator-admission-webhook
-    tag: "0.6.0-alpha.5"
+    tag: "0.6.0-rc.1"
 
     # Overrides the image uri
-    image: kabanero/kabanero-operator-admission-webhook:0.6.0-alpha.5
+    image: kabanero/kabanero-operator-admission-webhook:0.6.0-rc.1
     
   codeReadyWorkspaces:
     # CodeReadyWorkspaces CR instance deployment is disabled by default. To enable it, set the enable value to true. 
@@ -109,16 +109,11 @@ spec:
     - name: incubator
       https:
         url: https://github.com/kabanero-io/collections/releases/download/0.5.0/kabanero-index.yaml
-
-        # Sets the collection resource's initial desiredState value to active or inactive when 
-        # the CR instance is initially deployed. Post CR instance deployment, updates to 
-        # a collection's desired state can be done by editing each collection resource manually.
-        # A collection's desiredState value of active or inactive is what determines whether the 
-        # assets associated with a collection object are activated or deactived.
-        # Setting activateDefaultCollections to true sets the collection's initial desiredState to "active". 
-        # Setting activateDefaultCollections to false sets the collection's initial desiredState to "inactive".
-        # ActivateDefaultCollections' default value is false.
-        activateDefaultCollections: true
+    pipelines:
+    - id: default
+      sha256: 14d59b7ebae113c18fb815c2ccfd8a846c5fbf91d926ae92e0017ca5caf67c95
+      https:
+        url: https://github.com/kabanero-io/kabanero-pipelines/releases/download/0.6.0-rc1/default-kabanero-pipelines.tar.gz
 
   # The information in the Github section is used by the Kabanero CLI to
   # perform user to role mapping when accessing the collection.

--- a/config/versions.yaml
+++ b/config/versions.yaml
@@ -18,9 +18,9 @@ kabanero:
     cli-services: "0.6.0"
     landing: "0.5.0"
     events: "0.1.0"
-    collection-controller: "0.6.0-alpha.5"
-    stack-controller: "0.6.0-alpha.5"
-    admission-webhook: "0.6.0-alpha.5"
+    collection-controller: "0.6.0-rc.1"
+    stack-controller: "0.6.0-rc.1"
+    admission-webhook: "0.6.0-rc.1"
     sso: "7.3.2"
     codeready-workspaces: "0.6.0"
 
@@ -37,7 +37,7 @@ related-software:
     orchestrations: "orchestrations/cli-services/0.1"
     identifiers:
       repository: "kabanero/kabanero-command-line-services"
-      tag: "0.6.0-rc.2"
+      tag: "0.6.0-rc.3"
 
   codeready-workspaces:
   - version: "0.6.0"
@@ -54,25 +54,25 @@ related-software:
       tag: "0.1"
 
   collection-controller: 
-  - version: "0.6.0-alpha.5"
+  - version: "0.6.0-rc.1"
     orchestrations: "orchestrations/collection-controller/0.1"
     identifiers:
       repository: "kabanero/kabanero-operator-collection-controller"
-      tag: "0.6.0-alpha.5"
+      tag: "0.6.0-rc.1"
 
   stack-controller: 
-  - version: "0.6.0-alpha.5"
+  - version: "0.6.0-rc.1"
     orchestrations: "orchestrations/stack-controller/0.1"
     identifiers:
       repository: "kabanero/kabanero-operator-stack-controller"
-      tag: "0.6.0-alpha.5"
+      tag: "0.6.0-rc.1"
 
   admission-webhook:
-  - version: "0.6.0-alpha.5"
+  - version: "0.6.0-rc.1"
     orchestrations: "orchestrations/admission-webhook/0.2"
     identifiers:
       repository: "kabanero/kabanero-operator-admission-webhook"
-      tag: "0.6.0-alpha.5"
+      tag: "0.6.0-rc.1"
 
   sso:
   - version: "7.3.2"

--- a/deploy/crds/kabanero.io_kabaneros_crd.yaml
+++ b/deploy/crds/kabanero.io_kabaneros_crd.yaml
@@ -359,7 +359,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: true
+    storage: false
   - name: v1alpha2
     schema:
       openAPIV3Schema:
@@ -791,4 +791,4 @@ spec:
             type: object
         type: object
     served: true
-    storage: false
+    storage: true

--- a/registry/manifests/kabanero-operator/0.6.0/kabanero-operator.v0.6.0.clusterserviceversion.yaml
+++ b/registry/manifests/kabanero-operator/0.6.0/kabanero-operator.v0.6.0.clusterserviceversion.yaml
@@ -31,6 +31,15 @@ metadata:
                     "url": "https://github.com/kabanero-io/collections/releases/download/0.5.0/kabanero-index.yaml"
                   }
                 }
+              ],
+              "pipelines": [
+                {
+                  "id": "default",
+                  "sha256": "14d59b7ebae113c18fb815c2ccfd8a846c5fbf91d926ae92e0017ca5caf67c95",
+                  "https": {
+                    "url": "https://github.com/kabanero-io/kabanero-pipelines/releases/download/0.6.0-rc1/default-kabanero-pipelines.tar.gz"
+                  }
+                }
               ]
             }
           }
@@ -60,9 +69,9 @@ metadata:
                 "repositoryUrl": "https://github.com/kabanero-io/collections/releases/download/0.5.0/kabanero-index.yaml",
                 "pipelines": [
                   { "id": "default",
-                    "sha256": "14285a7f0bb152759b3e2141db19d72ea1f94f01bbf5ffbf866cab4e60e093dd",
+                    "sha256": "14d59b7ebae113c18fb815c2ccfd8a846c5fbf91d926ae92e0017ca5caf67c95",
                     "https": {
-                      "url": "https://github.com/kabanero-io/collections/releases/download/0.5.0/incubator.common.pipeline.default.tar.gz"
+                      "url": "https://github.com/kabanero-io/kabanero-pipelines/releases/download/0.6.0-rc1/default-kabanero-pipelines.tar.gz"
                     }
                   }
                 ],


### PR DESCRIPTION
* Use the new pipelines release
* Still no stack index, so using collection hub 0.5.0
* 0.6.0-rc.3 of the CLI service
* v1alpha2 kabanero is stored (we're committed)