### PR TITLE
mark kabanero v1alpha2 as storage version

### DIFF
--- a/pkg/apis/kabanero/v1alpha2/kabanero_types.go
+++ b/pkg/apis/kabanero/v1alpha2/kabanero_types.go
@@ -348,6 +348,7 @@ type SsoStatus struct {
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".status.kabaneroInstance.version",description="Kabanero operator instance version."
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.kabaneroInstance.ready",description="Kabanero operator instance readiness status. The status is directly correlated to the availability of the operator's resources dependencies."
 // +kubebuilder:resource:path=kabaneros,scope=Namespaced
+// +kubebuilder:storageversion
 type Kabanero struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
The build was resetting the storage version, marking v1alpha1 as the storage version, when it should be v1alpha2.  @dacleyra found the annotation that kubebuilder uses to determine what the storage version should be.  We should be explicitly setting v1alpha2 as the storage version.