### PR TITLE
Set the OpenShift project for codewind to kabanero

### DIFF
--- a/config/orchestrations/codeready-workspaces/0.1/codeready-workspaces-cr.yaml
+++ b/config/orchestrations/codeready-workspaces/0.1/codeready-workspaces-cr.yaml
@@ -43,6 +43,7 @@ spec:
       CHE_INFRA_KUBERNETES_WORKSPACE__START__TIMEOUT__MIN: "5"
       CHE_LIMITS_WORKSPACE_IDLE_TIMEOUT: "0"
       CHE_WORKSPACE_PLUGIN__BROKER_WAIT__TIMEOUT__MIN: "15"
+      CHE_INFRA_OPENSHIFT_PROJECT: kabanero
   database:
     # when set to true, the operator skips deploying Postgres, and passes connection details of existing DB to Che server
     # otherwise a Postgres deployment is created


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

Fixes https://github.com/kabanero-io/kabanero-operator/issues/505

I found that when CRW is enabled with OpenShift oAuth, it creates workspaces in randomly generated namespaces, rather than `kabanero`, which is where the necessary roles for Codewind was created. To fix this, this PR adds the following property to CodeReady Workspaces: `CHE_INFRA_OPENSHIFT_PROJECT: kabanero`. This is to ensure that workspaces that CRW creates will be in the `kabanero` namespace, rather than a randomly generated namespace.