### PR TITLE
Use manifestival/manifestival instead of kabanero-io/manifestival

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,9 +8,10 @@ require (
 	github.com/go-openapi/spec v0.19.4
 	github.com/google/go-cmp v0.3.1
 	github.com/google/go-github/v29 v29.0.3
-	github.com/kabanero-io/manifestival v0.0.0-20191230200607-194733cd27d9
 	github.com/knative/pkg v0.0.0-20190817231834-12ee58e32cc8 // indirect
 	github.com/knative/serving-operator v0.0.0-20190702004031-e30377b852ff
+	github.com/manifestival/controller-runtime-client v0.1.1-0.20200218204725-1af9550ddf8f
+	github.com/manifestival/manifestival v0.1.1-0.20200219193505-fabb889b98f5
 	github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible
 	github.com/operator-framework/operator-lifecycle-manager v3.11.0+incompatible
 	github.com/operator-framework/operator-sdk v0.15.1

--- a/go.sum
+++ b/go.sum
@@ -503,8 +503,6 @@ github.com/jsonnet-bundler/jsonnet-bundler v0.1.0/go.mod h1:YKsSFc9VFhhLITkJS3X2
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
-github.com/kabanero-io/manifestival v0.0.0-20191230200607-194733cd27d9 h1:xjLNYfHbT7XGG/PbAJzbHyFO0zh4f/sBgOj3V5yq+ts=
-github.com/kabanero-io/manifestival v0.0.0-20191230200607-194733cd27d9/go.mod h1:ajnXZ2Z+sYowGF8J6ZxjZW0fqNeOiYS7Pn8+OYMd334=
 github.com/kardianos/osext v0.0.0-20170510131534-ae77be60afb1/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
 github.com/karrick/godirwalk v1.7.5/go.mod h1:2c9FRhkDxdIbgkOnCEvnSWs71Bhugbl46shStcFDJ34=
@@ -553,6 +551,10 @@ github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.0 h1:aizVhC/NAAcKWb+5QsU1iNOZb4Yws5UO2I+aIprQITM=
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
+github.com/manifestival/controller-runtime-client v0.1.1-0.20200218204725-1af9550ddf8f h1:1tes5O5eRVhzX8+4DMKmYHgzSfTG+t3p9SdEMa1/Etg=
+github.com/manifestival/controller-runtime-client v0.1.1-0.20200218204725-1af9550ddf8f/go.mod h1:xK5vtLpVxkFQKIFk4ABGln7fpUKVf2UHybbP9wPWetw=
+github.com/manifestival/manifestival v0.1.1-0.20200219193505-fabb889b98f5 h1:EUT0ZE7jQFR4paHrVSGWnLUSPxCh+HgOtKT1tHjW6lY=
+github.com/manifestival/manifestival v0.1.1-0.20200219193505-fabb889b98f5/go.mod h1:jlYRi+Y1LEGR94OSBXU887tNJ7Y317sHd/DcNAHE2eI=
 github.com/maorfr/helm-plugin-utils v0.0.0-20181205064038-588190cb5e3b/go.mod h1:p3gwmRSFqbWw6plBpR0sKl3n3vpu8kX70gvCJKMvvCA=
 github.com/markbates/inflect v1.0.4/go.mod h1:1fR9+pO2KHEO9ZRtto13gDwwZaAKstQzferVeWqbgNs=
 github.com/marten-seemann/qtls v0.2.3/go.mod h1:xzjG7avBwGGbdZ8dTGxlBnLArsVKLvwmjgmPuiQEcYk=

--- a/pkg/controller/kabaneroplatform/admission_controller_webhook.go
+++ b/pkg/controller/kabaneroplatform/admission_controller_webhook.go
@@ -85,7 +85,7 @@ func reconcileAdmissionControllerWebhook(ctx context.Context, k *kabanerov1alpha
 		return err
 	}
 
-	mOrig, err := mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(c)))
+	mOrig, err := mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(c)), mf.UseLogger(reqLogger.WithName("manifestival")))
 	if err != nil {
 		return err
 	}
@@ -145,7 +145,7 @@ func reconcileAdmissionControllerWebhook(ctx context.Context, k *kabanerov1alpha
 			return err
 		}
 
-		m, err := mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(c)))
+		m, err := mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(c)), mf.UseLogger(reqLogger.WithName("manifestival")))
 		if err != nil {
 			return err
 		}
@@ -161,7 +161,7 @@ func reconcileAdmissionControllerWebhook(ctx context.Context, k *kabanerov1alpha
 
 // Removes the admission webhook server, as well as the resources
 // created by controller-runtime that support the webhook.
-func cleanupAdmissionControllerWebhook(k *kabanerov1alpha2.Kabanero, c client.Client) error {
+func cleanupAdmissionControllerWebhook(k *kabanerov1alpha2.Kabanero, c client.Client, reqLogger logr.Logger) error {
 
 	rev, err := resolveSoftwareRevision(k, "admission-webhook", k.Spec.AdmissionControllerWebhook.Version)
 	if err != nil {
@@ -188,7 +188,7 @@ func cleanupAdmissionControllerWebhook(k *kabanerov1alpha2.Kabanero, c client.Cl
 		return err
 	}
 
-	mOrig, err := mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(c)))
+	mOrig, err := mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(c)), mf.UseLogger(reqLogger.WithName("manifestival")))
 	if err != nil {
 		return err
 	}
@@ -199,11 +199,10 @@ func cleanupAdmissionControllerWebhook(k *kabanerov1alpha2.Kabanero, c client.Cl
 		return err
 	}
 
+	// Manifestival ignores the "NotFound" error for us.
 	err = m.Delete()
 	if err != nil {
-		if !errors.IsNotFound(err) {
-			return err
-		}
+		return err
 	}
 
 	// The webhook configs are only created by manifestival later than Kabanero 0.4.0.
@@ -218,16 +217,15 @@ func cleanupAdmissionControllerWebhook(k *kabanerov1alpha2.Kabanero, c client.Cl
 			return err
 		}
 
-		m, err := mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(c)))
+		m, err := mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(c)), mf.UseLogger(reqLogger.WithName("manifestival")))
 		if err != nil {
 			return err
 		}
 
+		// Manifestival ignores the "NotFound" error for us.
 		err = m.Delete()
 		if err != nil {
-			if !errors.IsNotFound(err) {
-				return err
-			}
+			return err
 		}
 	}
 

--- a/pkg/controller/kabaneroplatform/admission_controller_webhook.go
+++ b/pkg/controller/kabaneroplatform/admission_controller_webhook.go
@@ -11,7 +11,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	mf "github.com/kabanero-io/manifestival"
+	mf "github.com/manifestival/manifestival"
+	mfc "github.com/manifestival/controller-runtime-client"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -84,7 +85,7 @@ func reconcileAdmissionControllerWebhook(ctx context.Context, k *kabanerov1alpha
 		return err
 	}
 
-	m, err := mf.FromReader(strings.NewReader(s), c)
+	mOrig, err := mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(c)))
 	if err != nil {
 		return err
 	}
@@ -94,12 +95,12 @@ func reconcileAdmissionControllerWebhook(ctx context.Context, k *kabanerov1alpha
 		mf.InjectNamespace(k.GetNamespace()),
 	}
 
-	err = m.Transform(transforms...)
+	m, err := mOrig.Transform(transforms...)
 	if err != nil {
 		return err
 	}
 
-	err = m.ApplyAll()
+	err = m.Apply()
 	if err != nil {
 		return err
 	}
@@ -144,12 +145,12 @@ func reconcileAdmissionControllerWebhook(ctx context.Context, k *kabanerov1alpha
 			return err
 		}
 
-		m, err := mf.FromReader(strings.NewReader(s), c)
+		m, err := mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(c)))
 		if err != nil {
 			return err
 		}
 
-		err = m.ApplyAll()
+		err = m.Apply()
 		if err != nil {
 			return err
 		}
@@ -187,18 +188,18 @@ func cleanupAdmissionControllerWebhook(k *kabanerov1alpha2.Kabanero, c client.Cl
 		return err
 	}
 
-	m, err := mf.FromReader(strings.NewReader(s), c)
+	mOrig, err := mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(c)))
 	if err != nil {
 		return err
 	}
 
 	transforms := []mf.Transformer{mf.InjectNamespace(k.GetNamespace())}
-	err = m.Transform(transforms...)
+	m, err := mOrig.Transform(transforms...)
 	if err != nil {
 		return err
 	}
 
-	err = m.DeleteAll()
+	err = m.Delete()
 	if err != nil {
 		if !errors.IsNotFound(err) {
 			return err
@@ -217,12 +218,12 @@ func cleanupAdmissionControllerWebhook(k *kabanerov1alpha2.Kabanero, c client.Cl
 			return err
 		}
 
-		m, err := mf.FromReader(strings.NewReader(s), c)
+		m, err := mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(c)))
 		if err != nil {
 			return err
 		}
 
-		err = m.DeleteAll()
+		err = m.Delete()
 		if err != nil {
 			if !errors.IsNotFound(err) {
 				return err

--- a/pkg/controller/kabaneroplatform/cli.go
+++ b/pkg/controller/kabaneroplatform/cli.go
@@ -55,7 +55,7 @@ func reconcileKabaneroCli(ctx context.Context, k *kabanerov1alpha2.Kabanero, cl 
 		return err
 	}
 
-	mOrig, err := mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(cl)))
+	mOrig, err := mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(cl)), mf.UseLogger(reqLogger.WithName("manifestival")))
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/kabaneroplatform/cli.go
+++ b/pkg/controller/kabaneroplatform/cli.go
@@ -13,7 +13,8 @@ import (
 	"github.com/go-logr/logr"
 	kabanerov1alpha2 "github.com/kabanero-io/kabanero-operator/pkg/apis/kabanero/v1alpha2"
 	kabTransforms "github.com/kabanero-io/kabanero-operator/pkg/controller/transforms"
-	mf "github.com/kabanero-io/manifestival"
+	mf "github.com/manifestival/manifestival"
+	mfc "github.com/manifestival/controller-runtime-client"
 	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -54,7 +55,7 @@ func reconcileKabaneroCli(ctx context.Context, k *kabanerov1alpha2.Kabanero, cl 
 		return err
 	}
 
-	m, err := mf.FromReader(strings.NewReader(s), cl)
+	mOrig, err := mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(cl)))
 	if err != nil {
 		return err
 	}
@@ -114,12 +115,12 @@ func reconcileKabaneroCli(ctx context.Context, k *kabanerov1alpha2.Kabanero, cl 
 		transforms = append(transforms, kabTransforms.AddEnvVariable("JwtExpiration", "1440m"))
 	}
 
-	err = m.Transform(transforms...)
+	m, err := mOrig.Transform(transforms...)
 	if err != nil {
 		return err
 	}
 
-	err = m.ApplyAll()
+	err = m.Apply()
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/kabaneroplatform/codereadyworkspaces.go
+++ b/pkg/controller/kabaneroplatform/codereadyworkspaces.go
@@ -291,7 +291,7 @@ func processCRWYaml(ctx context.Context, k *kabanerov1alpha2.Kabanero, rev versi
 		return err
 	}
 
-	mOrig, err := mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(c)))
+	mOrig, err := mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(c)), mf.UseLogger(rlog.Log.WithName("manifestival")))
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/kabaneroplatform/collection-operator.go
+++ b/pkg/controller/kabaneroplatform/collection-operator.go
@@ -8,7 +8,8 @@ import (
 	kabanerov1alpha1 "github.com/kabanero-io/kabanero-operator/pkg/apis/kabanero/v1alpha1"
 	kabanerov1alpha2 "github.com/kabanero-io/kabanero-operator/pkg/apis/kabanero/v1alpha2"
 	"github.com/go-logr/logr"
-	mf "github.com/kabanero-io/manifestival"
+	mf "github.com/manifestival/manifestival"
+	mfc "github.com/manifestival/controller-runtime-client"
 	appsv1 "k8s.io/api/apps/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	rlog "sigs.k8s.io/controller-runtime/pkg/log"
@@ -53,7 +54,7 @@ func reconcileCollectionController(ctx context.Context, k *kabanerov1alpha2.Kaba
 		return err
 	}
 
-	m, err := mf.FromReader(strings.NewReader(s), c)
+	mOrig, err := mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(c)))
 	if err != nil {
 		return err
 	}
@@ -63,12 +64,12 @@ func reconcileCollectionController(ctx context.Context, k *kabanerov1alpha2.Kaba
 		mf.InjectNamespace(k.GetNamespace()),
 	}
 
-	err = m.Transform(transforms...)
+	m, err := mOrig.Transform(transforms...)
 	if err != nil {
 		return err
 	}
 
-	err = m.ApplyAll()
+	err = m.Apply()
 	if err != nil {
 		return err
 	}
@@ -89,12 +90,12 @@ func reconcileCollectionController(ctx context.Context, k *kabanerov1alpha2.Kaba
 		return err
 	}
 
-	m, err = mf.FromReader(strings.NewReader(s), c)
+	mOrig, err = mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(c)))
 	if err != nil {
 		return err
 	}
 
-	err = m.ApplyAll()
+	err = mOrig.Apply()
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/kabaneroplatform/collection-operator.go
+++ b/pkg/controller/kabaneroplatform/collection-operator.go
@@ -54,7 +54,7 @@ func reconcileCollectionController(ctx context.Context, k *kabanerov1alpha2.Kaba
 		return err
 	}
 
-	mOrig, err := mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(c)))
+	mOrig, err := mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(c)), mf.UseLogger(logger.WithName("manifestival")))
 	if err != nil {
 		return err
 	}
@@ -90,7 +90,7 @@ func reconcileCollectionController(ctx context.Context, k *kabanerov1alpha2.Kaba
 		return err
 	}
 
-	mOrig, err = mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(c)))
+	mOrig, err = mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(c)), mf.UseLogger(logger.WithName("manifestival")))
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/kabaneroplatform/events.go
+++ b/pkg/controller/kabaneroplatform/events.go
@@ -7,7 +7,8 @@ import (
 	"fmt"
 	"github.com/go-logr/logr"
 	kabanerov1alpha2 "github.com/kabanero-io/kabanero-operator/pkg/apis/kabanero/v1alpha2"
-	mf "github.com/kabanero-io/manifestival"
+	mf "github.com/manifestival/manifestival"
+	mfc "github.com/manifestival/controller-runtime-client"
 	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -51,7 +52,7 @@ func reconcileEvents(ctx context.Context, k *kabanerov1alpha2.Kabanero, cl clien
 		return err
 	}
 
-	m, err := mf.FromReader(strings.NewReader(s), cl)
+	mOrig, err := mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(cl)))
 	if err != nil {
 		return err
 	}
@@ -61,12 +62,12 @@ func reconcileEvents(ctx context.Context, k *kabanerov1alpha2.Kabanero, cl clien
 		mf.InjectNamespace(k.GetNamespace()),
 	}
 
-	err = m.Transform(transforms...)
+	m, err := mOrig.Transform(transforms...)
 	if err != nil {
 		return err
 	}
 
-	err = m.ApplyAll()
+	err = m.Apply()
 	if err != nil {
 		return err
 	}
@@ -105,7 +106,7 @@ func cleanupEvents(ctx context.Context, k *kabanerov1alpha2.Kabanero, cl client.
 		return err
 	}
 
-	m, err := mf.FromReader(strings.NewReader(s), cl)
+	mOrig, err := mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(cl)))
 	if err != nil {
 		return err
 	}
@@ -115,12 +116,12 @@ func cleanupEvents(ctx context.Context, k *kabanerov1alpha2.Kabanero, cl client.
 		mf.InjectNamespace(k.GetNamespace()),
 	}
 
-	err = m.Transform(transforms...)
+	m, err := mOrig.Transform(transforms...)
 	if err != nil {
 		return err
 	}
 
-	err = m.DeleteAll()
+	err = m.Delete()
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/kabaneroplatform/events.go
+++ b/pkg/controller/kabaneroplatform/events.go
@@ -23,7 +23,7 @@ func reconcileEvents(ctx context.Context, k *kabanerov1alpha2.Kabanero, cl clien
 
 	// The Events entry was not configured in the spec.  We should disable it.
 	if k.Spec.Events.Enable == false {
-		cleanupEvents(ctx, k, cl)
+		cleanupEvents(ctx, k, cl, reqLogger)
 		return nil
 	}
 
@@ -52,7 +52,7 @@ func reconcileEvents(ctx context.Context, k *kabanerov1alpha2.Kabanero, cl clien
 		return err
 	}
 
-	mOrig, err := mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(cl)))
+	mOrig, err := mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(cl)), mf.UseLogger(reqLogger.WithName("manifestival")))
 	if err != nil {
 		return err
 	}
@@ -82,7 +82,7 @@ func reconcileEvents(ctx context.Context, k *kabanerov1alpha2.Kabanero, cl clien
 }
 
 // Remove the events resources
-func cleanupEvents(ctx context.Context, k *kabanerov1alpha2.Kabanero, cl client.Client) error {
+func cleanupEvents(ctx context.Context, k *kabanerov1alpha2.Kabanero, cl client.Client, reqLogger logr.Logger) error {
 	rev, err := resolveSoftwareRevision(k, "events", k.Spec.Events.Version)
 	if err != nil {
 		return err
@@ -106,7 +106,7 @@ func cleanupEvents(ctx context.Context, k *kabanerov1alpha2.Kabanero, cl client.
 		return err
 	}
 
-	mOrig, err := mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(cl)))
+	mOrig, err := mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(cl)), mf.UseLogger(reqLogger.WithName("manifestival")))
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/kabaneroplatform/kabaneroplatform_controller.go
+++ b/pkg/controller/kabaneroplatform/kabaneroplatform_controller.go
@@ -411,7 +411,7 @@ func cleanup(ctx context.Context, k *kabanerov1alpha2.Kabanero, client client.Cl
 	}
 
 	// Remove the webhook configurations and friends.
-	err := cleanupAdmissionControllerWebhook(k, client)
+	err := cleanupAdmissionControllerWebhook(k, client, reqLogger)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/kabaneroplatform/landing.go
+++ b/pkg/controller/kabaneroplatform/landing.go
@@ -11,7 +11,8 @@ import (
 	"github.com/kabanero-io/kabanero-operator/pkg/controller/kabaneroplatform/utils"
 	kabTransforms "github.com/kabanero-io/kabanero-operator/pkg/controller/transforms"
 	"github.com/go-logr/logr"
-	mf "github.com/kabanero-io/manifestival"
+	mf "github.com/manifestival/manifestival"
+	mfc "github.com/manifestival/controller-runtime-client"
 	consolev1 "github.com/openshift/api/console/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -57,18 +58,18 @@ func deployLandingPage(_ context.Context, k *kabanerov1alpha2.Kabanero, c client
 		return err
 	}
 
-	m, err := mf.FromReader(strings.NewReader(s), c)
+	mOrig, err := mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(c)))
 	if err != nil {
 		return err
 	}
 
 	transforms := []mf.Transformer{mf.InjectOwner(k), mf.InjectNamespace(k.GetNamespace())}
-	err = m.Transform(transforms...)
+	m, err := mOrig.Transform(transforms...)
 	if err != nil {
 		return err
 	}
 
-	err = m.ApplyAll()
+	err = m.Apply()
 	if err != nil {
 		return err
 	}
@@ -91,7 +92,7 @@ func deployLandingPage(_ context.Context, k *kabanerov1alpha2.Kabanero, c client
 		return err
 	}
 
-	m, err = mf.FromReader(strings.NewReader(s), c)
+	mOrig, err = mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(c)))
 	if err != nil {
 		return err
 	}
@@ -141,12 +142,12 @@ func deployLandingPage(_ context.Context, k *kabanerov1alpha2.Kabanero, c client
 		}
 	}
 
-	err = m.Transform(transforms...)
+	m, err = mOrig.Transform(transforms...)
 	if err != nil {
 		return err
 	}
 
-	err = m.ApplyAll()
+	err = m.Apply()
 	if err != nil {
 		return err
 	}
@@ -203,18 +204,18 @@ func cleanupLandingPage(k *kabanerov1alpha2.Kabanero, c client.Client) error {
 		return err
 	}
 
-	m, err := mf.FromReader(strings.NewReader(s), c)
+	mOrig, err := mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(c)))
 	if err != nil {
 		return err
 	}
 
 	transforms := []mf.Transformer{mf.InjectOwner(k), mf.InjectNamespace(k.GetNamespace())}
-	err = m.Transform(transforms...)
+	m, err := mOrig.Transform(transforms...)
 	if err != nil {
 		return err
 	}
 
-	err = m.DeleteAll()
+	err = m.Delete()
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
 			return err

--- a/pkg/controller/kabaneroplatform/landing.go
+++ b/pkg/controller/kabaneroplatform/landing.go
@@ -28,7 +28,7 @@ import (
 var kllog = rlog.Log.WithName("kabanero-landing")
 
 // Deploys resources and customizes to the Openshift web console.
-func deployLandingPage(_ context.Context, k *kabanerov1alpha2.Kabanero, c client.Client, _ logr.Logger) error {
+func deployLandingPage(_ context.Context, k *kabanerov1alpha2.Kabanero, c client.Client, logger logr.Logger) error {
 	// if enable is false do not deploy the landing page
 	if k.Spec.Landing.Enable != nil && *(k.Spec.Landing.Enable) == false {
 		err := cleanupLandingPage(k, c)
@@ -58,7 +58,7 @@ func deployLandingPage(_ context.Context, k *kabanerov1alpha2.Kabanero, c client
 		return err
 	}
 
-	mOrig, err := mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(c)))
+	mOrig, err := mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(c)), mf.UseLogger(logger.WithName("manifestival")))
 	if err != nil {
 		return err
 	}
@@ -92,7 +92,7 @@ func deployLandingPage(_ context.Context, k *kabanerov1alpha2.Kabanero, c client
 		return err
 	}
 
-	mOrig, err = mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(c)))
+	mOrig, err = mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(c)), mf.UseLogger(logger.WithName("manifestival")))
 	if err != nil {
 		return err
 	}
@@ -204,7 +204,7 @@ func cleanupLandingPage(k *kabanerov1alpha2.Kabanero, c client.Client) error {
 		return err
 	}
 
-	mOrig, err := mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(c)))
+	mOrig, err := mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(c)), mf.UseLogger(rlog.Log.WithName("manifestival")))
 	if err != nil {
 		return err
 	}
@@ -217,9 +217,7 @@ func cleanupLandingPage(k *kabanerov1alpha2.Kabanero, c client.Client) error {
 
 	err = m.Delete()
 	if err != nil {
-		if !apierrors.IsNotFound(err) {
-			return err
-		}
+		return err
 	}
 
 	return nil

--- a/pkg/controller/kabaneroplatform/sso.go
+++ b/pkg/controller/kabaneroplatform/sso.go
@@ -91,7 +91,7 @@ func reconcileSso(ctx context.Context, k *kabanerov1alpha2.Kabanero, c client.Cl
 		return err
 	}
 
-	mOrig, err := mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(c)))
+	mOrig, err := mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(c)), mf.UseLogger(reqLogger.WithName("manifestival")))
 	if err != nil {
 		return err
 	}
@@ -179,7 +179,7 @@ func disableSso(ctx context.Context, k *kabanerov1alpha2.Kabanero, c client.Clie
 		return err
 	}
 
-	mOrig, err := mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(c)))
+	mOrig, err := mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(c)), mf.UseLogger(reqLogger.WithName("manifestival")))
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/kabaneroplatform/sso.go
+++ b/pkg/controller/kabaneroplatform/sso.go
@@ -11,7 +11,8 @@ import (
 	"github.com/go-logr/logr"
 	kabanerov1alpha2 "github.com/kabanero-io/kabanero-operator/pkg/apis/kabanero/v1alpha2"
 
-	mf "github.com/kabanero-io/manifestival"
+	mf "github.com/manifestival/manifestival"
+	mfc "github.com/manifestival/controller-runtime-client"
 	appsv1 "github.com/openshift/api/apps/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -90,7 +91,7 @@ func reconcileSso(ctx context.Context, k *kabanerov1alpha2.Kabanero, c client.Cl
 		return err
 	}
 
-	m, err := mf.FromReader(strings.NewReader(s), c)
+	mOrig, err := mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(c)))
 	if err != nil {
 		return err
 	}
@@ -100,12 +101,12 @@ func reconcileSso(ctx context.Context, k *kabanerov1alpha2.Kabanero, c client.Cl
 		mf.InjectNamespace(k.GetNamespace()),
 	}
 
-	err = m.Transform(transforms...)
+	m, err := mOrig.Transform(transforms...)
 	if err != nil {
 		return err
 	}
 
-	err = m.ApplyAll()
+	err = m.Apply()
 	if err != nil {
 		return err
 	}
@@ -178,7 +179,7 @@ func disableSso(ctx context.Context, k *kabanerov1alpha2.Kabanero, c client.Clie
 		return err
 	}
 
-	m, err := mf.FromReader(strings.NewReader(s), c)
+	mOrig, err := mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(c)))
 	if err != nil {
 		return err
 	}
@@ -187,12 +188,12 @@ func disableSso(ctx context.Context, k *kabanerov1alpha2.Kabanero, c client.Clie
 		mf.InjectNamespace(k.GetNamespace()),
 	}
 
-	err = m.Transform(transforms...)
+	m, err := mOrig.Transform(transforms...)
 	if err != nil {
 		return err
 	}
 
-	_ = m.DeleteAll()
+	_ = m.Delete()
 	
 	return nil
 }

--- a/pkg/controller/kabaneroplatform/stack-controller.go
+++ b/pkg/controller/kabaneroplatform/stack-controller.go
@@ -7,7 +7,8 @@ import (
 
 	kabanerov1alpha2 "github.com/kabanero-io/kabanero-operator/pkg/apis/kabanero/v1alpha2"
 	"github.com/go-logr/logr"
-	mf "github.com/kabanero-io/manifestival"
+	mf "github.com/manifestival/manifestival"
+	mfc "github.com/manifestival/controller-runtime-client"
 	appsv1 "k8s.io/api/apps/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	rlog "sigs.k8s.io/controller-runtime/pkg/log"
@@ -52,7 +53,7 @@ func reconcileStackController(ctx context.Context, k *kabanerov1alpha2.Kabanero,
 		return err
 	}
 
-	m, err := mf.FromReader(strings.NewReader(s), c)
+	mOrig, err := mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(c)))
 	if err != nil {
 		return err
 	}
@@ -62,12 +63,12 @@ func reconcileStackController(ctx context.Context, k *kabanerov1alpha2.Kabanero,
 		mf.InjectNamespace(k.GetNamespace()),
 	}
 
-	err = m.Transform(transforms...)
+	m, err := mOrig.Transform(transforms...)
 	if err != nil {
 		return err
 	}
 
-	err = m.ApplyAll()
+	err = m.Apply()
 	if err != nil {
 		return err
 	}
@@ -88,12 +89,12 @@ func reconcileStackController(ctx context.Context, k *kabanerov1alpha2.Kabanero,
 		return err
 	}
 
-	m, err = mf.FromReader(strings.NewReader(s), c)
+	mOrig, err = mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(c)))
 	if err != nil {
 		return err
 	}
 
-	err = m.ApplyAll()
+	err = mOrig.Apply()
 	if err != nil {
 		return err
 	}
@@ -160,12 +161,12 @@ func cleanupStackController(ctx context.Context, k *kabanerov1alpha2.Kabanero, c
 		return err
 	}
 
-	m, err := mf.FromReader(strings.NewReader(s), c)
+	m, err := mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(c)))
 	if err != nil {
 		return err
 	}
 
-	err = m.DeleteAll()
+	err = m.Delete()
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/kabaneroplatform/stack-controller.go
+++ b/pkg/controller/kabaneroplatform/stack-controller.go
@@ -53,7 +53,7 @@ func reconcileStackController(ctx context.Context, k *kabanerov1alpha2.Kabanero,
 		return err
 	}
 
-	mOrig, err := mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(c)))
+	mOrig, err := mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(c)), mf.UseLogger(logger.WithName("manifestival")))
 	if err != nil {
 		return err
 	}
@@ -89,7 +89,7 @@ func reconcileStackController(ctx context.Context, k *kabanerov1alpha2.Kabanero,
 		return err
 	}
 
-	mOrig, err = mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(c)))
+	mOrig, err = mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(c)), mf.UseLogger(logger.WithName("manifestival")))
 	if err != nil {
 		return err
 	}
@@ -161,7 +161,7 @@ func cleanupStackController(ctx context.Context, k *kabanerov1alpha2.Kabanero, c
 		return err
 	}
 
-	m, err := mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(c)))
+	m, err := mf.ManifestFrom(mf.Reader(strings.NewReader(s)), mf.UseClient(mfc.NewClient(c)), mf.UseLogger(logger.WithName("manifestival")))
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/stack/stack_controller.go
+++ b/pkg/controller/stack/stack_controller.go
@@ -468,7 +468,7 @@ func reconcileActiveVersions(stackResource *kabanerov1alpha2.Stack, c client.Cli
 						for _, manifest := range value.manifests {
 							if asset.Name == manifest.Name {
 								resources := []unstructured.Unstructured{manifest.Yaml}
-								mOrig, err := mf.ManifestFrom(mf.Slice(resources), mf.UseClient(mfc.NewClient(c)))
+								mOrig, err := mf.ManifestFrom(mf.Slice(resources), mf.UseClient(mfc.NewClient(c)), mf.UseLogger(log.WithName("manifestival")))
 
 								log.Info(fmt.Sprintf("Resources: %v", mOrig.Resources()))
 


### PR DESCRIPTION
The original Manifestival library now supports creating manifests from other source types.  Since that was essentially the only difference between our fork and the original, we should stop using our fork.

These were the changes that pertained to Kabanero:
* Manifest objects are now immutable, so we receive a new object after Transform()
* We're using the Manifestival controller-runtime client
* ApplyAll and DeleteAll were renamed to Apply and Delete respectively

@jcrossley3 if you have a few minutes to look this over, we'd appreciate it!