### PR TITLE
Add deployments/finalizers to Codewind role

### DIFF
--- a/config/orchestrations/codeready-workspaces/0.1/codewind-clusterrole.yaml
+++ b/config/orchestrations/codeready-workspaces/0.1/codewind-clusterrole.yaml
@@ -38,7 +38,7 @@ rules:
   verbs: ["*"]
 
 - apiGroups: ["apps", "extensions"]
-  resources: ["deployments"]
+  resources: ["deployments", "deployments/finalizers"]
   verbs: ["watch", "get", "list", "create", "update", "delete", "patch"]
 
 - apiGroups: ["extensions", "apps"]


### PR DESCRIPTION
Fixes https://github.com/kabanero-io/kabanero-operator/issues/515

Updates the roles given to Codewind to add `deployments/finalizers` to the Codewind cluster role created by Kabanero. Required by the fix to be delivered in https://github.com/eclipse/codewind/pull/2293