### PR TITLE
OL int test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -245,7 +245,7 @@ int-uninstall:
 	KABANERO_SUBSCRIPTIONS_YAML=deploy/kabanero-subscriptions.yaml KABANERO_CUSTOMRESOURCES_YAML=deploy/kabanero-customresources.yaml deploy/uninstall.sh
 
 # Stacks: Can be run in parallel ( -j ). Test manual pipeline run of stacks.
-int-test-stacks: int-test-java-microprofile int-test-java-spring-boot2 int-test-nodejs int-test-nodejs-express int-test-nodejs-loopback
+int-test-stacks: int-test-java-microprofile int-test-java-spring-boot2 int-test-nodejs int-test-nodejs-express int-test-java-openliberty
 
 int-test-java-microprofile:
 	tests/10-java-microprofile.sh
@@ -259,8 +259,8 @@ int-test-nodejs:
 int-test-nodejs-express:
 	tests/13-nodejs-express.sh
 
-int-test-nodejs-loopback:
-	tests/14-nodejs-loopback.sh
+int-test-java-openliberty:
+	tests/14-java-openliberty.sh
 
 # Lifecycle: Lifecycle of Kabanero, Stack and owned objects
 int-test-lifecycle: int-test-delete-pipeline int-test-delete-stack int-test-update-index int-test-deactivate-stack

--- a/tests/14-java-openliberty.sh
+++ b/tests/14-java-openliberty.sh
@@ -2,8 +2,8 @@
 
 set -Eeuox pipefail
 
-STACK="nodejs-loopback"
-APP="sample-nodejs-loopback" \
+STACK="java-openliberty"
+APP="sample-java-openliberty" \
 DOCKER_IMAGE="image-registry.openshift-image-registry.svc:5000/kabanero/${APP}" \
 APP_REPO="https://github.com/kabanero-io/${APP}/" \
 PIPELINE_RUN="${APP}-build-deploy-pl-run-kabanero" \

--- a/tests/pipelinerun.sh
+++ b/tests/pipelinerun.sh
@@ -26,6 +26,9 @@ namespace=kabanero
 oc -n ${namespace} delete pipelinerun ${PIPELINE_RUN} || true
 oc -n ${namespace} delete pipelineresource ${DOCKER_IMAGE_REF} ${GITHUB_SOURCE_REF} || true
 
+# Set registriesSkippingTagResolving for internal registry
+$(dirname "$0")/rstr.sh
+
 # Pipeline Resources: Source repo and destination container image
 cat <<EOF | oc -n ${namespace} apply -f -
 apiVersion: v1

--- a/tests/rstr.sh
+++ b/tests/rstr.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Avoid x509 error when using private registry
+# https://github.com/knative/serving/issues/5126
+
+set -Eeuox pipefail
+
+
+DATA=$(oc -n knative-serving get configmap config-deployment -o=jsonpath={.data.registriesSkippingTagResolving})
+if echo ${DATA} | grep image-registry.openshift-image-registry.svc:5000
+then
+  echo "knative-serving configmap config-deployment already skips image-registry.openshift-image-registry.svc:5000"
+elif [ -z "${DATA}" ]
+then
+  RSTR="image-registry.openshift-image-registry.svc:5000,dev.local,ko.local"
+  oc -n knative-serving patch configmap config-deployment -p '{"data":{"registriesSkippingTagResolving":"'${RSTR}'"}}'
+else
+  NEWDATA="${DATA},image-registry.openshift-image-registry.svc:5000"
+  oc -n knative-serving patch configmap config-deployment -p '{"data":{"registriesSkippingTagResolving":"'${NEWDATA}'"}}'
+fi
+
+


### PR DESCRIPTION
- remove nodejs-loopback test, as it is no longer in stack hub
- include java-open-liberty test

ksvc revision may reject internal registry with x509 error when doing tag resolve
