### PR TITLE
Knative Serving package name change

### DIFF
--- a/pkg/controller/kabaneroplatform/serverless.go
+++ b/pkg/controller/kabaneroplatform/serverless.go
@@ -143,7 +143,7 @@ func getKnativeServingStatus(k *kabanerov1alpha2.Kabanero, c client.Client, reqL
 	knsInstance := &unstructured.Unstructured{}
 	knsInstance.SetGroupVersionKind(schema.GroupVersionKind{
 		Kind:    "KnativeServing",
-		Group:   "serving.knative.dev",
+		Group:   "operator.knative.dev",
 		Version: "v1alpha1",
 	})
 


### PR DESCRIPTION
Fixes #526 
The name of the `KnativeServing` CRD changed (the group changed) and so the code also needs to change.