### PR TITLE
Compensate for including serverless 1.4.1 in kabanero 0.6.0

### DIFF
--- a/config/samples/default.yaml
+++ b/config/samples/default.yaml
@@ -11,6 +11,6 @@ spec:
         url: https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.6.0-rc.2/kabanero-stack-hub-index.yaml
     pipelines:
     - id: default
-      sha256: 147455156595e8ad95e71ee712e4066eeb0225903847b3ac04a59e69ba899f60
+      sha256: db32083d1961ae5a96aed9e3abd87b7b6f9a63c946eee302dd3ad8db299a6618
       https:
-        url: https://github.com/kabanero-io/kabanero-pipelines/releases/download/0.6.0-rc.6/default-kabanero-pipelines.tar.gz
+        url: https://github.com/kabanero-io/kabanero-pipelines/releases/download/0.6.0-rc.9/default-kabanero-pipelines.tar.gz

--- a/config/samples/full.yaml
+++ b/config/samples/full.yaml
@@ -111,9 +111,9 @@ spec:
           url: https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.6.0-rc.2/kabanero-stack-hub-index.yaml
       pipelines:
       - id: default
-        sha256: 147455156595e8ad95e71ee712e4066eeb0225903847b3ac04a59e69ba899f60
+        sha256: db32083d1961ae5a96aed9e3abd87b7b6f9a63c946eee302dd3ad8db299a6618
         https:
-          url: https://github.com/kabanero-io/kabanero-pipelines/releases/download/0.6.0-rc.6/default-kabanero-pipelines.tar.gz
+          url: https://github.com/kabanero-io/kabanero-pipelines/releases/download/0.6.0-rc.9/default-kabanero-pipelines.tar.gz
 
   # The information in the Github section is used by the Kabanero CLI to
   # perform user to role mapping when accessing the collection.

--- a/config/versions.yaml
+++ b/config/versions.yaml
@@ -29,9 +29,9 @@ kabanero:
     cli-services: "0.6.0"
     landing: "0.6.0"
     events: "0.1.0"
-    collection-controller: "0.6.0-rc.5"
-    stack-controller: "0.6.0-rc.5"
-    admission-webhook: "0.6.0-rc.5"
+    collection-controller: "0.6.0-rc.6"
+    stack-controller: "0.6.0-rc.6"
+    admission-webhook: "0.6.0-rc.6"
     sso: "7.3.2"
     codeready-workspaces: "0.6.0"
 
@@ -70,11 +70,11 @@ related-software:
     identifiers:
       repository: "kabanero/kabanero-operator-collection-controller"
       tag: "0.7.0-alpha.1"
-  - version: "0.6.0-rc.5"
+  - version: "0.6.0-rc.6"
     orchestrations: "orchestrations/collection-controller/0.1"
     identifiers:
       repository: "kabanero/kabanero-operator-collection-controller"
-      tag: "0.6.0-rc.5"
+      tag: "0.6.0-rc.6"
 
   stack-controller: 
   - version: "0.7.0-alpha.1"
@@ -82,11 +82,11 @@ related-software:
     identifiers:
       repository: "kabanero/kabanero-operator-stack-controller"
       tag: "0.7.0-alpha.1"
-  - version: "0.6.0-rc.5"
+  - version: "0.6.0-rc.6"
     orchestrations: "orchestrations/stack-controller/0.1"
     identifiers:
       repository: "kabanero/kabanero-operator-stack-controller"
-      tag: "0.6.0-rc.5"
+      tag: "0.6.0-rc.6"
 
   admission-webhook:
   - version: "0.7.0-alpha.1"
@@ -94,11 +94,11 @@ related-software:
     identifiers:
       repository: "kabanero/kabanero-operator-admission-webhook"
       tag: "0.7.0-alpha.1"
-  - version: "0.6.0-rc.5"
+  - version: "0.6.0-rc.6"
     orchestrations: "orchestrations/admission-webhook/0.2"
     identifiers:
       repository: "kabanero/kabanero-operator-admission-webhook"
-      tag: "0.6.0-rc.5"
+      tag: "0.6.0-rc.6"
 
   sso:
   - version: "7.3.2"

--- a/registry/manifests/kabanero-operator/0.6.0/kabanero-operator.v0.6.0.clusterserviceversion.yaml
+++ b/registry/manifests/kabanero-operator/0.6.0/kabanero-operator.v0.6.0.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     capabilities: Basic Install
     categories: "Integration & Delivery"
     certified: "false"
-    containerImage: kabanero/kabanero-operator:0.6.0
+    containerImage: kabanero/kabanero-operator:0.6.0-rc.6
     createdAt: 2019-11-19T12:00:00.000-0500
     description: Bringings together foundational open source technologies into a modern microservices-based framework.
     olm.skipRange: '>=0.5.0 <0.6.0'
@@ -35,9 +35,9 @@ metadata:
               "pipelines": [
                 {
                   "id": "default",
-                  "sha256": "147455156595e8ad95e71ee712e4066eeb0225903847b3ac04a59e69ba899f60",
+                  "sha256": "db32083d1961ae5a96aed9e3abd87b7b6f9a63c946eee302dd3ad8db299a6618",
                   "https": {
-                    "url": "https://github.com/kabanero-io/kabanero-pipelines/releases/download/0.6.0-rc.6/default-kabanero-pipelines.tar.gz"
+                    "url": "https://github.com/kabanero-io/kabanero-pipelines/releases/download/0.6.0-rc.9/default-kabanero-pipelines.tar.gz"
                   }
                 }
               ]
@@ -66,12 +66,11 @@ metadata:
             "name": "java-microprofile",
             "versions": [
               { "version": "0.2.25",
-                "repositoryUrl": "https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.6.0-rc.2/kabanero-stack-hub-index.yaml",
                 "pipelines": [
                   { "id": "default",
-                    "sha256": "147455156595e8ad95e71ee712e4066eeb0225903847b3ac04a59e69ba899f60",
+                    "sha256": "db32083d1961ae5a96aed9e3abd87b7b6f9a63c946eee302dd3ad8db299a6618",
                     "https": {
-                      "url": "https://github.com/kabanero-io/kabanero-pipelines/releases/download/0.6.0-rc.6/default-kabanero-pipelines.tar.gz"
+                      "url": "https://github.com/kabanero-io/kabanero-pipelines/releases/download/0.6.0-rc.9/default-kabanero-pipelines.tar.gz"
                     }
                   }
                 ],
@@ -86,7 +85,7 @@ metadata:
         }
       ]
 spec:
-  minKubeVersion: 1.14.0
+  minKubeVersion: 1.16.0
   apiservicedefinitions: {}
   maturity: alpha
   version: 0.6.0
@@ -297,7 +296,7 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: kabanero-operator
-                image: kabanero/kabanero-operator:0.6.0
+                image: kabanero/kabanero-operator:0.6.0-rc.6
                 imagePullPolicy: Always
                 name: kabanero-operator
                 resources: {}

--- a/registry/manifests/kabanero-operator/0.7.0/kabanero-operator.v0.7.0.clusterserviceversion.yaml
+++ b/registry/manifests/kabanero-operator/0.7.0/kabanero-operator.v0.7.0.clusterserviceversion.yaml
@@ -35,9 +35,9 @@ metadata:
               "pipelines": [
                 {
                   "id": "default",
-                  "sha256": "147455156595e8ad95e71ee712e4066eeb0225903847b3ac04a59e69ba899f60",
+                  "sha256": "db32083d1961ae5a96aed9e3abd87b7b6f9a63c946eee302dd3ad8db299a6618",
                   "https": {
-                    "url": "https://github.com/kabanero-io/kabanero-pipelines/releases/download/0.6.0-rc.6/default-kabanero-pipelines.tar.gz"
+                    "url": "https://github.com/kabanero-io/kabanero-pipelines/releases/download/0.6.0-rc.9/default-kabanero-pipelines.tar.gz"
                   }
                 }
               ]
@@ -66,12 +66,11 @@ metadata:
             "name": "java-microprofile",
             "versions": [
               { "version": "0.2.25",
-                "repositoryUrl": "https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.6.0-rc.2/kabanero-stack-hub-index.yaml",
                 "pipelines": [
                   { "id": "default",
-                    "sha256": "147455156595e8ad95e71ee712e4066eeb0225903847b3ac04a59e69ba899f60",
+                    "sha256": "db32083d1961ae5a96aed9e3abd87b7b6f9a63c946eee302dd3ad8db299a6618",
                     "https": {
-                      "url": "https://github.com/kabanero-io/kabanero-pipelines/releases/download/0.6.0-rc.6/default-kabanero-pipelines.tar.gz"
+                      "url": "https://github.com/kabanero-io/kabanero-pipelines/releases/download/0.6.0-rc.9/default-kabanero-pipelines.tar.gz"
                     }
                   }
                 ],
@@ -86,7 +85,7 @@ metadata:
         }
       ]
 spec:
-  minKubeVersion: 1.14.0
+  minKubeVersion: 1.16.0
   apiservicedefinitions: {}
   maturity: alpha
   version: 0.7.0

--- a/registry/manifests/serverless-operator/serverless-operator.package.yaml
+++ b/registry/manifests/serverless-operator/serverless-operator.package.yaml
@@ -7,7 +7,7 @@ channels:
 - name: kabanero-0.5
   currentCSV: serverless-operator.v1.2.0
 - name: kabanero-0.6
-  currentCSV: serverless-operator.v1.3.0
+  currentCSV: serverless-operator.v1.4.1
 - name: kabanero-0.7
   currentCSV: serverless-operator.v1.4.1
 defaultChannel: kabanero-0.7


### PR DESCRIPTION
We've already cut a 0.7.0 release, but we made changes to the 0.6.0 release, so this PR just updates the current (0.7.0) release with the changes made in 0.6.0.  Specifically, upgrading the level of serverless, and the pipelines.