### PR TITLE
Add Codewind tekton roles to the operator

### DIFF
--- a/config/orchestrations/codeready-workspaces/0.1/codewind-tektonbinding.yaml
+++ b/config/orchestrations/codeready-workspaces/0.1/codewind-tektonbinding.yaml
@@ -1,0 +1,22 @@
+#*******************************************************************************
+# Copyright (c) 2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v20.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: codewind-tektonbinding
+subjects:
+- kind: ServiceAccount
+  namespace: kabanero
+  name: che-workspace
+roleRef:
+  kind: ClusterRole
+  name: codewind-tekton
+  apiGroup: rbac.authorization.k8s.io

--- a/config/orchestrations/codeready-workspaces/0.1/codewind-tektonrole.yaml
+++ b/config/orchestrations/codeready-workspaces/0.1/codewind-tektonrole.yaml
@@ -1,0 +1,19 @@
+################################################################################
+# Copyright (c) 2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v20.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+################################################################################
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: codewind-tekton
+rules:
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list"]


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

Fixes https://github.com/kabanero-io/kabanero-operator/issues/536

This PR adds the necessary cluster roles and rolebinding that's needed for Codewind to open the tekton dashboard from the "Open Tekton Dashboard" button in Theia.