### PR TITLE
roll v0.6.0 GA into master

### DIFF
--- a/config/samples/default.yaml
+++ b/config/samples/default.yaml
@@ -8,9 +8,9 @@ spec:
     repositories:
     - name: central
       https:
-        url: https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.6.0-rc.2/kabanero-stack-hub-index.yaml
+        url: https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.6.0/kabanero-stack-hub-index.yaml
     pipelines:
     - id: default
-      sha256: db32083d1961ae5a96aed9e3abd87b7b6f9a63c946eee302dd3ad8db299a6618
+      sha256: abbc2ed0e19349aa5e23b511b75449fb1a515cfd6a548b05b6516fb7c6de1aba
       https:
-        url: https://github.com/kabanero-io/kabanero-pipelines/releases/download/0.6.0-rc.9/default-kabanero-pipelines.tar.gz
+        url: https://github.com/kabanero-io/kabanero-pipelines/releases/download/0.6.0/default-kabanero-pipelines.tar.gz

--- a/config/versions.yaml
+++ b/config/versions.yaml
@@ -29,9 +29,9 @@ kabanero:
     cli-services: "0.6.0"
     landing: "0.6.0"
     events: "0.1.0"
-    collection-controller: "0.6.0-rc.6"
-    stack-controller: "0.6.0-rc.6"
-    admission-webhook: "0.6.0-rc.6"
+    collection-controller: "0.6.0"
+    stack-controller: "0.6.0"
+    admission-webhook: "0.6.0"
     sso: "7.3.2"
     codeready-workspaces: "0.6.0"
 
@@ -48,7 +48,7 @@ related-software:
     orchestrations: "orchestrations/cli-services/0.1"
     identifiers:
       repository: "kabanero/kabanero-command-line-services"
-      tag: "0.6.0-rc.4"
+      tag: "0.6.0"
 
   codeready-workspaces:
   - version: "0.6.0"
@@ -70,11 +70,11 @@ related-software:
     identifiers:
       repository: "kabanero/kabanero-operator-collection-controller"
       tag: "0.7.0-alpha.1"
-  - version: "0.6.0-rc.6"
+  - version: "0.6.0"
     orchestrations: "orchestrations/collection-controller/0.1"
     identifiers:
       repository: "kabanero/kabanero-operator-collection-controller"
-      tag: "0.6.0-rc.6"
+      tag: "0.6.0"
 
   stack-controller: 
   - version: "0.7.0-alpha.1"
@@ -82,11 +82,11 @@ related-software:
     identifiers:
       repository: "kabanero/kabanero-operator-stack-controller"
       tag: "0.7.0-alpha.1"
-  - version: "0.6.0-rc.6"
+  - version: "0.6.0"
     orchestrations: "orchestrations/stack-controller/0.1"
     identifiers:
       repository: "kabanero/kabanero-operator-stack-controller"
-      tag: "0.6.0-rc.6"
+      tag: "0.6.0"
 
   admission-webhook:
   - version: "0.7.0-alpha.1"
@@ -94,11 +94,11 @@ related-software:
     identifiers:
       repository: "kabanero/kabanero-operator-admission-webhook"
       tag: "0.7.0-alpha.1"
-  - version: "0.6.0-rc.6"
+  - version: "0.6.0"
     orchestrations: "orchestrations/admission-webhook/0.2"
     identifiers:
       repository: "kabanero/kabanero-operator-admission-webhook"
-      tag: "0.6.0-rc.6"
+      tag: "0.6.0"
 
   sso:
   - version: "7.3.2"

--- a/registry/manifests/kabanero-operator/0.6.0/kabanero-operator.v0.6.0.clusterserviceversion.yaml
+++ b/registry/manifests/kabanero-operator/0.6.0/kabanero-operator.v0.6.0.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     capabilities: Basic Install
     categories: "Integration & Delivery"
     certified: "false"
-    containerImage: kabanero/kabanero-operator:0.6.0-rc.6
+    containerImage: kabanero/kabanero-operator:0.6.0
     createdAt: 2019-11-19T12:00:00.000-0500
     description: Bringings together foundational open source technologies into a modern microservices-based framework.
     olm.skipRange: '>=0.5.0 <0.6.0'
@@ -28,16 +28,16 @@ metadata:
                 {
                   "name": "incubator",
                   "https": {
-                    "url": "https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.6.0-rc.2/kabanero-stack-hub-index.yaml"
+                    "url": "https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.6.0/kabanero-stack-hub-index.yaml"
                   }
                 }
               ],
               "pipelines": [
                 {
                   "id": "default",
-                  "sha256": "db32083d1961ae5a96aed9e3abd87b7b6f9a63c946eee302dd3ad8db299a6618",
+                  "sha256": "abbc2ed0e19349aa5e23b511b75449fb1a515cfd6a548b05b6516fb7c6de1aba",
                   "https": {
-                    "url": "https://github.com/kabanero-io/kabanero-pipelines/releases/download/0.6.0-rc.9/default-kabanero-pipelines.tar.gz"
+                    "url": "https://github.com/kabanero-io/kabanero-pipelines/releases/download/0.6.0/default-kabanero-pipelines.tar.gz"
                   }
                 }
               ]
@@ -68,9 +68,9 @@ metadata:
               { "version": "0.2.25",
                 "pipelines": [
                   { "id": "default",
-                    "sha256": "db32083d1961ae5a96aed9e3abd87b7b6f9a63c946eee302dd3ad8db299a6618",
+                    "sha256": "abbc2ed0e19349aa5e23b511b75449fb1a515cfd6a548b05b6516fb7c6de1aba",
                     "https": {
-                      "url": "https://github.com/kabanero-io/kabanero-pipelines/releases/download/0.6.0-rc.9/default-kabanero-pipelines.tar.gz"
+                      "url": "https://github.com/kabanero-io/kabanero-pipelines/releases/download/0.6.0/default-kabanero-pipelines.tar.gz"
                     }
                   }
                 ],
@@ -296,7 +296,7 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: kabanero-operator
-                image: kabanero/kabanero-operator:0.6.0-rc.6
+                image: kabanero/kabanero-operator:0.6.0
                 imagePullPolicy: Always
                 name: kabanero-operator
                 resources: {}


### PR DESCRIPTION
Rolling the updates we made in the `release-0.6` branch for version 0.6.0, into master.  Some pieces had already been changed in master, but most have not.