### PR TITLE
Readme and dependency report update

### DIFF
--- a/3RD_PARTY
+++ b/3RD_PARTY
@@ -1,83 +1,82 @@
-github.com/mailru/easyjson                               MIT License
-github.com/PuerkitoBio/purell                            BSD 3-Clause "New" or "Revised" License
-github.com/googleapis/gnostic                            Apache License 2.0
-github.com/PuerkitoBio/urlesc                            BSD 3-Clause "New" or "Revised" License
-github.com/go-logr/zapr                                  Apache License 2.0
-github.com/tektoncd/operator                             Apache License 2.0
-github.com/go-openapi/jsonpointer                        Apache License 2.0
-go.opencensus.io                                         Apache License 2.0
-github.com/golang/groupcache                             Apache License 2.0
-github.com/go-logr/logr                                  Apache License 2.0
-github.com/tektoncd/pipeline                             Apache License 2.0
-github.com/modern-go/reflect2                            Apache License 2.0
-github.com/prometheus/client_model                       Apache License 2.0
-golang.org/x/xerrors                                     BSD 3-Clause "New" or "Revised" License
-google.golang.org/api                                    <license not found or detected>
+cloud.google.com/go                                      <license not found or detected>
 contrib.go.opencensus.io/exporter/ocagent                Apache License 2.0
-github.com/google/uuid                                   BSD 3-Clause "New" or "Revised" License
-github.com/knative/serving-operator                      Apache License 2.0
-golang.org/x/sync                                        BSD 3-Clause "New" or "Revised" License
-gopkg.in/fsnotify.v1                                     <license not found or detected>
-github.com/golang/protobuf                               BSD 3-Clause "New" or "Revised" License
-github.com/pborman/uuid                                  BSD 3-Clause "New" or "Revised" License
-golang.org/x/text                                        BSD 3-Clause "New" or "Revised" License
-github.com/openshift/api                                 Apache License 2.0
+github.com/Azure/go-autorest                             Apache License 2.0
+github.com/beorn7/perks                                  MIT License
+github.com/blang/semver                                  MIT License
 github.com/census-instrumentation/opencensus-proto       Apache License 2.0
-k8s.io/utils                                             Apache License 2.0
-golang.org/x/time                                        BSD 3-Clause "New" or "Revised" License
-github.com/davecgh/go-spew                               ISC License
-github.com/operator-framework/operator-lifecycle-manager Apache License 2.0
-github.com/emicklei/go-restful                           MIT License
-github.com/prometheus/common                             Apache License 2.0
 github.com/coreos/go-semver                              Apache License 2.0
 github.com/coreos/prometheus-operator                    Apache License 2.0
-k8s.io/apiextensions-apiserver                           Apache License 2.0
-go.uber.org/zap                                          MIT License
-google.golang.org/genproto                               Apache License 2.0
-github.com/matttproud/golang_protobuf_extensions         Apache License 2.0
-k8s.io/kube-state-metrics                                Apache License 2.0
-github.com/blang/semver                                  MIT License
-k8s.io/kube-openapi                                      Apache License 2.0
-go.uber.org/multierr                                     MIT License
-github.com/mattbaird/jsonpatch                           Apache License 2.0
-go.uber.org/atomic                                       MIT License
-github.com/kabanero-io/manifestival                      Apache License 2.0
-google.golang.org/grpc                                   Apache License 2.0
-github.com/gophercloud/gophercloud                       Apache License 2.0
-github.com/evanphx/json-patch                            BSD 3-Clause "New" or "Revised" License
-github.com/openshift-knative/knative-eventing-operator   Apache License 2.0
-golang.org/x/oauth2                                      BSD 3-Clause "New" or "Revised" License
-github.com/beorn7/perks                                  MIT License
-github.com/modern-go/concurrent                          Apache License 2.0
-gomodules.xyz/jsonpatch                                  Apache License 2.0
+github.com/davecgh/go-spew                               ISC License
 github.com/dgrijalva/jwt-go                              MIT License
-cloud.google.com/go                                      <license not found or detected>
-golang.org/x/crypto                                      BSD 3-Clause "New" or "Revised" License
-k8s.io/apimachinery                                      Apache License 2.0
+github.com/emicklei/go-restful                           MIT License
+github.com/evanphx/json-patch                            BSD 3-Clause "New" or "Revised" License
+github.com/gogo/protobuf                                 <license not found or detected>
+github.com/golang/groupcache                             Apache License 2.0
+github.com/golang/protobuf                               BSD 3-Clause "New" or "Revised" License
+github.com/go-logr/logr                                  Apache License 2.0
+github.com/go-logr/zapr                                  Apache License 2.0
+github.com/googleapis/gnostic                            Apache License 2.0
 github.com/google/go-cmp                                 BSD 3-Clause "New" or "Revised" License
+github.com/google/gofuzz                                 Apache License 2.0
+github.com/google/uuid                                   BSD 3-Clause "New" or "Revised" License
+github.com/go-openapi/jsonpointer                        Apache License 2.0
 github.com/go-openapi/jsonreference                      Apache License 2.0
+github.com/go-openapi/spec                               Apache License 2.0
 github.com/go-openapi/swag                               Apache License 2.0
+github.com/gophercloud/gophercloud                       Apache License 2.0
+github.com/grpc-ecosystem/grpc-gateway                   BSD 3-Clause "New" or "Revised" License
+github.com/hashicorp/golang-lru                          Mozilla Public License 2.0
+github.com/imdario/mergo                                 BSD 3-Clause "New" or "Revised" License
+github.com/json-iterator/go                              MIT License
+github.com/kabanero-io/manifestival                      Apache License 2.0
+github.com/knative/pkg                                   Apache License 2.0
+github.com/knative/serving-operator                      Apache License 2.0
+github.com/mailru/easyjson                               MIT License
+github.com/mattbaird/jsonpatch                           Apache License 2.0
+github.com/matttproud/golang_protobuf_extensions         Apache License 2.0
+github.com/modern-go/concurrent                          Apache License 2.0
+github.com/modern-go/reflect2                            Apache License 2.0
+github.com/openshift/api                                 Apache License 2.0
+github.com/operator-framework/operator-lifecycle-manager Apache License 2.0
+github.com/operator-framework/operator-sdk               Apache License 2.0
+github.com/pborman/uuid                                  BSD 3-Clause "New" or "Revised" License
 github.com/pkg/errors                                    BSD 2-Clause "Simplified" License
+github.com/prometheus/client_golang                      Apache License 2.0
+github.com/prometheus/client_model                       Apache License 2.0
+github.com/prometheus/common                             Apache License 2.0
+github.com/prometheus/procfs                             Apache License 2.0
+github.com/PuerkitoBio/purell                            BSD 3-Clause "New" or "Revised" License
+github.com/PuerkitoBio/urlesc                            BSD 3-Clause "New" or "Revised" License
+github.com/spf13/pflag                                   BSD 3-Clause "New" or "Revised" License
+github.com/tektoncd/operator                             Apache License 2.0
+github.com/tektoncd/pipeline                             Apache License 2.0
+golang.org/x/crypto                                      BSD 3-Clause "New" or "Revised" License
+golang.org/x/net                                         BSD 3-Clause "New" or "Revised" License
+golang.org/x/oauth2                                      BSD 3-Clause "New" or "Revised" License
+golang.org/x/sync                                        BSD 3-Clause "New" or "Revised" License
+golang.org/x/sys                                         BSD 3-Clause "New" or "Revised" License
+golang.org/x/text                                        BSD 3-Clause "New" or "Revised" License
+golang.org/x/time                                        BSD 3-Clause "New" or "Revised" License
+golang.org/x/xerrors                                     BSD 3-Clause "New" or "Revised" License
+gomodules.xyz/jsonpatch                                  Apache License 2.0
+google.golang.org/api                                    <license not found or detected>
+google.golang.org/genproto                               Apache License 2.0
+google.golang.org/grpc                                   Apache License 2.0
+go.opencensus.io                                         Apache License 2.0
+gopkg.in/fsnotify.v1                                     <license not found or detected>
 gopkg.in/inf.v0                                          BSD 3-Clause "New" or "Revised" License
+gopkg.in/yaml.v2                                         Apache License 2.0
+go.uber.org/atomic                                       MIT License
+go.uber.org/multierr                                     MIT License
+go.uber.org/zap                                          MIT License
+k8s.io/api                                               Apache License 2.0
+k8s.io/apiextensions-apiserver                           Apache License 2.0
+k8s.io/apimachinery                                      Apache License 2.0
+k8s.io/client-go                                         Apache License 2.0
+k8s.io/klog                                              Apache License 2.0
+k8s.io/kube-openapi                                      Apache License 2.0
+k8s.io/kube-state-metrics                                Apache License 2.0
+k8s.io/utils                                             Apache License 2.0
 knative.dev/pkg                                          Apache License 2.0
 sigs.k8s.io/controller-runtime                           Apache License 2.0
-github.com/google/gofuzz                                 Apache License 2.0
-github.com/spf13/pflag                                   BSD 3-Clause "New" or "Revised" License
-k8s.io/klog                                              Apache License 2.0
-k8s.io/client-go                                         Apache License 2.0
-github.com/hashicorp/golang-lru                          Mozilla Public License 2.0
-github.com/Azure/go-autorest                             Apache License 2.0
-github.com/imdario/mergo                                 BSD 3-Clause "New" or "Revised" License
-github.com/operator-framework/operator-sdk               Apache License 2.0
-github.com/json-iterator/go                              MIT License
-github.com/grpc-ecosystem/grpc-gateway                   BSD 3-Clause "New" or "Revised" License
-github.com/prometheus/procfs                             Apache License 2.0
-golang.org/x/net                                         BSD 3-Clause "New" or "Revised" License
-github.com/prometheus/client_golang                      Apache License 2.0
-k8s.io/api                                               Apache License 2.0
-github.com/gogo/protobuf                                 <license not found or detected>
 sigs.k8s.io/yaml                                         <license not found or detected>
-golang.org/x/sys                                         BSD 3-Clause "New" or "Revised" License
-github.com/knative/pkg                                   Apache License 2.0
-gopkg.in/yaml.v2                                         Apache License 2.0
-github.com/go-openapi/spec                               Apache License 2.0

--- a/Makefile
+++ b/Makefile
@@ -216,7 +216,7 @@ ifndef GITHUB_TOKEN
 endif
 	mkdir -p build/bin
 	curl -L https://github.com/mitchellh/golicense/releases/download/v0.2.0/golicense_0.2.0_$(detected_OS)_x86_64.tar.gz | tar -C build/bin -xzf - golicense
-	build/bin/golicense -plain ./license-rules.json build/_output/bin/admission-webhook build/_output/bin/kabanero-operator build/_output/bin/kabanero-operator-collection-controller build/_output/bin/kabanero-operator-stack-controller > 3RD_PARTY || true
+	build/bin/golicense -plain ./license-rules.json build/_output/bin/admission-webhook build/_output/bin/kabanero-operator build/_output/bin/kabanero-operator-collection-controller build/_output/bin/kabanero-operator-stack-controller | sort > 3RD_PARTY || true
 	rm build/bin/golicense
 
 # Integration Tests

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ The following README pertains to kabanero-operator development.  If you are tryi
 # Status
 [![Build Status](https://travis-ci.org/kabanero-io/kabanero-operator.svg?branch=master)](https://travis-ci.org/kabanero-io/kabanero-operator)
 
-The Kabanero operator is developed using `operator-sdk` version 0.15.1.
+The Kabanero operator is developed using:
+* `operator-sdk` version 0.15.1.
+* `go` version 1.13.x
 
 ## Clone the Kabanero operator
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The following README pertains to kabanero-operator development.  If you are tryi
 # Status
 [![Build Status](https://travis-ci.org/kabanero-io/kabanero-operator.svg?branch=master)](https://travis-ci.org/kabanero-io/kabanero-operator)
 
-The Kabanero operator is developed using `operator-sdk` version 0.11.0.
+The Kabanero operator is developed using `operator-sdk` version 0.15.1.
 
 ## Clone the Kabanero operator
 
@@ -13,7 +13,7 @@ git clone https://github.com/kabanero-io/kabanero-operator
 cd kabanero-operator
 ```
 
-# Quickstart - OpenShift Container Platform (OCP) 4.2
+# Quickstart - OpenShift Container Platform (OCP) 4.3
 
 We recommend you follow the install instructions referenced above to set up your cluster for the first time.  If you would rather set it up manually, please continue with the following steps:
 
@@ -27,9 +27,11 @@ oc login -u admin -p admin https://openshift.my.com:8443/
 ## Deploy Prerequisite operators:
 
 The following operators need to be installed at the cluster scope:
-* [OpenShift Serverless Operator](https://docs.openshift.com/container-platform/4.2/serverless/installing-openshift-serverless.html)
+* [OpenShift Serverless Operator](https://docs.openshift.com/container-platform/4.3/serverless/installing-openshift-serverless.html)
 * OpenShift Pipelines Operator (from community-operators)
 * Appsody Operator (from certified-operators)
+* Open Liberty Operator (from certified-operators)
+* CodeReady Workspaces Operator (from redhat-operators)
 
 ## Build images, create catalogsource and OLM subscription
 


### PR DESCRIPTION
Fixes #540 
Fixes #522 
The README.md needs to be updated to reflect the higher versions of OCP and operator-sdk.
The dependency report needs to be updated.  I also added a `sort` to the dependency report (in the Makefile) to make it easier to spot changes next time around.