### PR TITLE
Ignore colons in the first token of an image repository

### DIFF
--- a/pkg/controller/stack/utils/stacks.go
+++ b/pkg/controller/stack/utils/stacks.go
@@ -27,9 +27,29 @@ func GetImageRepository(image string) (string, error) {
 		return "", fmt.Errorf("The input image is empty.")
 	}
 
+	// A tag name must be valid ASCII and may contain lowercase and uppercase
+	// letters, digits, underscores, periods and dashes.  A tag name may not
+	// start with a period or a dash, and may contain a maximum of 128
+	// characters.
+	//
+	// The tag cannot contain a slash.  So, if we find a slash past the last
+	// colon, what we found is not a tag and we should leave it alone.
+	//
+	// Additionally, the components of a repository name cannot contain
+	// a colon, with the exception of the first component which is actually
+	// a hostname.  So if the repository contains a colon which is not the
+	// tag separator, it must occur in the first component, and there must
+	// also be a second component after the first (implying there is a
+	// slash between the components).
+	//
+	// Reference (docker-specific, but should apply to others):
+	//   https://github.com/docker/distribution/blob/release/2.7/reference/reference.go
+	//   https://docs.docker.com/engine/reference/commandline/tag/
+	
 	repo := image
 	tagIndex := strings.LastIndex(image, ":")
-	if tagIndex >= 0 {
+	slashIndex := strings.LastIndex(image, "/")
+	if (tagIndex >= 0) && (slashIndex < tagIndex) {
 		repo = image[0:tagIndex]
 	}
 

--- a/pkg/controller/stack/utils/stacks_test.go
+++ b/pkg/controller/stack/utils/stacks_test.go
@@ -48,6 +48,7 @@ func TestRemoveTagFromStackImages(t *testing.T) {
 
 // Tests that GetImageRepository removes the tag from the input image.  .
 func TestGetImageRepository(t *testing.T) {
+	// Test external repository:tag
 	image := "kabanero/kabanero-image:1.2.3"
 	repo, err := GetImageRepository(image)
 	if err != nil {
@@ -58,6 +59,18 @@ func TestGetImageRepository(t *testing.T) {
 		t.Fatal(fmt.Sprintf("Repo should be %v, but it is %v", expectedRepo, repo))
 	}
 
+	// Test external repository with no tag.
+	image = "kabanero/kabanero-image"
+	repo, err = GetImageRepository(image)
+	if err != nil {
+		t.Fatal(fmt.Sprintf("Unexpected error while removing tag from image: %v. Error: ", err))
+	}
+	expectedRepo = "kabanero/kabanero-image"
+	if repo != expectedRepo {
+		t.Fatal(fmt.Sprintf("Repo should be %v, but it is %v", expectedRepo, repo))
+	}
+
+	// Test internal respository (with port) and tag
 	image = "image-registry.openshift-image-registry.svc:5000/kabanero/java-microprofile:1.2.3"
 	repo, err = GetImageRepository(image)
 	if err != nil {
@@ -65,6 +78,42 @@ func TestGetImageRepository(t *testing.T) {
 	}
 
 	expectedRepo = "image-registry.openshift-image-registry.svc:5000/kabanero/java-microprofile"
+	if repo != expectedRepo {
+		t.Fatal(fmt.Sprintf("Repo should be %v, but it is %v", expectedRepo, repo))
+	}
+
+	// Test internal respository (with port) and no tag
+	image = "image-registry.openshift-image-registry.svc:5000/kabanero/java-microprofile"
+	repo, err = GetImageRepository(image)
+	if err != nil {
+		t.Fatal(fmt.Sprintf("Unexpected error while removing tag from image: %v. Error: ", err))
+	}
+
+	expectedRepo = "image-registry.openshift-image-registry.svc:5000/kabanero/java-microprofile"
+	if repo != expectedRepo {
+		t.Fatal(fmt.Sprintf("Repo should be %v, but it is %v", expectedRepo, repo))
+	}
+
+	// Test default (?) repository and tag
+	image = "java-microprofile:1.2.3"
+	repo, err = GetImageRepository(image)
+	if err != nil {
+		t.Fatal(fmt.Sprintf("Unexpected error while removing tag from image: %v. Error: ", err))
+	}
+
+	expectedRepo = "java-microprofile"
+	if repo != expectedRepo {
+		t.Fatal(fmt.Sprintf("Repo should be %v, but it is %v", expectedRepo, repo))
+	}
+
+	// Test default (?) repository and no tag
+	image = "java-microprofile"
+	repo, err = GetImageRepository(image)
+	if err != nil {
+		t.Fatal(fmt.Sprintf("Unexpected error while removing tag from image: %v. Error: ", err))
+	}
+
+	expectedRepo = "java-microprofile"
 	if repo != expectedRepo {
 		t.Fatal(fmt.Sprintf("Repo should be %v, but it is %v", expectedRepo, repo))
 	}


### PR DESCRIPTION
There are multiple places in Kabanero where we attempt to remove a tag from an image name.  We can argue whether there should be a single place where we do this, but, the operation should be idempotent.

If a colon occurs in the first path component of a multi-component container image name, it is not the tag separator and the Kabanero operator should ignore it.

@jgawor I would appreciate your review as well.