### PR TITLE
Cleanup existing stacks

### DIFF
--- a/deploy/crds/kabanero.io_stacks_crd.yaml
+++ b/deploy/crds/kabanero.io_stacks_crd.yaml
@@ -10,9 +10,9 @@ spec:
       across separate operations.
     name: Age
     type: date
-  - JSONPath: .status.status
-    description: Stack status.
-    name: Status
+  - JSONPath: .status.summary
+    description: Stack summary.
+    name: Summary
     type: string
   group: kabanero.io
   names:
@@ -109,6 +109,8 @@ spec:
           description: StackStatus defines the observed state of a stack
           properties:
             statusMessage:
+              type: string
+            summary:
               type: string
             versions:
               items:

--- a/pkg/controller/kabaneroplatform/featured_stacks_test.go
+++ b/pkg/controller/kabaneroplatform/featured_stacks_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 
+	"github.com/go-logr/logr"
 	kabanerov1alpha2 "github.com/kabanero-io/kabanero-operator/pkg/apis/kabanero/v1alpha2"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -136,6 +137,7 @@ var defaultIndexPipeline = "https://github.com/kabanero-io/collections/releases/
 var defaultIndexPipelineDigest = "0123456789012345678901234567890123456789012345678901234567890123"
 var secondIndexPipeline = "https://github.com/kabanero-io/collections/releases/download/0.6.0/incubator.common.pipeline.default.tar.gz"
 var secondIndexPipelineDigest = "1234567890123456789012345678901234567890123456789012345678901234"
+var featuredTestLogger logr.Logger = log.WithValues("Request.Namespace", "test", "Request.Name", "featured_stacks_test")
 
 var stackResource kabanerov1alpha2.Stack = kabanerov1alpha2.Stack{
 	ObjectMeta: metav1.ObjectMeta{Name: "nodejs", UID: "myuid", Namespace: "kabanero"},
@@ -210,7 +212,7 @@ func TestReconcileFeaturedStacks(t *testing.T) {
 	stackUrl := server.URL + defaultIndexName
 	k := createKabanero(stackUrl)
 
-	err := reconcileFeaturedStacks(ctx, k, cl)
+	err := reconcileFeaturedStacks(ctx, k, cl, featuredTestLogger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -285,7 +287,7 @@ func TestReconcileFeaturedStacksTwoRepositories(t *testing.T) {
 	k := createKabanero(stackUrl)
 	k.Spec.Stacks.Repositories = append(k.Spec.Stacks.Repositories, kabanerov1alpha2.RepositoryConfig{Name: "two", Https: kabanerov1alpha2.HttpsProtocolFile{Url: stackUrlTwo}})
 
-	err := reconcileFeaturedStacks(ctx, k, cl)
+	err := reconcileFeaturedStacks(ctx, k, cl, featuredTestLogger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -366,7 +368,7 @@ func TestReconcileAppsodyStacksCustomPipelines(t *testing.T) {
 	customPipelineUrl := kabanerov1alpha2.HttpsProtocolFile{Url: secondIndexPipeline}
 	k.Spec.Stacks.Repositories[0].Pipelines = append(k.Spec.Stacks.Repositories[0].Pipelines, kabanerov1alpha2.PipelineSpec{Id: "custom", Sha256: secondIndexPipelineDigest, Https: customPipelineUrl})
 
-	err := reconcileFeaturedStacks(ctx, k, cl)
+	err := reconcileFeaturedStacks(ctx, k, cl, featuredTestLogger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -434,7 +436,7 @@ func TestReconcileAppsodyStacksDefaultPipelines(t *testing.T) {
 	pipelineUrl := kabanerov1alpha2.HttpsProtocolFile{Url: defaultIndexPipeline}
 	k.Spec.Stacks.Pipelines = append(k.Spec.Stacks.Pipelines, kabanerov1alpha2.PipelineSpec{Id: "default", Sha256: defaultIndexPipelineDigest, Https: pipelineUrl})
 
-	err := reconcileFeaturedStacks(ctx, k, cl)
+	err := reconcileFeaturedStacks(ctx, k, cl, featuredTestLogger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -496,7 +498,7 @@ func TestResolveFeaturedStacks(t *testing.T) {
 	stack_index_url := server.URL + defaultIndexName
 	k := createKabanero(stack_index_url)
 
-	stacks, err := featuredStacks(k, nil)
+	stacks, err := featuredStacks(k, nil, featuredTestLogger)
 	if err != nil {
 		t.Fatal("Could not resolve the featured stacks from the default index", err)
 	}
@@ -537,7 +539,7 @@ func TestResolveFeaturedStacksTwoRepositories(t *testing.T) {
 	k := createKabanero(stack_index_url)
 	k.Spec.Stacks.Repositories = append(k.Spec.Stacks.Repositories, kabanerov1alpha2.RepositoryConfig{Name: "two", Https: kabanerov1alpha2.HttpsProtocolFile{Url: stack_index_url_two}})
 
-	stacks, err := featuredStacks(k, nil)
+	stacks, err := featuredStacks(k, nil, featuredTestLogger)
 	if err != nil {
 		t.Fatal("Could not resolve the featured stacks from the default index", err)
 	}
@@ -587,7 +589,7 @@ func TestResolveFeaturedStacksCleanupMatchingStackVersionWithNonActiveState(t *t
 	k := createKabanero(stackUrl)
 
 	ctx := context.Background()
-	err := reconcileFeaturedStacks(ctx, k, cl)
+	err := reconcileFeaturedStacks(ctx, k, cl, featuredTestLogger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -658,7 +660,7 @@ func TestResolveFeaturedStacksCleanupMatchingStackVersionWithActiveState(t *test
 	k := createKabanero(stackUrl)
 
 	ctx := context.Background()
-	err := reconcileFeaturedStacks(ctx, k, cl)
+	err := reconcileFeaturedStacks(ctx, k, cl, featuredTestLogger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -730,7 +732,7 @@ func TestResolveFeaturedStacksCleanupUnmatchingStacksOneActiveVersion(t *testing
 	k := createKabanero(stackUrl)
 
 	ctx := context.Background()
-	err := reconcileFeaturedStacks(ctx, k, cl)
+	err := reconcileFeaturedStacks(ctx, k, cl, featuredTestLogger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -834,7 +836,7 @@ func TestResolveFeaturedStacksCleanupUnmatchingStacksNoActiveVersion(t *testing.
 	k := createKabanero(stackUrl)
 
 	ctx := context.Background()
-	err := reconcileFeaturedStacks(ctx, k, cl)
+	err := reconcileFeaturedStacks(ctx, k, cl, featuredTestLogger)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/controller/kabaneroplatform/featured_stacks_test.go
+++ b/pkg/controller/kabaneroplatform/featured_stacks_test.go
@@ -40,8 +40,24 @@ func (c unitTestClient) Get(ctx context.Context, key client.ObjectKey, obj runti
 	stack.DeepCopyInto(u)
 	return nil
 }
+
 func (c unitTestClient) List(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
-	return errors.New("List is not supported")
+	l, ok := list.(*kabanerov1alpha2.StackList)
+	if !ok {
+		fmt.Printf("Received an invalid list object: %v\n", list)
+		return errors.New("Get only supports stacks")
+	}
+
+	stackList := &kabanerov1alpha2.StackList{}
+	items := []kabanerov1alpha2.Stack{}
+	for _, stack := range c.objs {
+		items = append(items, *stack)
+	}
+
+	stackList.Items = items
+	stackList.DeepCopyInto(l)
+
+	return nil
 }
 func (c unitTestClient) Create(ctx context.Context, obj runtime.Object, opts ...client.CreateOption) error {
 	u, ok := obj.(*kabanerov1alpha2.Stack)
@@ -61,7 +77,14 @@ func (c unitTestClient) Create(ctx context.Context, obj runtime.Object, opts ...
 	return nil
 }
 func (c unitTestClient) Delete(ctx context.Context, obj runtime.Object, opts ...client.DeleteOption) error {
-	return errors.New("Delete is not supported")
+	u, ok := obj.(*kabanerov1alpha2.Stack)
+	if !ok {
+		fmt.Printf("Received an invalid delete object: %v\n", obj)
+		return errors.New("Update only supports Stack")
+	}
+
+	delete(c.objs, u.Name)
+	return nil
 }
 func (c unitTestClient) DeleteAllOf(ctx context.Context, obj runtime.Object, opts ...client.DeleteAllOfOption) error {
 	return errors.New("DeleteAllOf is not supported")
@@ -113,6 +136,40 @@ var defaultIndexPipeline = "https://github.com/kabanero-io/collections/releases/
 var defaultIndexPipelineDigest = "0123456789012345678901234567890123456789012345678901234567890123"
 var secondIndexPipeline = "https://github.com/kabanero-io/collections/releases/download/0.6.0/incubator.common.pipeline.default.tar.gz"
 var secondIndexPipelineDigest = "1234567890123456789012345678901234567890123456789012345678901234"
+
+var stackResource kabanerov1alpha2.Stack = kabanerov1alpha2.Stack{
+	ObjectMeta: metav1.ObjectMeta{Name: "nodejs", UID: "myuid", Namespace: "kabanero"},
+	Spec: kabanerov1alpha2.StackSpec{
+		Name: "nodejs",
+		Versions: []kabanerov1alpha2.StackVersion{
+			kabanerov1alpha2.StackVersion{
+				Version: "0.2.4",
+				Pipelines: []kabanerov1alpha2.PipelineSpec{{
+					Id:     "trigger.pipeline.0.2.4.tar.gz",
+					Sha256: "2e8ff2e5c6ce8526edc9ce413876c450383814d4fa6f5f37b690d167433da363",
+					Https:  kabanerov1alpha2.HttpsProtocolFile{Url: "https://pipelines/default/0.2.4"},
+				}},
+			},
+			kabanerov1alpha2.StackVersion{
+				Version: "0.2.5",
+				Pipelines: []kabanerov1alpha2.PipelineSpec{{
+					Id:     "trigger.pipeline.0.2.5.tar.gz",
+					Sha256: "2e8ff2e5c6ce8526edc9ce413876c450383814d4fa6f5f37b690d167433da363",
+					Https:  kabanerov1alpha2.HttpsProtocolFile{Url: "https://pipelines/default/0.2.5"},
+				}},
+			},
+			kabanerov1alpha2.StackVersion{
+				Version: "0.2.6",
+				Pipelines: []kabanerov1alpha2.PipelineSpec{{
+					Id:     "trigger.pipeline.0.2.6.tar.gz",
+					Sha256: "2e8ff2e5c6ce8526edc9ce413876c450383814d4fa6f5f37b690d167433da363",
+					Https:  kabanerov1alpha2.HttpsProtocolFile{Url: "https://pipelines/default/0.2.6"},
+				}},
+			},
+		},
+	},
+	Status: kabanerov1alpha2.StackStatus{},
+}
 
 // -----------------------------------------------------------------------------------------------
 // Test cases
@@ -507,5 +564,332 @@ func TestResolveFeaturedStacksTwoRepositories(t *testing.T) {
 
 	if len(nodejsStackVersions) != 2 {
 		t.Fatal(fmt.Sprintf("Expected two versions of nodejs stack, but found %v: %v", len(nodejsStackVersions), nodejsStackVersions))
+	}
+}
+
+// Tests that if an existing stack version with an non-active desired state matches the name/version of a stack in the index, the
+// data associated with the index version overrides the existing version.
+// Tests that a stack version with an unset desired state is removed if it is not found in the index being deployed.
+// Tests that if an existing stack version with an active state is not found in the index being deployed, the existing version
+// remains untouched.
+func TestResolveFeaturedStacksCleanupMatchingStackVersionWithNonActiveState(t *testing.T) {
+	stack := stackResource.DeepCopy()
+	stack.Spec.Versions[0].DesiredState = "NotAValidState"
+	stack.Spec.Versions[1].DesiredState = kabanerov1alpha2.StackDesiredStateActive
+
+	deployedStacks := make(map[string]*kabanerov1alpha2.Stack)
+	deployedStacks[stack.Name] = stack
+	cl := unitTestClient{deployedStacks}
+
+	server := httptest.NewServer(stackIndexHandler{})
+	defer server.Close()
+	stackUrl := server.URL + defaultIndexName
+	k := createKabanero(stackUrl)
+
+	ctx := context.Background()
+	err := reconcileFeaturedStacks(ctx, k, cl)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Two stacks should have been created.
+	javaMicroprofileStack := &kabanerov1alpha2.Stack{}
+	err = cl.Get(ctx, types.NamespacedName{Name: "java-microprofile"}, javaMicroprofileStack)
+	if err != nil {
+		t.Fatal("Could not resolve the java-microprofile stack", err)
+	}
+
+	nodejsStack := &kabanerov1alpha2.Stack{}
+	err = cl.Get(ctx, types.NamespacedName{Name: "nodejs"}, nodejsStack)
+	if err != nil {
+		t.Fatal("Could not resolve the java-microprofile stack", err)
+	}
+
+	// Only two nodejs versions are expected to be available.
+	if len(nodejsStack.Spec.Versions) != 2 {
+		t.Fatal(fmt.Sprintf("The nodejs stack did not have the number of expected versions: 2. It has: %v. Stack: %v", len(nodejsStack.Spec.Versions), nodejsStack))
+	}
+
+	// Iterate and validate that the expected versions and content match what we expect them to be.
+	for _, njVersion := range nodejsStack.Spec.Versions {
+		// Existing version 0.2.6 matches what is in the index. The content should have been overriden with what is in the index because
+		// the existing stack version did not have its desired state set.
+		if njVersion.Version == "0.2.6" {
+			if njVersion.Pipelines[0].Https.Url != "https://github.com/kabanero-io/collections/releases/download/0.4.0/incubator.common.pipeline.default.tar.gz" {
+				t.Fatal(fmt.Sprintf("Nodejs stack version 0.2.6 should have been updated. Stack version: %v", njVersion))
+			}
+		}
+
+		// Existing version 0.2.5 does exist in the new index. However it's desired state is set to active; therefore, this version must remain unchanged.
+		if njVersion.Version == "0.2.5" {
+			if njVersion.Pipelines[0].Https.Url != "https://pipelines/default/0.2.5" {
+				t.Fatal(fmt.Sprintf("Nodejs stack version 0.2.5 did not contain the expected Url. Url found: %v. Stack version: %v", njVersion.Pipelines[0].Https.Url, njVersion))
+			}
+			if njVersion.DesiredState != "active" {
+				t.Fatal(fmt.Sprintf("Nodejs stack version 0.2.5 did not contain the expected desired state of active. Desired state found: %v. Stack version: %v", njVersion.DesiredState, njVersion))
+			}
+		}
+
+		// Existing version 0.2.4 should have been deleted because it is not in the new index and its current desired state was not set.
+		if njVersion.Version == "0.2.4" {
+			t.Fatal(fmt.Sprintf("Nodejs stack version 0.2.4 should have been deleted. Stack: %v", nodejsStack))
+		}
+	}
+}
+
+// Tests that if an existing stack version with an active desired state matches the name/version of a stack in the index, the
+// data associated with the index version is ignored.
+// Tests that if an existing stack version with an active desired state does not match the name/version of a stack in the index, but
+// the existing stack version defines a desire state of active, the existing stack version is kept.
+// Tests that a stack versions with an unset/not-active desired states are removed if they are not found in the index being deployed.
+func TestResolveFeaturedStacksCleanupMatchingStackVersionWithActiveState(t *testing.T) {
+	stack := stackResource.DeepCopy()
+	stack.Spec.Versions[0].DesiredState = kabanerov1alpha2.StackDesiredStateActive
+	stack.Spec.Versions[1].DesiredState = ""
+	stack.Spec.Versions[2].DesiredState = kabanerov1alpha2.StackDesiredStateActive
+
+	deployedStacks := make(map[string]*kabanerov1alpha2.Stack)
+	deployedStacks[stack.Name] = stack
+	cl := unitTestClient{deployedStacks}
+
+	server := httptest.NewServer(stackIndexHandler{})
+	defer server.Close()
+	stackUrl := server.URL + defaultIndexName
+	k := createKabanero(stackUrl)
+
+	ctx := context.Background()
+	err := reconcileFeaturedStacks(ctx, k, cl)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Two stacks should have been created.
+	javaMicroprofileStack := &kabanerov1alpha2.Stack{}
+	err = cl.Get(ctx, types.NamespacedName{Name: "java-microprofile"}, javaMicroprofileStack)
+	if err != nil {
+		t.Fatal("Could not resolve the java-microprofile stack", err)
+	}
+
+	nodejsStack := &kabanerov1alpha2.Stack{}
+	err = cl.Get(ctx, types.NamespacedName{Name: "nodejs"}, nodejsStack)
+	if err != nil {
+		t.Fatal("Could not resolve the java-microprofile stack", err)
+	}
+
+	// Only one nodejs versions are expected to be available.
+	if len(nodejsStack.Spec.Versions) != 2 {
+		t.Fatal(fmt.Sprintf("The nodejs stack did not have the number of expected versions: 2. It has: %v. Stack: %v", len(nodejsStack.Spec.Versions), nodejsStack))
+	}
+
+	// Iterate and validate that the expected versions and content match what we expect them to be.
+	for _, njVersion := range nodejsStack.Spec.Versions {
+		// Existing version 0.2.4 does not what is in the index; however, the existing version has a desired state of active.
+		// This means that the existing version 0.2.4 should be kept.
+		if njVersion.Version == "0.2.4" {
+			if njVersion.Pipelines[0].Https.Url != "https://pipelines/default/0.2.4" {
+				t.Fatal(fmt.Sprintf("Nodejs stack version 0.2.4 should not have been updated. Stack version: %v", njVersion))
+			}
+			if njVersion.DesiredState != "active" {
+				t.Fatal(fmt.Sprintf("Nodejs stack version 0.2.4 did not contain the expected desired state of active. Desired state found: %v. Stack version: %v", njVersion.DesiredState, njVersion))
+			}
+		}
+
+		// Existing version 0.2.5 should have been deleted because it is not in the new index and its current desired state was not set.
+		if njVersion.Version == "0.2.5" {
+			t.Fatal(fmt.Sprintf("Nodejs stack version 0.2.5 should have been deleted. Stack: %v", nodejsStack))
+		}
+
+		// Existing version 0.2.6 matches what is in the index; however, the existing version has a desired state of active.
+		// This means that the existing 0.2.6 values should not be overriden by the contents of the index.
+		if njVersion.Version == "0.2.6" {
+			if njVersion.Pipelines[0].Https.Url != "https://pipelines/default/0.2.6" {
+				t.Fatal(fmt.Sprintf("Nodejs stack version 0.2.6 should not have been updated. Stack version: %v", njVersion))
+			}
+			if njVersion.DesiredState != "active" {
+				t.Fatal(fmt.Sprintf("Nodejs stack version 0.2.6 did not contain the expected desired state of active. Desired state found: %v. Stack version: %v", njVersion.DesiredState, njVersion))
+			}
+		}
+	}
+}
+
+// Tests that an existing stack is not deleted if the index does not have a matching stack and there is at least one existing stack version that defines
+// an active satate. Furthermore, any other versions of the existing stack that do not define an active desired state, should be deleted.
+func TestResolveFeaturedStacksCleanupUnmatchingStacksOneActiveVersion(t *testing.T) {
+	stack := stackResource.DeepCopy()
+	stack.Spec.Name = "cleanuptest"
+	stack.ObjectMeta.Name = "cleanuptest"
+	stack.Spec.Versions[1].DesiredState = kabanerov1alpha2.StackDesiredStateActive
+
+	deployedStacks := make(map[string]*kabanerov1alpha2.Stack)
+	deployedStacks[stack.Name] = stack
+	cl := unitTestClient{deployedStacks}
+
+	server := httptest.NewServer(stackIndexHandler{})
+	defer server.Close()
+	stackUrl := server.URL + defaultIndexName
+	k := createKabanero(stackUrl)
+
+	ctx := context.Background()
+	err := reconcileFeaturedStacks(ctx, k, cl)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Three stacks should have been deployed. nodejs and java-microprofile were defined in index
+	// and teststack was a pre-existing stack with one version set to active.
+	javaMicroprofileStack := &kabanerov1alpha2.Stack{}
+	err = cl.Get(ctx, types.NamespacedName{Name: "java-microprofile"}, javaMicroprofileStack)
+	if err != nil {
+		t.Fatal("Could not resolve the java-microprofile stack", err)
+	}
+
+	// Only one nodejs version is expected to be available.
+	if len(javaMicroprofileStack.Spec.Versions) != 1 {
+		t.Fatal(fmt.Sprintf("The java-microprofile stack did not have the number of expected versions: 1. It has: %v. Stack: %v", len(javaMicroprofileStack.Spec.Versions), javaMicroprofileStack))
+	}
+
+	// Iterate and validate that the expected versions and content match what we expect them to be.
+	for _, jmVersion := range javaMicroprofileStack.Spec.Versions {
+		// Existing version 0.2.19 matches what is in the index; however, the existing version has a desired state of active.
+		// This means that the existing values should not be overriden by the contents of the index.
+		if jmVersion.Version == "0.2.19" {
+			if jmVersion.Pipelines[0].Https.Url != "https://github.com/kabanero-io/collections/releases/download/0.4.0/incubator.common.pipeline.default.tar.gz" {
+				t.Fatal(fmt.Sprintf("java-microprofile stack version 0.2.19 should not have been updated. Stack version: %v", jmVersion))
+			}
+		}
+	}
+
+	nodejsStack := &kabanerov1alpha2.Stack{}
+	err = cl.Get(ctx, types.NamespacedName{Name: "nodejs"}, nodejsStack)
+	if err != nil {
+		t.Fatal("Could not resolve the java-microprofile stack", err)
+	}
+
+	// Only one nodejs version is expected to be available.
+	if len(nodejsStack.Spec.Versions) != 1 {
+		t.Fatal(fmt.Sprintf("The nodejs stack did not have the number of expected versions: 1. It has: %v. Stack: %v", len(nodejsStack.Spec.Versions), nodejsStack))
+	}
+
+	// Iterate and validate that the expected versions and content match what we expect them to be.
+	for _, njVersion := range nodejsStack.Spec.Versions {
+		// Existing version 0.2.6 matches what is in the index; however, the existing version has a desired state of active.
+		// This means that the existing values should not be overriden by the contents of the index.
+		if njVersion.Version == "0.2.6" {
+			if njVersion.Pipelines[0].Https.Url != "https://github.com/kabanero-io/collections/releases/download/0.4.0/incubator.common.pipeline.default.tar.gz" {
+				t.Fatal(fmt.Sprintf("Nodejs stack version 0.2.6 should not have been updated. Stack version: %v", njVersion))
+			}
+		}
+	}
+
+	cleanuptestStack := &kabanerov1alpha2.Stack{}
+	err = cl.Get(ctx, types.NamespacedName{Name: "cleanuptest"}, cleanuptestStack)
+	if err != nil {
+		t.Fatal("Could not resolve the cleanuptest stack", err)
+	}
+
+	// Only one nodejs version is expected to be available.
+	if len(cleanuptestStack.Spec.Versions) != 1 {
+		t.Fatal(fmt.Sprintf("The cleanuptest stack did not have the number of expected versions: 1. It has: %v. Stack: %v", len(cleanuptestStack.Spec.Versions), cleanuptestStack))
+	}
+
+	// Iterate and validate that the expected versions and content match what we expect them to be.
+	for _, ctVersion := range cleanuptestStack.Spec.Versions {
+		// Existing version 0.2.4 should have been deleted because it is not in the new index and its current desired state set to something other than active.
+		if ctVersion.Version == "0.2.4" {
+			t.Fatal(fmt.Sprintf("Nodejs stack version 0.2.4 should have been deleted. Stack: %v", cleanuptestStack))
+		}
+
+		// Existing version 0.2.6 should have been deleted because it is not in the new index and its current desired state was not set.
+		if ctVersion.Version == "0.2.6" {
+			t.Fatal(fmt.Sprintf("Nodejs stack version 0.2.6 should have been deleted. Stack: %v", cleanuptestStack))
+		}
+
+		// Existing version 0.2.5 matches what is in the index; however, the existing version has a desired state of active.
+		// This means that the existing values should not be overriden by the contents of the index.
+		if ctVersion.Version == "0.2.5" {
+			if ctVersion.Pipelines[0].Https.Url != "https://pipelines/default/0.2.5" {
+				t.Fatal(fmt.Sprintf("Cleanuptest stack version 0.2.6 should not have been updated. Stack version: %v", ctVersion))
+			}
+			if ctVersion.DesiredState != "active" {
+				t.Fatal(fmt.Sprintf("Cleanuptest stack version 0.2.6 did not contain the expected desired state of active. Desired state found: %v. Stack version: %v", ctVersion.DesiredState, ctVersion))
+			}
+		}
+	}
+}
+
+// Tests that an existing stack is deleted if the index does not have a matching stack and the existing stack's versions
+// do not specify an active desired state.
+func TestResolveFeaturedStacksCleanupUnmatchingStacksNoActiveVersion(t *testing.T) {
+	stack := stackResource.DeepCopy()
+	stack.Spec.Name = "cleanuptest"
+	stack.ObjectMeta.Name = "cleanuptest"
+
+	deployedStacks := make(map[string]*kabanerov1alpha2.Stack)
+	deployedStacks[stack.Name] = stack
+	cl := unitTestClient{deployedStacks}
+
+	server := httptest.NewServer(stackIndexHandler{})
+	defer server.Close()
+	stackUrl := server.URL + defaultIndexName
+	k := createKabanero(stackUrl)
+
+	ctx := context.Background()
+	err := reconcileFeaturedStacks(ctx, k, cl)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Two stacks should have been deployed from the index: nodejs and java-microprofile.
+	// The cleanuptest stack should have been deleted.
+	javaMicroprofileStack := &kabanerov1alpha2.Stack{}
+	err = cl.Get(ctx, types.NamespacedName{Name: "java-microprofile"}, javaMicroprofileStack)
+	if err != nil {
+		t.Fatal("Could not resolve the java-microprofile stack", err)
+	}
+
+	// Only one nodejs version is expected to be available.
+	if len(javaMicroprofileStack.Spec.Versions) != 1 {
+		t.Fatal(fmt.Sprintf("The java-microprofile stack did not have the number of expected versions: 1. It has: %v. Stack: %v", len(javaMicroprofileStack.Spec.Versions), javaMicroprofileStack))
+	}
+
+	// Iterate and validate that the expected versions and content match what we expect them to be.
+	for _, jmVersion := range javaMicroprofileStack.Spec.Versions {
+		// Existing version 0.2.19 matches what is in the index; however, the existing version has a desired state of active.
+		// This means that the existing values should not be overriden by the contents of the index.
+		if jmVersion.Version == "0.2.19" {
+			if jmVersion.Pipelines[0].Https.Url != "https://github.com/kabanero-io/collections/releases/download/0.4.0/incubator.common.pipeline.default.tar.gz" {
+				t.Fatal(fmt.Sprintf("java-microprofile stack version 0.2.19 should not have been updated. Stack version: %v", jmVersion))
+			}
+		}
+	}
+
+	nodejsStack := &kabanerov1alpha2.Stack{}
+	err = cl.Get(ctx, types.NamespacedName{Name: "nodejs"}, nodejsStack)
+	if err != nil {
+		t.Fatal("Could not resolve the java-microprofile stack", err)
+	}
+
+	// Only one nodejs version is expected to be available.
+	if len(nodejsStack.Spec.Versions) != 1 {
+		t.Fatal(fmt.Sprintf("The nodejsStack stack did not have the number of expected versions: 1. It has: %v. Stack: %v", len(nodejsStack.Spec.Versions), nodejsStack))
+	}
+
+	// Iterate and validate that the expected versions and content match what we expect them to be.
+	for _, njVersion := range nodejsStack.Spec.Versions {
+		// Existing version 0.2.6 matches what is in the index; however, the existing version has a desired state of active.
+		// This means that the existing values should not be overriden by the contents of the index.
+		if njVersion.Version == "0.2.6" {
+			if njVersion.Pipelines[0].Https.Url != "https://github.com/kabanero-io/collections/releases/download/0.4.0/incubator.common.pipeline.default.tar.gz" {
+				t.Fatal(fmt.Sprintf("Nodejs stack version 0.2.6 should not have been updated. Stack version: %v", njVersion))
+			}
+		}
+	}
+
+	cleanuptestStack := &kabanerov1alpha2.Stack{}
+	err = cl.Get(ctx, types.NamespacedName{Name: "cleanuptest"}, cleanuptestStack)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			t.Fatal("Could not resolve the cleanuptest stack", err)
+		}
 	}
 }

--- a/pkg/controller/kabaneroplatform/kabaneroplatform_controller.go
+++ b/pkg/controller/kabaneroplatform/kabaneroplatform_controller.go
@@ -323,7 +323,7 @@ func (r *ReconcileKabanero) Reconcile(request reconcile.Request) (reconcile.Resu
 	}
 
 	// Deploy feature collection resources.
-	err = reconcileFeaturedStacks(ctx, instance, r.client)
+	err = reconcileFeaturedStacks(ctx, instance, r.client, reqLogger)
 	if err != nil {
 		reqLogger.Error(err, "Error reconciling featured stacks.")
 		processStatus(ctx, request, instance, r.client, reqLogger)

--- a/pkg/controller/stack/resolver_test.go
+++ b/pkg/controller/stack/resolver_test.go
@@ -3,10 +3,13 @@ package stack
 import (
 	"testing"
 
+	"github.com/go-logr/logr"
 	kabanerov1alpha2 "github.com/kabanero-io/kabanero-operator/pkg/apis/kabanero/v1alpha2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+var resolverTestLogger logr.Logger = log.WithValues("Request.Namespace", "test", "Request.Name", "resolver_test")
 
 var testSecret corev1.Secret = corev1.Secret{
 	ObjectMeta: metav1.ObjectMeta{
@@ -32,7 +35,7 @@ func TestResolveIndex(t *testing.T) {
 		},
 	}
 
-	index, err := ResolveIndex(nil, repoConfig, "kabanero", []Pipelines{}, []Trigger{}, "")
+	index, err := ResolveIndex(nil, repoConfig, "kabanero", []Pipelines{}, []Trigger{}, "", resolverTestLogger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -54,7 +57,7 @@ func TestResolveIndexForStacks(t *testing.T) {
 
 	pipelines := []Pipelines{{Id: "testPipeline", Sha256: "1234567890", Url: "https://github.com/kabanero-io/collections/releases/download/0.5.0-rc.2/incubator.common.pipeline.default.tar.gz"}}
 	triggers := []Trigger{{Id: "testTrigger", Sha256: "0987654321", Url: "https://github.com/kabanero-io/collections/releases/download/0.5.0-rc.2/incubator.trigger.tar.gz"}}
-	index, err := ResolveIndex(nil, repoConfig, "kabanero", pipelines, triggers, "kabanerobeta")
+	index, err := ResolveIndex(nil, repoConfig, "kabanero", pipelines, triggers, "kabanerobeta", resolverTestLogger)
 
 	if err != nil {
 		t.Fatal(err)
@@ -118,7 +121,7 @@ func TestResolveIndexForStacksInPublicGitFailure1(t *testing.T) {
 
 	pipelines := []Pipelines{{Id: "testPipeline", Sha256: "1234567890", Url: "https://github.com/kabanero-io/collections/releases/download/0.5.0-rc.2/incubator.common.pipeline.default.tar.gz"}}
 	triggers := []Trigger{{Id: "testTrigger", Sha256: "0987654321", Url: "https://github.com/kabanero-io/collections/releases/download/0.5.0-rc.2/incubator.trigger.tar.gz"}}
-	index, err := ResolveIndex(nil, repoConfig, "kabanero", pipelines, triggers, "kabanerobeta")
+	index, err := ResolveIndex(nil, repoConfig, "kabanero", pipelines, triggers, "kabanerobeta", resolverTestLogger)
 
 	if err == nil {
 		t.Fatal("No Git release or Http url were specified. An error was expected. Index: ", index)

--- a/pkg/controller/stack/stack_controller.go
+++ b/pkg/controller/stack/stack_controller.go
@@ -11,9 +11,9 @@ import (
 	kabanerov1alpha2 "github.com/kabanero-io/kabanero-operator/pkg/apis/kabanero/v1alpha2"
 	sutils "github.com/kabanero-io/kabanero-operator/pkg/controller/stack/utils"
 	"github.com/kabanero-io/kabanero-operator/pkg/controller/transforms"
-	mf "github.com/manifestival/manifestival"
 	mfc "github.com/manifestival/controller-runtime-client"
-	
+	mf "github.com/manifestival/manifestival"
+
 	//	corev1 "k8s.io/api/core/v1"
 	pipelinev1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -136,7 +136,7 @@ type ReconcileStack struct {
 	scheme *runtime.Scheme
 
 	//The indexResolver which will be used during reconciliation
-	indexResolver func(client.Client, kabanerov1alpha2.RepositoryConfig, string, []Pipelines, []Trigger, string) (*Index, error)
+	indexResolver func(client.Client, kabanerov1alpha2.RepositoryConfig, string, []Pipelines, []Trigger, string, logr.Logger) (*Index, error)
 }
 
 // Reconcile reads that state of the cluster for a Stack object and makes changes based on the state read
@@ -585,7 +585,7 @@ func reconcileActiveVersions(stackResource *kabanerov1alpha2.Stack, c client.Cli
 		log.Info(fmt.Sprintf("Updated stack status: %#v", newStackVersionStatus))
 		newStackStatus.Versions = append(newStackStatus.Versions, newStackVersionStatus)
 	}
-	
+
 	newStackStatus.Summary = stackSummary(newStackStatus)
 
 	stackResource.Status = newStackStatus

--- a/pkg/controller/stack/stack_controller_test.go
+++ b/pkg/controller/stack/stack_controller_test.go
@@ -41,7 +41,7 @@ func init() {
 }
 
 func TestReconcileStack(t *testing.T) {
-	r := &ReconcileStack{indexResolver: func(client.Client, kabanerov1alpha2.RepositoryConfig, string, []Pipelines, []Trigger, string) (*Index, error) {
+	r := &ReconcileStack{indexResolver: func(client.Client, kabanerov1alpha2.RepositoryConfig, string, []Pipelines, []Trigger, string, logr.Logger) (*Index, error) {
 		return &Index{
 			APIVersion: "v2",
 			Stacks: []Stack{


### PR DESCRIPTION
Associated with #353.
This PR allows existing stacks to be cleaned up based on their set desired state (existing stack versions with an active desired state are not touched per the new definition of desired state - see 353 for details) and the index file(s) being processed.