### PR TITLE
Prep for Kabanero version 0.8.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ STACK_CTRLR_REPOSITORY=$(firstword $(subst :, ,${STACK_CTRLR_IMAGE}))
 
 
 # Current release (used for CSV management)
-CURRENT_RELEASE=0.7.0
+CURRENT_RELEASE=0.8.0
 
 # OS detection
 ifeq ($(OS),Windows_NT)

--- a/config/samples/default.yaml
+++ b/config/samples/default.yaml
@@ -3,7 +3,7 @@ kind: Kabanero
 metadata:
   name: kabanero
 spec:
-  version: "0.7.0"
+  version: "0.8.0"
   stacks:
     repositories:
     - name: central

--- a/config/samples/default.yaml
+++ b/config/samples/default.yaml
@@ -8,9 +8,9 @@ spec:
     repositories:
     - name: central
       https:
-        url: https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.7.0-rc.1/kabanero-stack-hub-index.yaml
+        url: https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.7.0/kabanero-stack-hub-index.yaml
     pipelines:
     - id: default
-      sha256: 8d2cba24eef31fea470abc860909b407f0af54016acb79b723c04c711350d344
+      sha256: e6ebc6aeaf21540f0d0dac8caf0a2d805e8d90f174cb912a31831f700d049bb1
       https:
-        url: https://github.com/kabanero-io/kabanero-pipelines/releases/download/0.7.0-rc.1/default-kabanero-pipelines.tar.gz
+        url: https://github.com/kabanero-io/kabanero-pipelines/releases/download/0.7.0/default-kabanero-pipelines.tar.gz

--- a/config/samples/full.yaml
+++ b/config/samples/full.yaml
@@ -17,14 +17,14 @@ spec:
 
   cliServices:
     # Overrides the setting for version on this component
-    version: "0.7.0-rc.1"
+    version: "0.7.0"
 
     # Overrides the image as a separate repository or tag
     repository: kabanero/kabanero-command-line-services
-    tag: "0.7.0-rc.1"
+    tag: "0.7.0"
 
     # Overrides the image uri
-    image: kabanero/kabanero-command-line-services:0.7.0-rc.1
+    image: kabanero/kabanero-command-line-services:0.7.0
 
     # Indicates the token expiration time 
     # Specify a positive integer followed by a unit of time, which can be hours (h), minutes (m), or seconds (s). 
@@ -34,50 +34,50 @@ spec:
 
   collectionController:
     # Overrides the setting for version on this component
-    version: "0.7.0-rc.1"
+    version: "0.7.0"
 
     # Overrides the image as a separate repository or tag
     repository: kabanero/kabaner-operator-collection-controller
-    tag: "0.7.0-rc.1"
+    tag: "0.7.0"
 
     # Overrides the image uri
-    image: kabanero/kabanero-operator-collection-controller:0.7.0-rc.1
+    image: kabanero/kabanero-operator-collection-controller:0.7.0
 
   stackController:
     # Overrides the setting for version on this component
-    version: "0.7.0-rc.1"
+    version: "0.7.0"
 
     # Overrides the image as a separate repository or tag
     repository: kabanero/kabaner-operator-stack-controller
-    tag: "0.7.0-rc.1"
+    tag: "0.7.0"
 
     # Overrides the image uri
-    image: kabanero/kabanero-operator-stack-controller:0.7.0-rc.1
+    image: kabanero/kabanero-operator-stack-controller:0.7.0
 
   landing:
     # The landing page is enabled by default. To disable specify false.
     enable: true
 
     # Overrides the setting for version on this component
-    version: "0.7.0-rc.1"
+    version: "0.7.0"
 
     # Overrides the image as a separate repository or tag
     repository: kabanero/landing
-    tag: "0.7.0-rc.1"
+    tag: "0.7.0"
 
     # Overrides the image uri
-    image: kabanero/landing:0.7.0-rc.1
+    image: kabanero/landing:0.7.0
 
   admissionControllerWebhook:
     # Overrides the setting for version on this component
-    version: "0.7.0-rc.1"
+    version: "0.7.0"
 
     # Overrides the image as a separate repository or tag
     repository: kabanero/kabanero-operator-admission-webhook
-    tag: "0.7.0-rc.1"
+    tag: "0.7.0"
 
     # Overrides the image uri
-    image: kabanero/kabanero-operator-admission-webhook:0.7.0-rc.1
+    image: kabanero/kabanero-operator-admission-webhook:0.7.0
     
   codeReadyWorkspaces:
     # CodeReadyWorkspaces CR instance deployment is disabled by default. To enable it, set the enable value to true. 
@@ -118,12 +118,12 @@ spec:
     repositories: 
     - name: incubator
       https:
-        url: https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.7.0-rc.1/kabanero-stack-hub-index.yaml
+        url: https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.7.0/kabanero-stack-hub-index.yaml
     pipelines:
     - id: default
-      sha256: 8d2cba24eef31fea470abc860909b407f0af54016acb79b723c04c711350d344
+      sha256: e6ebc6aeaf21540f0d0dac8caf0a2d805e8d90f174cb912a31831f700d049bb1
       https:
-        url: https://github.com/kabanero-io/kabanero-pipelines/releases/download/0.7.0-rc.1/default-kabanero-pipelines.tar.gz
+        url: https://github.com/kabanero-io/kabanero-pipelines/releases/download/0.7.0/default-kabanero-pipelines.tar.gz
 
   # The information in the 'github' section is used by the Kabanero CLI and Console to
   # help access and manage the stacks.

--- a/config/samples/full.yaml
+++ b/config/samples/full.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   # The platform version determines the desired version for all components, but those
   # can be overriden individually as well
-  version: "0.7.0"
+  version: "0.8.0"
 
   targetNamespaces:
   - ns1

--- a/config/versions.yaml
+++ b/config/versions.yaml
@@ -13,6 +13,17 @@ default: "0.7.0"
 
 # Top level: relates Kabanero versions to software versions
 kabanero:
+- version: "0.8.0"
+  related-versions: 
+    cli-services: "0.7.0"
+    landing: "0.7.0"
+    events: "0.1.0"
+    collection-controller: "0.7.0"
+    stack-controller: "0.7.0"
+    admission-webhook: "0.7.0"
+    sso: "7.3.2"
+    codeready-workspaces: "0.6.0"
+
 - version: "0.7.0"
   related-versions: 
     cli-services: "0.7.0"

--- a/config/versions.yaml
+++ b/config/versions.yaml
@@ -15,12 +15,12 @@ default: "0.7.0"
 kabanero:
 - version: "0.7.0"
   related-versions: 
-    cli-services: "0.7.0-rc.1"
+    cli-services: "0.7.0"
     landing: "0.7.0"
     events: "0.1.0"
-    collection-controller: "0.7.0-rc.1"
-    stack-controller: "0.7.0-rc.1"
-    admission-webhook: "0.7.0-rc.1"
+    collection-controller: "0.7.0"
+    stack-controller: "0.7.0"
+    admission-webhook: "0.7.0"
     sso: "7.3.2"
     codeready-workspaces: "0.6.0"
 
@@ -29,9 +29,9 @@ kabanero:
     cli-services: "0.6.0"
     landing: "0.6.0"
     events: "0.1.0"
-    collection-controller: "0.6.1-rc.3"
-    stack-controller: "0.6.1-rc.3"
-    admission-webhook: "0.6.1-rc.3"
+    collection-controller: "0.6.1"
+    stack-controller: "0.6.1"
+    admission-webhook: "0.6.1"
     sso: "7.3.2"
     codeready-workspaces: "0.6.0"
     
@@ -60,11 +60,11 @@ related-software:
       tag: "0.6.0"
 
   cli-services: 
-  - version: "0.7.0-rc.1"
+  - version: "0.7.0"
     orchestrations: "orchestrations/cli-services/0.1"
     identifiers:
       repository: "kabanero/kabanero-command-line-services"
-      tag: "0.7.0-rc.1"
+      tag: "0.7.0"
   - version: "0.6.0"
     orchestrations: "orchestrations/cli-services/0.1"
     identifiers:
@@ -86,16 +86,16 @@ related-software:
       tag: "0.1"
 
   collection-controller: 
-  - version: "0.7.0-rc.1"
+  - version: "0.7.0"
     orchestrations: "orchestrations/collection-controller/0.1"
     identifiers:
       repository: "kabanero/kabanero-operator-collection-controller"
-      tag: "0.7.0-rc.1"
-  - version: "0.6.1-rc.3"
+      tag: "0.7.0"
+  - version: "0.6.1"
     orchestrations: "orchestrations/collection-controller/0.1"
     identifiers:
       repository: "kabanero/kabanero-operator-collection-controller"
-      tag: "0.6.1-rc.3"
+      tag: "0.6.1"
   - version: "0.6.0"
     orchestrations: "orchestrations/collection-controller/0.1"
     identifiers:
@@ -103,16 +103,16 @@ related-software:
       tag: "0.6.0"
 
   stack-controller: 
-  - version: "0.7.0-rc.1"
+  - version: "0.7.0"
     orchestrations: "orchestrations/stack-controller/0.1"
     identifiers:
       repository: "kabanero/kabanero-operator-stack-controller"
-      tag: "0.7.0-rc.1"
-  - version: "0.6.1-rc.3"
+      tag: "0.7.0"
+  - version: "0.6.1"
     orchestrations: "orchestrations/stack-controller/0.1"
     identifiers:
       repository: "kabanero/kabanero-operator-stack-controller"
-      tag: "0.6.1-rc.3"
+      tag: "0.6.1"
   - version: "0.6.0"
     orchestrations: "orchestrations/stack-controller/0.1"
     identifiers:
@@ -120,16 +120,16 @@ related-software:
       tag: "0.6.0"
 
   admission-webhook:
-  - version: "0.7.0-rc.1"
+  - version: "0.7.0"
     orchestrations: "orchestrations/admission-webhook/0.2"
     identifiers:
       repository: "kabanero/kabanero-operator-admission-webhook"
-      tag: "0.7.0-rc.1"
-  - version: "0.6.1-rc.3"
+      tag: "0.7.0"
+  - version: "0.6.1"
     orchestrations: "orchestrations/admission-webhook/0.2"
     identifiers:
       repository: "kabanero/kabanero-operator-admission-webhook"
-      tag: "0.6.1-rc.3"
+      tag: "0.6.1"
   - version: "0.6.0"
     orchestrations: "orchestrations/admission-webhook/0.2"
     identifiers:

--- a/deploy/kabanero-subscriptions.yaml
+++ b/deploy/kabanero-subscriptions.yaml
@@ -169,7 +169,7 @@ metadata:
   labels:
     kabanero.io/install: 14-subscription
 spec:
-  channel: release-0.7
+  channel: release-0.8
   installPlanApproval: Automatic
   name: kabanero-operator
   source: kabanero-catalog

--- a/registry/manifests/kabanero-operator/0.7.0/kabanero-operator.v0.7.0.clusterserviceversion.yaml
+++ b/registry/manifests/kabanero-operator/0.7.0/kabanero-operator.v0.7.0.clusterserviceversion.yaml
@@ -28,16 +28,16 @@ metadata:
                 {
                   "name": "incubator",
                   "https": {
-                    "url": "https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.7.0-rc.1/kabanero-stack-hub-index.yaml"
+                    "url": "https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.7.0/kabanero-stack-hub-index.yaml"
                   }
                 }
               ],
               "pipelines": [
                 {
                   "id": "default",
-                  "sha256": "8d2cba24eef31fea470abc860909b407f0af54016acb79b723c04c711350d344",
+                  "sha256": "e6ebc6aeaf21540f0d0dac8caf0a2d805e8d90f174cb912a31831f700d049bb1",
                   "https": {
-                    "url": "https://github.com/kabanero-io/kabanero-pipelines/releases/download/0.7.0-rc.1/default-kabanero-pipelines.tar.gz"
+                    "url": "https://github.com/kabanero-io/kabanero-pipelines/releases/download/0.7.0/default-kabanero-pipelines.tar.gz"
                   }
                 }
               ]
@@ -68,9 +68,9 @@ metadata:
               { "version": "0.2.25",
                 "pipelines": [
                   { "id": "default",
-                    "sha256": "8d2cba24eef31fea470abc860909b407f0af54016acb79b723c04c711350d344",
+                    "sha256": "e6ebc6aeaf21540f0d0dac8caf0a2d805e8d90f174cb912a31831f700d049bb1",
                     "https": {
-                      "url": "https://github.com/kabanero-io/kabanero-pipelines/releases/download/0.7.0-rc.1/default-kabanero-pipelines.tar.gz"
+                      "url": "https://github.com/kabanero-io/kabanero-pipelines/releases/download/0.7.0/default-kabanero-pipelines.tar.gz"
                     }
                   }
                 ],

--- a/registry/manifests/kabanero-operator/0.7.0/kabanero.io_collections_crd.yaml
+++ b/registry/manifests/kabanero-operator/0.7.0/kabanero.io_collections_crd.yaml
@@ -1,0 +1,207 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: collections.kabanero.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.creationTimestamp
+    description: CreationTimestamp is a timestamp representing the server time when
+      this object was created. It is not guaranteed to be set in happens-before order
+      across separate operations.
+    name: Age
+    type: date
+  - JSONPath: .status.status
+    description: Collection status.
+    name: Status
+    type: string
+  group: kabanero.io
+  names:
+    kind: Collection
+    listKind: CollectionList
+    plural: collections
+    singular: collection
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Collection is the Schema for the collections API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: CollectionSpec defines the desired composition of a Collection
+          properties:
+            desiredState:
+              type: string
+            name:
+              type: string
+            repositoryUrl:
+              type: string
+            skipCertVerification:
+              type: boolean
+            version:
+              type: string
+            versions:
+              items:
+                description: CollectionVersion defines the desired composition of
+                  a specific collection version.
+                properties:
+                  desiredState:
+                    type: string
+                  repositoryUrl:
+                    type: string
+                  skipCertVerification:
+                    type: boolean
+                  version:
+                    type: string
+                type: object
+              type: array
+          type: object
+        status:
+          description: CollectionStatus defines the observed state of a collection
+          properties:
+            activeLocation:
+              type: string
+            activePipelines:
+              items:
+                description: PipelineStatus defines the observed state of the assets
+                  located within a single pipeline .tar.gz.
+                properties:
+                  activeAssets:
+                    items:
+                      description: RepositoryAssetStatus defines the observed state
+                        of a single asset in a respository, in the collection.
+                      properties:
+                        assetDigest:
+                          type: string
+                        assetName:
+                          type: string
+                        group:
+                          type: string
+                        kind:
+                          type: string
+                        namespace:
+                          type: string
+                        status:
+                          type: string
+                        statusMessage:
+                          type: string
+                        version:
+                          type: string
+                      type: object
+                    type: array
+                  digest:
+                    type: string
+                  name:
+                    type: string
+                  url:
+                    type: string
+                required:
+                - digest
+                - name
+                - url
+                type: object
+              type: array
+            activeVersion:
+              type: string
+            availableLocation:
+              type: string
+            availableVersion:
+              type: string
+            images:
+              items:
+                description: Image defines a container image used by a collection
+                properties:
+                  id:
+                    type: string
+                  image:
+                    type: string
+                type: object
+              type: array
+            status:
+              type: string
+            statusMessage:
+              type: string
+            versions:
+              items:
+                description: CollectionVersionStatus defines the observed state of
+                  a specific collection version.
+                properties:
+                  images:
+                    items:
+                      description: Image defines a container image used by a collection
+                      properties:
+                        id:
+                          type: string
+                        image:
+                          type: string
+                      type: object
+                    type: array
+                  location:
+                    type: string
+                  pipelines:
+                    items:
+                      description: PipelineStatus defines the observed state of the
+                        assets located within a single pipeline .tar.gz.
+                      properties:
+                        activeAssets:
+                          items:
+                            description: RepositoryAssetStatus defines the observed
+                              state of a single asset in a respository, in the collection.
+                            properties:
+                              assetDigest:
+                                type: string
+                              assetName:
+                                type: string
+                              group:
+                                type: string
+                              kind:
+                                type: string
+                              namespace:
+                                type: string
+                              status:
+                                type: string
+                              statusMessage:
+                                type: string
+                              version:
+                                type: string
+                            type: object
+                          type: array
+                        digest:
+                          type: string
+                        name:
+                          type: string
+                        url:
+                          type: string
+                      required:
+                      - digest
+                      - name
+                      - url
+                      type: object
+                    type: array
+                  status:
+                    type: string
+                  statusMessage:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              type: array
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/registry/manifests/kabanero-operator/0.7.0/kabanero.io_kabaneros_crd.yaml
+++ b/registry/manifests/kabanero-operator/0.7.0/kabanero.io_kabaneros_crd.yaml
@@ -1,0 +1,868 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kabaneros.kabanero.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.creationTimestamp
+    description: CreationTimestamp is a timestamp representing the server time when
+      this object was created. It is not guaranteed to be set in happens-before order
+      across separate operations.
+    name: Age
+    type: date
+  - JSONPath: .status.kabaneroInstance.version
+    description: Kabanero operator instance version.
+    name: Version
+    type: string
+  - JSONPath: .status.kabaneroInstance.ready
+    description: Kabanero operator instance readiness status. The status is directly
+      correlated to the availability of the operator's resources dependencies.
+    name: Ready
+    type: string
+  group: kabanero.io
+  names:
+    kind: Kabanero
+    listKind: KabaneroList
+    plural: kabaneros
+    singular: kabanero
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KabaneroSpec defines the desired state of Kabanero
+            properties:
+              admissionControllerWebhook:
+                properties:
+                  image:
+                    type: string
+                  repository:
+                    type: string
+                  tag:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              che:
+                description: CheCustomizationSpec defines customization entries for
+                  Che.
+                properties:
+                  cheOperatorInstance:
+                    description: CheOperatorInstanceSpec defines customization entries
+                      for the Che operator instance.
+                    properties:
+                      cheWorkspaceClusterRole:
+                        type: string
+                    type: object
+                  enable:
+                    type: boolean
+                  kabaneroChe:
+                    description: KabaneroCheSpec defines customization entries for
+                      Kabanero Che.
+                    properties:
+                      image:
+                        type: string
+                      repository:
+                        type: string
+                      tag:
+                        type: string
+                      version:
+                        type: string
+                    type: object
+                type: object
+              cliServices:
+                description: KabaneroCliServicesCustomizationSpec defines customization
+                  entries for the Kabanero CLI.
+                properties:
+                  image:
+                    type: string
+                  repository:
+                    type: string
+                  sessionExpirationSeconds:
+                    type: string
+                  tag:
+                    type: string
+                  version:
+                    description: 'Future: Enable     bool   `json:"enable,omitempty"`'
+                    type: string
+                type: object
+              collectionController:
+                description: CollectionControllerSpec defines customization entried
+                  for the Kabanero collection controller.
+                properties:
+                  image:
+                    type: string
+                  repository:
+                    type: string
+                  tag:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              collections:
+                description: InstanceCollectionConfig defines the customization entries
+                  for a set of collections.
+                properties:
+                  repositories:
+                    items:
+                      description: RepositoryConfig defines customization entries
+                        for a collection.
+                      properties:
+                        activateDefaultCollections:
+                          type: boolean
+                        name:
+                          type: string
+                        skipCertVerification:
+                          type: boolean
+                        url:
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              events:
+                properties:
+                  enable:
+                    type: boolean
+                  image:
+                    type: string
+                  repository:
+                    type: string
+                  tag:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              github:
+                description: GithubConfig represents the Github information (public
+                  or GHE) where the organization and teams managing the collections
+                  live.  Members of the specified team in the specified organization
+                  will have admin authority in the Kabanero CLI.
+                properties:
+                  apiUrl:
+                    type: string
+                  organization:
+                    type: string
+                  teams:
+                    items:
+                      type: string
+                    type: array
+                type: object
+              landing:
+                description: KabaneroLandingCustomizationSpec defines customization
+                  entries for Kabanero landing page.
+                properties:
+                  enable:
+                    type: boolean
+                  version:
+                    type: string
+                type: object
+              targetNamespaces:
+                items:
+                  type: string
+                type: array
+              tekton:
+                description: TektonCustomizationSpec defines customization entries
+                  for Tekton
+                properties:
+                  disabled:
+                    type: boolean
+                  version:
+                    type: string
+                type: object
+              version:
+                type: string
+            type: object
+          status:
+            description: KabaneroStatus defines the observed state of the Kabanero
+              instance.
+            properties:
+              admissionControllerWebhook:
+                description: Admission webhook instance status
+                properties:
+                  errorMessage:
+                    type: string
+                  ready:
+                    type: string
+                type: object
+              appsody:
+                description: Appsody instance readiness status.
+                properties:
+                  errorMessage:
+                    type: string
+                  ready:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              che:
+                description: Che instance readiness status.
+                properties:
+                  cheOperator:
+                    description: CheOperatorStatus defines the observed status details
+                      of the Che operator.
+                    properties:
+                      version:
+                        type: string
+                    type: object
+                  errorMessage:
+                    type: string
+                  kabaneroChe:
+                    description: KabaneroCheStatus defines the observed status details
+                      of Kabanero Che.
+                    properties:
+                      version:
+                        type: string
+                    type: object
+                  kabaneroCheInstance:
+                    description: KabaneroCheInstanceStatus defines the observed status
+                      details of Che instance.
+                    properties:
+                      cheImage:
+                        type: string
+                      cheImageTag:
+                        type: string
+                      cheWorkspaceClusterRole:
+                        type: string
+                    type: object
+                  ready:
+                    type: string
+                type: object
+              cli:
+                description: CLI readiness status.
+                properties:
+                  errorMessage:
+                    type: string
+                  hostnames:
+                    items:
+                      type: string
+                    type: array
+                  ready:
+                    type: string
+                type: object
+              collectionController:
+                description: Kabanero collection controller readiness status.
+                properties:
+                  errorMessage:
+                    type: string
+                  ready:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              events:
+                description: Events instance status
+                properties:
+                  errorMessage:
+                    type: string
+                  hostnames:
+                    items:
+                      type: string
+                    type: array
+                  ready:
+                    type: string
+                type: object
+              kabaneroInstance:
+                description: Kabanero operator instance readiness status. The status
+                  is directly correlated to the availability of resources dependencies.
+                properties:
+                  errorMessage:
+                    type: string
+                  ready:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              kappnav:
+                description: Kabanero Application Navigator instance readiness status.
+                properties:
+                  apiLocations:
+                    items:
+                      type: string
+                    type: array
+                  errorMessage:
+                    type: string
+                  ready:
+                    type: string
+                  uiLocations:
+                    items:
+                      type: string
+                    type: array
+                type: object
+              knativeEventing:
+                description: Knative eventing instance readiness status.
+                properties:
+                  errorMessage:
+                    type: string
+                  ready:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              landing:
+                description: Kabanero Landing page readiness status.
+                properties:
+                  errorMessage:
+                    type: string
+                  ready:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              serverless:
+                description: OpenShift serverless operator status.
+                properties:
+                  errorMessage:
+                    type: string
+                  knativeServing:
+                    description: KnativeServingStatus defines the observed status
+                      details of Knative Serving.
+                    properties:
+                      errorMessage:
+                        type: string
+                      ready:
+                        type: string
+                      version:
+                        type: string
+                    type: object
+                  ready:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              tekton:
+                description: Tekton instance readiness status.
+                properties:
+                  errorMessage:
+                    type: string
+                  ready:
+                    type: string
+                  version:
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: false
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KabaneroSpec defines the desired state of Kabanero
+            properties:
+              admissionControllerWebhook:
+                properties:
+                  image:
+                    type: string
+                  repository:
+                    type: string
+                  tag:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              cliServices:
+                description: KabaneroCliServicesCustomizationSpec defines customization
+                  entries for the Kabanero CLI.
+                properties:
+                  image:
+                    type: string
+                  repository:
+                    type: string
+                  sessionExpirationSeconds:
+                    type: string
+                  tag:
+                    type: string
+                  version:
+                    description: 'Future: Enable     bool   `json:"enable,omitempty"`'
+                    type: string
+                type: object
+              codeReadyWorkspaces:
+                description: CRWCustomizationSpec defines customization entries for
+                  codeready-workspaces.
+                properties:
+                  enable:
+                    type: boolean
+                  operator:
+                    description: CRWOperatorSpec defines customization entries for
+                      the codeready-workspaces operator.
+                    properties:
+                      customResourceInstance:
+                        description: CRWOperatorCustomResourceSpec defines custom
+                          resource customization entries for the codeready-workspaces
+                          operator.
+                        properties:
+                          cheWorkspaceClusterRole:
+                            type: string
+                          devFileRegistryImage:
+                            description: CWRCustomResourceDevFileRegImage defines
+                              DevFileRegistryImage custom resource customization for
+                              the codeready-workspaces operator.
+                            properties:
+                              image:
+                                type: string
+                              repository:
+                                type: string
+                              tag:
+                                type: string
+                              version:
+                                type: string
+                            type: object
+                          openShiftOAuth:
+                            type: boolean
+                          selfSignedCert:
+                            type: boolean
+                          tlsSupport:
+                            type: boolean
+                        type: object
+                    type: object
+                type: object
+              collectionController:
+                description: CollectionControllerSpec defines customization entried
+                  for the Kabanero collection controller.
+                properties:
+                  image:
+                    type: string
+                  repository:
+                    type: string
+                  tag:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              events:
+                properties:
+                  enable:
+                    type: boolean
+                  image:
+                    type: string
+                  repository:
+                    type: string
+                  tag:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              github:
+                description: GithubConfig represents the Github information (public
+                  or GHE) where the organization and teams managing the stacks live.  Members
+                  of the specified team in the specified organization will have admin
+                  authority in the Kabanero CLI.
+                properties:
+                  apiUrl:
+                    type: string
+                  organization:
+                    type: string
+                  teams:
+                    items:
+                      type: string
+                    type: array
+                type: object
+              landing:
+                description: KabaneroLandingCustomizationSpec defines customization
+                  entries for Kabanero landing page.
+                properties:
+                  enable:
+                    type: boolean
+                  image:
+                    type: string
+                  repository:
+                    type: string
+                  tag:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              sso:
+                properties:
+                  adminSecretName:
+                    type: string
+                  enable:
+                    type: boolean
+                  provider:
+                    type: string
+                type: object
+              stackController:
+                description: StackControllerSpec defines customization entried for
+                  the Kabanero stack controller.
+                properties:
+                  image:
+                    type: string
+                  repository:
+                    type: string
+                  tag:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              stacks:
+                description: InstanceStackConfig defines the customization entries
+                  for a set of stacks.
+                properties:
+                  pipelines:
+                    items:
+                      description: PipelineSpec defines the sets of default pipelines
+                        for the stacks.
+                      properties:
+                        gitRelease:
+                          description: GitReleaseSpec defines customization entries
+                            for a Git release.
+                          properties:
+                            assetName:
+                              type: string
+                            hostname:
+                              type: string
+                            organization:
+                              type: string
+                            project:
+                              type: string
+                            release:
+                              type: string
+                            skipCertVerification:
+                              type: boolean
+                          type: object
+                        https:
+                          description: HttpsProtocolFile defines how to retrieve a
+                            file over https
+                          properties:
+                            skipCertVerification:
+                              type: boolean
+                            url:
+                              type: string
+                          type: object
+                        id:
+                          type: string
+                        sha256:
+                          type: string
+                      type: object
+                    type: array
+                  repositories:
+                    items:
+                      description: RepositoryConfig defines customization entries
+                        for a stack.
+                      properties:
+                        gitRelease:
+                          description: GitReleaseSpec defines customization entries
+                            for a Git release.
+                          properties:
+                            assetName:
+                              type: string
+                            hostname:
+                              type: string
+                            organization:
+                              type: string
+                            project:
+                              type: string
+                            release:
+                              type: string
+                            skipCertVerification:
+                              type: boolean
+                          type: object
+                        https:
+                          description: HttpsProtocolFile defines how to retrieve a
+                            file over https
+                          properties:
+                            skipCertVerification:
+                              type: boolean
+                            url:
+                              type: string
+                          type: object
+                        name:
+                          type: string
+                        pipelines:
+                          items:
+                            description: PipelineSpec defines the sets of default
+                              pipelines for the stacks.
+                            properties:
+                              gitRelease:
+                                description: GitReleaseSpec defines customization
+                                  entries for a Git release.
+                                properties:
+                                  assetName:
+                                    type: string
+                                  hostname:
+                                    type: string
+                                  organization:
+                                    type: string
+                                  project:
+                                    type: string
+                                  release:
+                                    type: string
+                                  skipCertVerification:
+                                    type: boolean
+                                type: object
+                              https:
+                                description: HttpsProtocolFile defines how to retrieve
+                                  a file over https
+                                properties:
+                                  skipCertVerification:
+                                    type: boolean
+                                  url:
+                                    type: string
+                                type: object
+                              id:
+                                type: string
+                              sha256:
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    type: array
+                type: object
+              targetNamespaces:
+                items:
+                  type: string
+                type: array
+              triggers:
+                items:
+                  description: TriggerSpec defines the sets of default triggers for
+                    the stacks
+                  properties:
+                    gitRelease:
+                      description: GitReleaseSpec defines customization entries for
+                        a Git release.
+                      properties:
+                        assetName:
+                          type: string
+                        hostname:
+                          type: string
+                        organization:
+                          type: string
+                        project:
+                          type: string
+                        release:
+                          type: string
+                        skipCertVerification:
+                          type: boolean
+                      type: object
+                    https:
+                      description: HttpsProtocolFile defines how to retrieve a file
+                        over https
+                      properties:
+                        skipCertVerification:
+                          type: boolean
+                        url:
+                          type: string
+                      type: object
+                    id:
+                      type: string
+                    sha256:
+                      type: string
+                  type: object
+                type: array
+              version:
+                type: string
+            type: object
+          status:
+            description: KabaneroStatus defines the observed state of the Kabanero
+              instance.
+            properties:
+              admissionControllerWebhook:
+                description: Admission webhook instance status
+                properties:
+                  message:
+                    type: string
+                  ready:
+                    type: string
+                type: object
+              appsody:
+                description: Appsody instance readiness status.
+                properties:
+                  message:
+                    type: string
+                  ready:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              cli:
+                description: CLI readiness status.
+                properties:
+                  hostnames:
+                    items:
+                      type: string
+                    type: array
+                  message:
+                    type: string
+                  ready:
+                    type: string
+                type: object
+              codereadyWorkspaces:
+                description: Codeready-workspaces instance readiness status.
+                properties:
+                  message:
+                    type: string
+                  operator:
+                    description: CRWOperatorStatus defines the observed status details
+                      of the codeready-workspaces operator.
+                    properties:
+                      instance:
+                        description: CRWInstanceStatus defines the observed status
+                          details of the codeready-workspaces operator custom resource.
+                        properties:
+                          cheWorkspaceClusterRole:
+                            type: string
+                          devfileRegistryImage:
+                            type: string
+                          openShiftOAuth:
+                            type: boolean
+                          selfSignedCert:
+                            type: boolean
+                          tlsSupport:
+                            type: boolean
+                        required:
+                        - cheWorkspaceClusterRole
+                        - devfileRegistryImage
+                        - openShiftOAuth
+                        - selfSignedCert
+                        - tlsSupport
+                        type: object
+                      version:
+                        type: string
+                    type: object
+                  ready:
+                    type: string
+                type: object
+              collectionController:
+                description: Kabanero collection controller readiness status.
+                properties:
+                  message:
+                    type: string
+                  ready:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              events:
+                description: Events instance status
+                properties:
+                  hostnames:
+                    items:
+                      type: string
+                    type: array
+                  message:
+                    type: string
+                  ready:
+                    type: string
+                type: object
+              kabaneroInstance:
+                description: Kabanero operator instance readiness status. The status
+                  is directly correlated to the availability of resources dependencies.
+                properties:
+                  message:
+                    type: string
+                  ready:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              kappnav:
+                description: Kabanero Application Navigator instance readiness status.
+                properties:
+                  apiLocations:
+                    items:
+                      type: string
+                    type: array
+                  message:
+                    type: string
+                  ready:
+                    type: string
+                  uiLocations:
+                    items:
+                      type: string
+                    type: array
+                type: object
+              landing:
+                description: Kabanero Landing page readiness status.
+                properties:
+                  message:
+                    type: string
+                  ready:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              serverless:
+                description: OpenShift serverless operator status.
+                properties:
+                  knativeServing:
+                    description: KnativeServingStatus defines the observed status
+                      details of Knative Serving.
+                    properties:
+                      message:
+                        type: string
+                      ready:
+                        type: string
+                      version:
+                        type: string
+                    type: object
+                  message:
+                    type: string
+                  ready:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              sso:
+                description: SSO server status
+                properties:
+                  configured:
+                    type: string
+                  message:
+                    type: string
+                  ready:
+                    type: string
+                type: object
+              stackController:
+                description: Kabanero stack controller readiness status.
+                properties:
+                  message:
+                    type: string
+                  ready:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              tekton:
+                description: Tekton instance readiness status.
+                properties:
+                  message:
+                    type: string
+                  ready:
+                    type: string
+                  version:
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true

--- a/registry/manifests/kabanero-operator/0.7.0/kabanero.io_stacks_crd.yaml
+++ b/registry/manifests/kabanero-operator/0.7.0/kabanero.io_stacks_crd.yaml
@@ -1,0 +1,204 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: stacks.kabanero.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.creationTimestamp
+    description: CreationTimestamp is a timestamp representing the server time when
+      this object was created. It is not guaranteed to be set in happens-before order
+      across separate operations.
+    name: Age
+    type: date
+  - JSONPath: .status.summary
+    description: Stack summary.
+    name: Summary
+    type: string
+  group: kabanero.io
+  names:
+    kind: Stack
+    listKind: StackList
+    plural: stacks
+    singular: stack
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Stack is the Schema for the stack API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: StackSpec defines the desired composition of a Stack
+          properties:
+            name:
+              type: string
+            versions:
+              items:
+                description: StackVersion defines the desired composition of a specific
+                  stack version.
+                properties:
+                  desiredState:
+                    type: string
+                  images:
+                    items:
+                      description: Image defines a container image used by a stack
+                      properties:
+                        id:
+                          type: string
+                        image:
+                          type: string
+                      type: object
+                    type: array
+                  pipelines:
+                    items:
+                      description: PipelineSpec defines the sets of default pipelines
+                        for the stacks.
+                      properties:
+                        gitRelease:
+                          description: GitReleaseSpec defines customization entries
+                            for a Git release.
+                          properties:
+                            assetName:
+                              type: string
+                            hostname:
+                              type: string
+                            organization:
+                              type: string
+                            project:
+                              type: string
+                            release:
+                              type: string
+                            skipCertVerification:
+                              type: boolean
+                          type: object
+                        https:
+                          description: HttpsProtocolFile defines how to retrieve a
+                            file over https
+                          properties:
+                            skipCertVerification:
+                              type: boolean
+                            url:
+                              type: string
+                          type: object
+                        id:
+                          type: string
+                        sha256:
+                          type: string
+                      type: object
+                    type: array
+                  skipCertVerification:
+                    type: boolean
+                  version:
+                    type: string
+                type: object
+              type: array
+          type: object
+        status:
+          description: StackStatus defines the observed state of a stack
+          properties:
+            statusMessage:
+              type: string
+            summary:
+              type: string
+            versions:
+              items:
+                description: StackVersionStatus defines the observed state of a specific
+                  stack version.
+                properties:
+                  images:
+                    items:
+                      description: Image defines a container image used by a stack
+                      properties:
+                        id:
+                          type: string
+                        image:
+                          type: string
+                      type: object
+                    type: array
+                  location:
+                    type: string
+                  pipelines:
+                    items:
+                      description: PipelineStatus defines the observed state of the
+                        assets located within a single pipeline .tar.gz.
+                      properties:
+                        activeAssets:
+                          items:
+                            description: RepositoryAssetStatus defines the observed
+                              state of a single asset in a respository, in the stack.
+                            properties:
+                              assetDigest:
+                                type: string
+                              assetName:
+                                type: string
+                              group:
+                                type: string
+                              kind:
+                                type: string
+                              namespace:
+                                type: string
+                              status:
+                                type: string
+                              statusMessage:
+                                type: string
+                              version:
+                                type: string
+                            type: object
+                          type: array
+                        digest:
+                          type: string
+                        gitRelease:
+                          description: GitReleaseSpec defines customization entries
+                            for a Git release.
+                          properties:
+                            assetName:
+                              type: string
+                            hostname:
+                              type: string
+                            organization:
+                              type: string
+                            project:
+                              type: string
+                            release:
+                              type: string
+                            skipCertVerification:
+                              type: boolean
+                          type: object
+                        name:
+                          type: string
+                        url:
+                          type: string
+                      required:
+                      - digest
+                      - gitRelease
+                      - name
+                      - url
+                      type: object
+                    type: array
+                  status:
+                    type: string
+                  statusMessage:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              type: array
+          type: object
+      type: object
+  version: v1alpha2
+  versions:
+  - name: v1alpha2
+    served: true
+    storage: true

--- a/registry/manifests/kabanero-operator/0.8.0/kabanero-operator.v0.8.0.clusterserviceversion.yaml
+++ b/registry/manifests/kabanero-operator/0.8.0/kabanero-operator.v0.8.0.clusterserviceversion.yaml
@@ -1,16 +1,16 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: kabanero-operator.v0.7.0
+  name: kabanero-operator.v0.8.0
   namespace: placeholder
   annotations:
     capabilities: Basic Install
     categories: "Integration & Delivery"
     certified: "false"
-    containerImage: kabanero/kabanero-operator:0.7.0
+    containerImage: kabanero/kabanero-operator:latest
     createdAt: 2019-11-19T12:00:00.000-0500
     description: Bringings together foundational open source technologies into a modern microservices-based framework.
-    olm.skipRange: '>=0.6.0 <0.7.0'
+    olm.skipRange: '>=0.7.0 <0.8.0'
     repository: https://github.com/kabanero-io/kabanero-operator
     support: IBM
     alm-examples: |-
@@ -22,7 +22,7 @@ metadata:
             "name": "kabanero"
           },
           "spec": {
-            "version": "0.7.0",
+            "version": "0.8.0",
             "stacks": {
               "repositories": [
                 {
@@ -88,8 +88,8 @@ spec:
   minKubeVersion: 1.16.0
   apiservicedefinitions: {}
   maturity: alpha
-  version: 0.7.0
-  replaces: kabanero-operator.v0.6.1
+  version: 0.8.0
+  replaces: kabanero-operator.v0.7.0
   displayName: Kabanero Operator
   description: |
     The Kabanero operator is used to manage Kabanero Foundation instances on your Open Shift or Kubernetes cluster.
@@ -296,7 +296,7 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: kabanero-operator
-                image: kabanero/kabanero-operator:0.7.0
+                image: kabanero/kabanero-operator:latest
                 imagePullPolicy: Always
                 name: kabanero-operator
                 resources: {}

--- a/registry/manifests/kabanero-operator/kabanero-operator-package.yaml
+++ b/registry/manifests/kabanero-operator/kabanero-operator-package.yaml
@@ -12,5 +12,7 @@ channels:
   currentCSV: kabanero-operator.v0.6.1
 - name: release-0.7
   currentCSV: kabanero-operator.v0.7.0
-defaultChannel: release-0.7
+- name: release-0.8
+  currentCSV: kabanero-operator.v0.8.0
+defaultChannel: release-0.8
 


### PR DESCRIPTION
Create the manifests in the operator catalog, etc.

Also fold in the 0.7.0 GM changes from release-0.7 branch.