### PR TITLE
Add EventListeners to tekton-pipelines namespace for now

### DIFF
--- a/config/orchestrations/stack-controller/0.1/stack-controller-tekton.yaml
+++ b/config/orchestrations/stack-controller/0.1/stack-controller-tekton.yaml
@@ -1,7 +1,7 @@
-# This role lets the stack controller create triggerbindings and
-# triggertemplates in the tekton-pipelines namespace, as required by
-# the tekton dashboard webhooks extension.  The Role was created
-# during Kabanero install.
+# This role lets the stack controller create triggerbindings,
+# triggertemplates and eventlisteners in the tekton-pipelines
+# namespace, as required by the tekton dashboard webhooks
+# extension.  The Role was created during Kabanero install.
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/deploy/kabanero-customresources.yaml
+++ b/deploy/kabanero-customresources.yaml
@@ -286,6 +286,7 @@ rules:
   resources:
   - triggerbindings
   - triggertemplates
+  - eventlisteners
   verbs:
   - get
   - list

--- a/pkg/controller/stack/stack_controller.go
+++ b/pkg/controller/stack/stack_controller.go
@@ -282,9 +282,14 @@ type pipelineVersion struct {
 func getNamespaceForObject(u *unstructured.Unstructured, defaultNamespace string) string {
 	kind := u.GetKind()
 
-	// Presently, TriggerBinding and TriggerTemplate objects are created
+	// Presently, TriggerBinding, TriggerTemplate and EventListener objects are created
 	// in the tekton-pipelines namespace.
-	if (kind == "TriggerBinding") || (kind == "TriggerTemplate") {
+	//
+	// TODO (future): Kabanero Eventing will likely want to create these objects in the
+	//                kabanero namespace, since they are not interacting with the Tekton
+	//                Webhook Extension anymore.  We'll need to make this selectable
+	//                somehow, perhaps just using the namespace in the yaml.
+	if (kind == "TriggerBinding") || (kind == "TriggerTemplate") || (kind == "EventListener") {
 		return "tekton-pipelines"
 	}
 


### PR DESCRIPTION
Fixes #581
The kabanero pipelines for kabanero eventing will be creating eventlistener objects.  Since kabanero currently creates the triggerbindings and triggertemplates in the tekton-pipelines namespace, to satisfy restrictions on the tekton webhooks extension, for now we'll also create eventlistener objects in the tekton-pipelines namespace.

Long term, we'll need to find a way to make the namespace selectable.  Perhaps we can add logic to the stack controller, for certain kinds, to just honor the namespace field in the object definition, instead of trying to inject it ourselves.