### PR TITLE
Don't panic when no stack digest

### DIFF
--- a/pkg/controller/stack/stack_controller.go
+++ b/pkg/controller/stack/stack_controller.go
@@ -416,7 +416,11 @@ func reconcileActiveVersions(stackResource *kabanerov1alpha2.Stack, c client.Cli
 				// Add the Digest to the rendering context. No need to validate if the digest was tampered
 				// with here. Later one and before we do anything with this, we will have validated the specified
 				// digest against the generated digest from the archive.
-				renderingContext["Digest"] = value.Digest[0:8]
+				if len(value.Digest) >= 8 {
+					renderingContext["Digest"] = value.Digest[0:8]
+				} else {
+					renderingContext["Digest"] = "nodigest"
+				}
 
 				// Retrieve manifests as unstructured.  If we could not get them, skip.
 				manifests, err := GetManifests(c, stackResource.GetNamespace(), value.PipelineStatus, renderingContext, log)
@@ -474,7 +478,11 @@ func reconcileActiveVersions(stackResource *kabanerov1alpha2.Stack, c client.Cli
 						// Make sure the manifests are loaded.
 						if len(value.manifests) == 0 {
 							// Add the Digest to the rendering context.
-							renderingContext["Digest"] = value.Digest[0:8]
+							if len(value.Digest) >= 8 {
+								renderingContext["Digest"] = value.Digest[0:8]
+							} else {
+								renderingContext["Digest"] = "nodigest"
+							}
 
 							// Retrieve manifests as unstructured
 							manifests, err := GetManifests(c, stackResource.GetNamespace(), value.PipelineStatus, renderingContext, log)


### PR DESCRIPTION
Fixes #379 
The stack validating admission webhook should prevent a stack CR from being admitting if it's missing a pipeline digest (sha256).  But if one somehow gets thru, the stack controller will panic.  This change stops the stack controller from panic-ing.  Note that the stack still won't activate correctly, because when the stack controller tries to download the pipeline zip, the digest on the download won't match the digest that was specified in the stack CR instance (it was empty).  This just stops the panic and container crash looping.