### PR TITLE
Add roles for Tekton and add updates for Codewind 0.11.0/CRW 2.1

### DIFF
--- a/config/orchestrations/codeready-workspaces/0.1/codeready-workspaces-cr.yaml
+++ b/config/orchestrations/codeready-workspaces/0.1/codeready-workspaces-cr.yaml
@@ -40,10 +40,11 @@ spec:
     serverMemoryLimit: ''
     # additional custom Che properties
     customCheProperties:
-      CHE_INFRA_KUBERNETES_WORKSPACE__START__TIMEOUT__MIN: "5"
+      CHE_INFRA_KUBERNETES_WORKSPACE__START__TIMEOUT__MIN: "15"
       CHE_LIMITS_WORKSPACE_IDLE_TIMEOUT: "0"
       CHE_WORKSPACE_PLUGIN__BROKER_WAIT__TIMEOUT__MIN: "15"
       CHE_INFRA_OPENSHIFT_PROJECT: kabanero
+      CHE_INFRA_KUBERNETES_CLUSTER__ROLE__NAME: {{ .cheWorkspaceClusterRole }}
   database:
     # when set to true, the operator skips deploying Postgres, and passes connection details of existing DB to Che server
     # otherwise a Postgres deployment is created

--- a/config/orchestrations/codeready-workspaces/0.1/codewind-clusterrole.yaml
+++ b/config/orchestrations/codeready-workspaces/0.1/codewind-clusterrole.yaml
@@ -1,9 +1,9 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: eclipse-codewind
+  name: kabanero-codewind
   labels:
-    app: eclipse-codewind
+    app: kabanero-codewind
 rules:
 - apiGroups: ["extensions", ""]
   resources: ["ingresses", "ingresses/status", "podsecuritypolicies"]
@@ -56,3 +56,8 @@ rules:
 - apiGroups: ["route.openshift.io"]
   resources: ["routes", "routes/custom-host"]
   verbs: ["get", "list", "create", "delete", "watch", "patch", "update"]
+
+- apiGroups: ["security.openshift.io"]
+  resources: ["securitycontextconstraints"]
+  verbs: ["use"]
+  resourceNames: ["anyuid", "privileged"]

--- a/config/orchestrations/codeready-workspaces/0.1/codewind-tekton-role.yaml
+++ b/config/orchestrations/codeready-workspaces/0.1/codewind-tekton-role.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kabanero-codewind-tekton-role
+  namespace: tekton-pipelines
+rules:
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list"]

--- a/config/orchestrations/codeready-workspaces/0.1/codewind-tekton-rolebinding.yaml
+++ b/config/orchestrations/codeready-workspaces/0.1/codewind-tekton-rolebinding.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kabanero-codewind-tekton
+  namespace: tekton-pipelines
+subjects:
+- kind: ServiceAccount
+  name: che-workspace
+  namespace: kabanero
+roleRef:
+  kind: Role
+  name: kabanero-codewind-tekton-role 
+  apiGroup: rbac.authorization.k8s.io

--- a/config/samples/full.yaml
+++ b/config/samples/full.yaml
@@ -98,8 +98,8 @@ spec:
           image: kabanero/che-devfile-registry:0.11.0
 
         # Specifies a custom cluster role to user for the Che workspaces uses the default roles if left blank.
-        # The default value is eclipse-codewind.
-        cheWorkspaceClusterRole: eclipse-codewind
+        # The default value is kabanero-codewind.
+        cheWorkspaceClusterRole: kabanero-codewind
 
         # TLS mode for Che. Make sure you either have public cert, or set selfSignedCert to true. The default value is false.
         tlsSupport: false

--- a/pkg/controller/kabaneroplatform/codereadyworkspaces.go
+++ b/pkg/controller/kabaneroplatform/codereadyworkspaces.go
@@ -484,6 +484,16 @@ func deleteCRWOperatorResources(ctx context.Context, k *kabanerov1alpha2.Kabaner
 		if err != nil {
 			return err
 		}
+
+		// Delete the Tekton role and rolebinding too
+		err = processCRWYaml(ctx, k, rev, unstructured.Unstructured{}.Object, c, crwYamlNameCodewindTektonRole, false, "tekton-pipelines")
+		if err != nil {
+			return err
+		}
+		err = processCRWYaml(ctx, k, rev, unstructured.Unstructured{}.Object, c, crwYamlNameCodewindTektonBinding, false, "tekton-pipelines")
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/controller/kabaneroplatform/codereadyworkspaces.go
+++ b/pkg/controller/kabaneroplatform/codereadyworkspaces.go
@@ -32,12 +32,14 @@ import (
 var crwlog = rlog.Log.WithName("kabanero-codeready-workspaces")
 
 const (
-	crwOrchestrationFilePath       = "orchestrations/codeready-workspaces/0.1"
-	crwYamlNameCodewindClusterRole = "codewind-clusterrole.yaml"
-	crwOperatorCR                  = "codeready-workspaces-cr.yaml"
-	crwOperatorCRNameSuffix        = "codeready-workspaces"
-	crwVersionSoftwareName         = "codeready-workspaces"
-	crwOperatorSubscriptionName    = "codeready-workspaces"
+	crwOrchestrationFilePath         = "orchestrations/codeready-workspaces/0.1"
+	crwYamlNameCodewindClusterRole   = "codewind-clusterrole.yaml"
+	crwYamlNameCodewindTektonRole    = "codewind-tekton-role.yaml"
+	crwYamlNameCodewindTektonBinding = "codewind-tekton-rolebinding.yaml"
+	crwOperatorCR                    = "codeready-workspaces-cr.yaml"
+	crwOperatorCRNameSuffix          = "codeready-workspaces"
+	crwVersionSoftwareName           = "codeready-workspaces"
+	crwOperatorSubscriptionName      = "codeready-workspaces"
 
 	crwVersionOrchDevfileRegRepository = "devfile-reg-repository"
 	crwVersionOrchDevfileRegTag        = "devfile-reg-tag"
@@ -67,10 +69,24 @@ func reconcileCRW(ctx context.Context, k *kabanerov1alpha2.Kabanero, c client.Cl
 
 	templateCtx := unstructured.Unstructured{}.Object
 
-	// Deploy the cluster role with the required permissions for codewind.
-	err = processCRWYaml(ctx, k, rev, templateCtx, c, crwYamlNameCodewindClusterRole, true)
+	// Deploy the Codewind cluster role with the required permissions for codewind.
+	err = processCRWYaml(ctx, k, rev, templateCtx, c, crwYamlNameCodewindClusterRole, true, k.GetNamespace())
 	if err != nil {
 		logger.Error(err, fmt.Sprintf("Failed to Apply clusterRole resource. Revision: %v. TemplateCtx: %v", rev, templateCtx))
+		return err
+	}
+
+	// Deploy the Codewind Tekton role
+	err = processCRWYaml(ctx, k, rev, templateCtx, c, crwYamlNameCodewindTektonRole, true, "tekton-pipelines")
+	if err != nil {
+		logger.Error(err, fmt.Sprintf("Failed to Apply role resource. Revision: %v. TemplateCtx: %v", rev, templateCtx))
+		return err
+	}
+
+	// Deploy the Codewind Tekton rolebinding
+	err = processCRWYaml(ctx, k, rev, templateCtx, c, crwYamlNameCodewindTektonBinding, true, "tekton-pipelines")
+	if err != nil {
+		logger.Error(err, fmt.Sprintf("Failed to Apply rolebinding resource. Revision: %v. TemplateCtx: %v", rev, templateCtx))
 		return err
 	}
 
@@ -110,7 +126,7 @@ func deployCRWInstance(ctx context.Context, k *kabanerov1alpha2.Kabanero, c clie
 			return err
 		}
 
-		err = processCRWYaml(ctx, k, rev, templateCtx, c, crwOperatorCR, true)
+		err = processCRWYaml(ctx, k, rev, templateCtx, c, crwOperatorCR, true, k.GetNamespace())
 		if err != nil {
 			return err
 		}
@@ -281,7 +297,7 @@ func validateCRWInstance(ctx context.Context, k *kabanerov1alpha2.Kabanero, c cl
 }
 
 // Applies or deletes the specified yaml file.
-func processCRWYaml(ctx context.Context, k *kabanerov1alpha2.Kabanero, rev versioning.SoftwareRevision, templateCtx map[string]interface{}, c client.Client, fileName string, apply bool) error {
+func processCRWYaml(ctx context.Context, k *kabanerov1alpha2.Kabanero, rev versioning.SoftwareRevision, templateCtx map[string]interface{}, c client.Client, fileName string, apply bool, namespace string) error {
 	f, err := rev.OpenOrchestration(fileName)
 	if err != nil {
 		return err
@@ -299,7 +315,7 @@ func processCRWYaml(ctx context.Context, k *kabanerov1alpha2.Kabanero, rev versi
 
 	transforms := []mf.Transformer{
 		mf.InjectOwner(k),
-		mf.InjectNamespace(k.GetNamespace()),
+		mf.InjectNamespace(namespace),
 	}
 
 	m, err := mOrig.Transform(transforms...)
@@ -464,7 +480,7 @@ func deleteCRWOperatorResources(ctx context.Context, k *kabanerov1alpha2.Kabaner
 	}
 
 	if len(kiList.Items) == 1 {
-		err = processCRWYaml(ctx, k, rev, unstructured.Unstructured{}.Object, c, crwYamlNameCodewindClusterRole, false)
+		err = processCRWYaml(ctx, k, rev, unstructured.Unstructured{}.Object, c, crwYamlNameCodewindClusterRole, false, k.GetNamespace())
 		if err != nil {
 			return err
 		}
@@ -479,7 +495,7 @@ func deleteCRWInstance(ctx context.Context, k *kabanerov1alpha2.Kabanero, rev ve
 		return err
 	}
 
-	err = processCRWYaml(ctx, k, rev, templateCtx, c, crwOperatorCR, false)
+	err = processCRWYaml(ctx, k, rev, templateCtx, c, crwOperatorCR, false, k.GetNamespace())
 	if err != nil {
 		return err
 	}
@@ -579,7 +595,7 @@ func getCRWCRDevfileRegistryImage(k *kabanerov1alpha2.Kabanero, rev versioning.S
 func getCRWClusterRole(k *kabanerov1alpha2.Kabanero) string {
 	crwcr := k.Spec.CodereadyWorkspaces.Operator.CustomResourceInstance.CheWorkspaceClusterRole
 	if len(crwcr) == 0 {
-		crwcr = "eclipse-codewind"
+		crwcr = "kabanero-codewind"
 	}
 	return crwcr
 }


### PR DESCRIPTION
This PR tackles a few items:
- Adds a role and rolebinding in the `tekton-pipelines` namespace, allowing the tekton dashboard to be accessed from CRW (fixes https://github.com/kabanero-io/kabanero-operator/issues/536)
- Renames the cluster role used for CRW, to prevent an issue when Kabanero and Eclipse Che are installed on the same cluster (and use the same cluster role for codewind)
- Updates the role for Codewind, allowing it to start in per-user namespaces in CRW, when openshiftOAuth is enabled