### PR TITLE
tekton triggers apis moved to triggers.tekton.dev

### DIFF
--- a/deploy/kabanero-customresources.yaml
+++ b/deploy/kabanero-customresources.yaml
@@ -300,7 +300,7 @@ metadata:
     kabanero.io/install: 25-triggers-role
 rules:
 - apiGroups:
-  - tekton.dev
+  - triggers.tekton.dev
   resources:
   - triggerbindings
   - triggertemplates

--- a/pkg/controller/stack/stack_controller.go
+++ b/pkg/controller/stack/stack_controller.go
@@ -531,9 +531,9 @@ func reconcileActiveVersions(stackResource *kabanerov1alpha2.Stack, c client.Cli
 								// Only allow Group: tekton.dev
 								allowed := true
 								for _, resource := range resources {
-									if resource.GroupVersionKind().Group != "tekton.dev" {
+									if (resource.GroupVersionKind().Group != "tekton.dev") && (resource.GroupVersionKind().Group != "triggers.tekton.dev") {
 										value.ActiveAssets[index].Status = assetStatusFailed
-										value.ActiveAssets[index].StatusMessage = "Manifest rejected: contains a Group not equal to tekton.dev"
+										value.ActiveAssets[index].StatusMessage = "Manifest rejected: contains a Group not equal to tekton.dev or triggers.tekton.dev"
 										allowed = false
 									}
 								}


### PR DESCRIPTION
Fixes #656 
With the triggers moving to `triggers.tekton.dev` our RBAC needed a couple of tweaks to allow the resources to be deployed.