### PR TITLE
Move tekton dashboard back to tekton-pipelines namespace

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -318,8 +318,8 @@ oc new-project tekton-pipelines || true
 
 openshift_master_default_subdomain=$(oc get ingresses.config.openshift.io cluster --output=jsonpath={.spec.domain})
 
-curl -s -L https://github.com/tektoncd/dashboard/releases/download/v0.6.1/openshift-tekton-webhooks-extension-release.yaml | sed "s/{openshift_master_default_subdomain}/${openshift_master_default_subdomain}/" | oc apply -f -
-oc apply -f https://github.com/tektoncd/dashboard/releases/download/v0.6.1/openshift-tekton-dashboard-release.yaml
+curl -s -L https://github.com/tektoncd/dashboard/releases/download/v0.6.1/openshift-tekton-webhooks-extension-release.yaml | sed "s/{openshift_master_default_subdomain}/${openshift_master_default_subdomain}/" | sed "s/openshift-pipelines/tekton-pipelines/" | oc apply -f -
+curl -s -L https://github.com/tektoncd/dashboard/releases/download/v0.6.1/openshift-tekton-dashboard-release.yaml | sed "s/openshift-pipelines/tekton-pipelines/" | oc apply -f -
 
 # Network policy for kabanero and tekton pipelines namespaces
 oc apply -f $KABANERO_CUSTOMRESOURCES_YAML --selector kabanero.io/install=23-cr-network-policy

--- a/deploy/uninstall.sh
+++ b/deploy/uninstall.sh
@@ -103,9 +103,8 @@ oc delete namespaces --selector=kabanero.io/component=kappnav --ignore-not-found
 oc delete --ignore-not-found -f $KABANERO_CUSTOMRESOURCES_YAML --selector kabanero.io/install=25-triggers-role
 
 # Tekton Dashboard
-oc delete --ignore-not-found -f https://github.com/tektoncd/dashboard/releases/download/v0.6.1/openshift-tekton-webhooks-extension-release.yaml
-oc delete --ignore-not-found -f https://github.com/tektoncd/dashboard/releases/download/v0.6.1/openshift-tekton-dashboard-release.yaml
-
+curl -s -L https://github.com/tektoncd/dashboard/releases/download/v0.6.1/openshift-tekton-webhooks-extension-release.yaml | sed "s/openshift-pipelines/tekton-pipelines/" | oc delete --ignore-not-found -f -
+curl -s -L https://github.com/tektoncd/dashboard/releases/download/v0.6.1/openshift-tekton-dashboard-release.yaml | sed "s/openshift-pipelines/tekton-pipelines/" | oc delete --ignore-not-found -f -
 
 # Delete CustomResources, do not delete namespaces , which can lead to finalizer problems.
 oc delete -f $KABANERO_CUSTOMRESOURCES_YAML --ignore-not-found --selector kabanero.io/install=23-cr-network-policy,kabanero.io/namespace!=true


### PR DESCRIPTION
Fixes #665 
Version 0.6.1 of the Tekton dashboard moved (for OpenShift) from `tekton-pipelines` to `openshift-pipelines` namespace.  Since the Kabanero runtime expects the dashboard to be in the `tekton-pipelines` namespace, for the time being we are going to move it back there.