### PR TITLE
fix router TLS config for landing and CLI service

### DIFF
--- a/config/orchestrations/cli-services/0.2/kabanero-cli.yaml
+++ b/config/orchestrations/cli-services/0.2/kabanero-cli.yaml
@@ -29,6 +29,7 @@ spec:
     name: kabanero-cli
   tls:
     termination: reencrypt
+    insecureEdgeTerminationPolicy: Redirect
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/config/orchestrations/landing/0.2/kabanero-landing.yaml
+++ b/config/orchestrations/landing/0.2/kabanero-landing.yaml
@@ -29,6 +29,7 @@ spec:
     name: kabanero-landing
   tls:
     termination: reencrypt
+    insecureEdgeTerminationPolicy: Redirect
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
Fixes #674 
Couple things to note here:
* I removed the key/certificate from the `reencrypt` route for the landing page and CLI service.  They were specified incorrectly.  Those parameters identify the route to the external caller.  We want the external caller to see the default ingress certificate.  To get that behavior, we should not be specifying the key/certificate on the route.
* The internal (route -> pod) connection uses a service serving certificate.  The doc that I could find says that when you use `reencrypt` you have to provide the CA that signed the certificate in the pod, in the route's configuration.  However it appears that OpenShift implicitly trusts the service serving certificate CA.  This must be true, because the existing configuration did not supply a destination CA certificate, and everything worked fine.  So the route now has no certificates or keys in it.  This means that all of the code that reads the CA/certificate and encodes/decodes it, is deleted.
* I added the config to the route that converts http->https at @davco01a 's request.

I tested connectivity between my browser and the landing page / CLI service, and I am presented with the ingress certificate, as we expect.