### PR TITLE
Correct `omitEmpty` -> `omitempty` in JSON markers

### DIFF
--- a/deploy/crds/kabanero.io_kabaneros_crd.yaml
+++ b/deploy/crds/kabanero.io_kabaneros_crd.yaml
@@ -878,11 +878,6 @@ spec:
                           type: string
                         url:
                           type: string
-                      required:
-                      - digest
-                      - gitRelease
-                      - name
-                      - url
                       type: object
                     type: array
                   ready:

--- a/deploy/crds/kabanero.io_stacks_crd.yaml
+++ b/deploy/crds/kabanero.io_stacks_crd.yaml
@@ -191,11 +191,6 @@ spec:
                           type: string
                         url:
                           type: string
-                      required:
-                      - digest
-                      - gitRelease
-                      - name
-                      - url
                       type: object
                     type: array
                   status:

--- a/pkg/apis/kabanero/v1alpha2/kabanero_types.go
+++ b/pkg/apis/kabanero/v1alpha2/kabanero_types.go
@@ -285,10 +285,10 @@ type KabaneroStatus struct {
 
 // PipelineStatus defines the observed state of the assets located within a single pipeline .tar.gz.
 type PipelineStatus struct {
-	Name       string         `json:"name,omitEmpty"`
-	Url        string         `json:"url,omitEmpty"`
-	GitRelease GitReleaseInfo `json:"gitRelease,omitEmpty"`
-	Digest     string         `json:"digest,omitEmpty"`
+	Name       string         `json:"name,omitempty"`
+	Url        string         `json:"url,omitempty"`
+	GitRelease GitReleaseInfo `json:"gitRelease,omitempty"`
+	Digest     string         `json:"digest,omitempty"`
 	// +listType=set
 	ActiveAssets []RepositoryAssetStatus `json:"activeAssets,omitempty"`
 }


### PR DESCRIPTION
Due to a typo in some json markers, the Kabanero and Stack CRDs have some required fields in their status sections.  This doesn't make a lot of sense as the status is generated dynamically.  When doing a Kabanero upgrade from 0.6.0 to 0.9.0 (or any version after 0.6.0 really) OLM may complain because it can't migrate existing CR instances to the new version, because they are missing required fields (specifically `gitRelease` in the pipelines status).