### PR TITLE
Add openlibertyapplication to pipeline deploy role

### DIFF
--- a/deploy/kabanero-customresources.yaml
+++ b/deploy/kabanero-customresources.yaml
@@ -290,6 +290,18 @@ rules:
   - delete
   - patch
   - watch
+- apiGroups:
+  - openliberty.io
+  resources:
+  - openlibertyapplications
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role


### PR DESCRIPTION
Fixes #695 
Recent versions of Appsody will create `openlibertyapplication` during deploy instead of `appsodyapplication`.  The pipelines service account needs to have permission to query and create these objects.

The error that you get if you don't do this is documented in the issue.
@smcclem verified this fix for me.  Thanks Scott.