### PR TITLE
cli-services for golang migration

### DIFF
--- a/config/orchestrations/cli-services/0.3/kabanero-cli-deployment.yaml
+++ b/config/orchestrations/cli-services/0.3/kabanero-cli-deployment.yaml
@@ -1,0 +1,47 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: kabanero-cli
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kabanero-cli
+  template:
+    metadata:
+      labels:
+        app: kabanero-cli
+        app.kubernetes.io/name: kabanero-cli
+        app.kubernetes.io/instance: {{ .instance }}
+        app.kubernetes.io/version: {{ .version }}
+        app.kubernetes.io/component: kabanero-cli
+        app.kubernetes.io/part-of: kabanero
+        app.kubernetes.io/managed-by: kabanero-operator
+    spec:
+      containers:
+        - name: kabanero-cli
+          env:
+            - name: AESEncryptionKey
+              valueFrom:
+                secretKeyRef:
+                  name: kabanero-cli-aes-encryption-key-secret
+                  key: AESEncryptionKey
+                  optional: false
+            - name: KABANERO_CLI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          ports:
+            - containerPort: 9443
+              protocol: TCP
+          imagePullPolicy: Always
+          image: {{ .image }}
+          volumeMounts:
+            - name: kabanero-cli-cert-secret
+              mountPath: /etc/tls/secrets/openshift.io/kabanero.cli/certs
+              readOnly: true
+      serviceAccountName: kabanero-cli
+      volumes:
+      - name: kabanero-cli-cert-secret
+        secret:
+          secretName: kabanero-cli-service-cert-secret

--- a/config/orchestrations/cli-services/0.3/kabanero-cli.yaml
+++ b/config/orchestrations/cli-services/0.3/kabanero-cli.yaml
@@ -1,0 +1,134 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kabanero-cli
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: kabanero-cli-service-cert-secret
+  labels:
+    app.kubernetes.io/name: kabanero-cli
+    app.kubernetes.io/instance: {{ .instance }}
+    app.kubernetes.io/version: {{ .version }}
+    app.kubernetes.io/component: kabanero-cli
+    app.kubernetes.io/part-of: kabanero
+    app.kubernetes.io/managed-by: kabanero-operator
+spec:
+  selector:
+    app: kabanero-cli
+  ports:
+  - protocol: TCP
+    port: 443
+    targetPort: 9443
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: kabanero-cli
+spec:
+  to:
+    kind: Service
+    name: kabanero-cli
+  tls:
+    termination: reencrypt
+    insecureEdgeTerminationPolicy: Redirect
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: kabanero-cli
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - services
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - apps
+  resourceNames:
+  - kabanero-cli
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - kabanero.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kabanero-cli
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kabanero-cli
+subjects:
+- kind: ServiceAccount
+  name: kabanero-cli
+roleRef:
+  kind: Role
+  name: kabanero-cli
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kabanero-cli
+rules:
+- verbs:
+  - get
+  - list
+  - watch
+  apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kabanero-cli
+subjects:
+- kind: ServiceAccount
+  name: kabanero-cli
+  namespace: kabanero
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kabanero-cli

--- a/config/versions.yaml
+++ b/config/versions.yaml
@@ -92,6 +92,11 @@ related-software:
       tag: "0.6.0"
 
   cli-services:
+  - version: "go-prototype"
+    orchestrations: "orchestrations/cli-services/0.3"
+    identifiers:
+      repository: "davco01a/kabanero-command-line-services"
+      tag: "latest"
   - version: "0.9.0"
     orchestrations: "orchestrations/cli-services/0.2"
     identifiers:


### PR DESCRIPTION
Fixes #705 
The CLI services will have a prototype implemented in golang.  This orchestration will be used by the prototype.

See #705 for the syntax to enable the new orchestration in the Kabanero CR instance.