### PR TITLE
labels for deploy

### DIFF
--- a/config/orchestrations/admission-webhook/0.1/kabanero-operator-admission-webhook.yaml
+++ b/config/orchestrations/admission-webhook/0.1/kabanero-operator-admission-webhook.yaml
@@ -114,6 +114,14 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kabanero-operator-admission-webhook
+  labels:
+    name: kabanero-operator-admission-webhook
+    app.kubernetes.io/name: kabanero-operator-admission-webhook
+    app.kubernetes.io/instance: {{ .instance }}
+    app.kubernetes.io/version: {{ .version }}
+    app.kubernetes.io/component: admission-webhook
+    app.kubernetes.io/part-of: kabanero
+    app.kubernetes.io/managed-by: kabanero-operator
 spec:
   replicas: 1
   selector:

--- a/config/orchestrations/admission-webhook/0.2/kabanero-operator-admission-webhook.yaml
+++ b/config/orchestrations/admission-webhook/0.2/kabanero-operator-admission-webhook.yaml
@@ -91,6 +91,14 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kabanero-operator-admission-webhook
+  labels:
+    name: kabanero-operator-admission-webhook
+    app.kubernetes.io/name: kabanero-operator-admission-webhook
+    app.kubernetes.io/instance: {{ .instance }}
+    app.kubernetes.io/version: {{ .version }}
+    app.kubernetes.io/component: admission-webhook
+    app.kubernetes.io/part-of: kabanero
+    app.kubernetes.io/managed-by: kabanero-operator
 spec:
   replicas: 1
   selector:

--- a/config/orchestrations/cli-services/0.1/kabanero-cli.yaml
+++ b/config/orchestrations/cli-services/0.1/kabanero-cli.yaml
@@ -127,6 +127,14 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: kabanero-cli
+  labels:
+    app: kabanero-cli
+    app.kubernetes.io/name: kabanero-cli
+    app.kubernetes.io/instance: {{ .instance }}
+    app.kubernetes.io/version: {{ .version }}
+    app.kubernetes.io/component: kabanero-cli
+    app.kubernetes.io/part-of: kabanero
+    app.kubernetes.io/managed-by: kabanero-operator
 spec:
   replicas: 1
   selector:

--- a/config/orchestrations/cli-services/0.2/kabanero-cli-deployment.yaml
+++ b/config/orchestrations/cli-services/0.2/kabanero-cli-deployment.yaml
@@ -2,6 +2,14 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: kabanero-cli
+  labels:
+    app: kabanero-cli
+    app.kubernetes.io/name: kabanero-cli
+    app.kubernetes.io/instance: {{ .instance }}
+    app.kubernetes.io/version: {{ .version }}
+    app.kubernetes.io/component: kabanero-cli
+    app.kubernetes.io/part-of: kabanero
+    app.kubernetes.io/managed-by: kabanero-operator
 spec:
   replicas: 1
   selector:

--- a/config/orchestrations/collection-controller/0.1/collection-controller.yaml
+++ b/config/orchestrations/collection-controller/0.1/collection-controller.yaml
@@ -115,6 +115,14 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kabanero-operator-collection-controller
+  labels:
+    app: kabanero-operator-collection-controller
+    app.kubernetes.io/name: kabanero-operator-collection-controller
+    app.kubernetes.io/instance: {{ .instance }}
+    app.kubernetes.io/version: {{ .version }}
+    app.kubernetes.io/component: collection-controller
+    app.kubernetes.io/part-of: kabanero
+    app.kubernetes.io/managed-by: kabanero-operator
 spec:
   replicas: 1
   selector:

--- a/config/orchestrations/events/0.1/kabanero-events.yaml
+++ b/config/orchestrations/events/0.1/kabanero-events.yaml
@@ -104,6 +104,14 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kabanero-events
+  labels:
+    name: kabanero-events
+    app.kubernetes.io/name: kabanero-events
+    app.kubernetes.io/instance: {{ .instance }}
+    app.kubernetes.io/version: {{ .version }}
+    app.kubernetes.io/component: kabanero-events
+    app.kubernetes.io/part-of: kabanero
+    app.kubernetes.io/managed-by: kabanero-operator
 spec:
   replicas: 1
   selector:

--- a/config/orchestrations/events/0.2/kabanero-events.yaml
+++ b/config/orchestrations/events/0.2/kabanero-events.yaml
@@ -391,6 +391,14 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: events-operator
+  labels:
+    name: events-operator
+    app.kubernetes.io/name: events-operator
+    app.kubernetes.io/instance: {{ .instance }}
+    app.kubernetes.io/version: {{ .version }}
+    app.kubernetes.io/component: events-operator
+    app.kubernetes.io/part-of: kabanero
+    app.kubernetes.io/managed-by: kabanero-operator
 spec:
   replicas: 1
   selector:

--- a/config/orchestrations/landing/0.1/kabanero-landing-deployment.yaml
+++ b/config/orchestrations/landing/0.1/kabanero-landing-deployment.yaml
@@ -2,6 +2,14 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: kabanero-landing
+  labels:
+    app: kabanero-landing
+    app.kubernetes.io/name: kabanero-landing
+    app.kubernetes.io/instance: {{ .instance }}
+    app.kubernetes.io/version: {{ .version }}
+    app.kubernetes.io/component: kabanero-landing
+    app.kubernetes.io/part-of: kabanero
+    app.kubernetes.io/managed-by: kabanero-operator
 spec:
   replicas: 1
   selector:

--- a/config/orchestrations/landing/0.2/kabanero-landing-deployment.yaml
+++ b/config/orchestrations/landing/0.2/kabanero-landing-deployment.yaml
@@ -2,6 +2,14 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: kabanero-landing
+  labels:
+    app: kabanero-landing
+    app.kubernetes.io/name: kabanero-landing
+    app.kubernetes.io/instance: {{ .instance }}
+    app.kubernetes.io/version: {{ .version }}
+    app.kubernetes.io/component: kabanero-landing
+    app.kubernetes.io/part-of: kabanero
+    app.kubernetes.io/managed-by: kabanero-operator
 spec:
   replicas: 1
   selector:

--- a/config/orchestrations/sso/0.1/sso.yaml
+++ b/config/orchestrations/sso/0.1/sso.yaml
@@ -84,6 +84,12 @@ metadata:
     application: sso
     rhsso: 7.3.2.GA
     template: sso73-x509-postgresql-persistent
+    app.kubernetes.io/name: sso
+    app.kubernetes.io/instance: {{ .instance }}
+    app.kubernetes.io/version: '0.1'
+    app.kubernetes.io/component: sso
+    app.kubernetes.io/part-of: kabanero
+    app.kubernetes.io/managed-by: kabanero-operator
   name: sso
 spec:
   replicas: 1
@@ -230,6 +236,12 @@ metadata:
     application: sso
     rhsso: 7.3.2.GA
     template: sso73-x509-postgresql-persistent
+    app.kubernetes.io/name: sso-postgresql
+    app.kubernetes.io/instance: {{ .instance }}
+    app.kubernetes.io/version: {{ .version }}
+    app.kubernetes.io/component: postgresql
+    app.kubernetes.io/part-of: kabanero
+    app.kubernetes.io/managed-by: kabanero-operator
   name: sso-postgresql
 spec:
   replicas: 1

--- a/config/orchestrations/stack-controller/0.1/stack-controller.yaml
+++ b/config/orchestrations/stack-controller/0.1/stack-controller.yaml
@@ -119,6 +119,14 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kabanero-operator-stack-controller
+  labels:
+    app: kabanero-operator-stack-controller
+    app.kubernetes.io/name: kabanero-operator-stack-controller
+    app.kubernetes.io/instance: {{ .instance }}
+    app.kubernetes.io/version: {{ .version }}
+    app.kubernetes.io/component: stack-controller
+    app.kubernetes.io/part-of: kabanero
+    app.kubernetes.io/managed-by: kabanero-operator
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
Add the labels to the Deployment, not just the template for the Pods

@justinflemingibm


```
oc get deploy -n kabanero --show-labels
NAME                                      READY   UP-TO-DATE   AVAILABLE   AGE     LABELS
codeready                                 1/1     1            1           2m      app=codeready,component=codeready
codeready-operator                        1/1     1            1           23h     olm.owner.kind=ClusterServiceVersion,olm.owner.namespace=kabanero,olm.owner=crwoperator.v2.1.1
devfile-registry                          1/1     1            1           2m33s   app=codeready,component=devfile-registry
events-operator                           1/1     1            1           4m18s   app.kubernetes.io/component=events-operator,app.kubernetes.io/instance=89d344df-6fdd-4beb-a6de-f17cf3b92bb0,app.kubernetes.io/managed-by=kabanero-operator,app.kubernetes.io/name=events-operator,app.kubernetes.io/part-of=kabanero,app.kubernetes.io/version=0.9.0,name=events-operator
kabanero-cli                              1/1     1            1           4m18s   app.kubernetes.io/component=kabanero-cli,app.kubernetes.io/instance=89d344df-6fdd-4beb-a6de-f17cf3b92bb0,app.kubernetes.io/managed-by=kabanero-operator,app.kubernetes.io/name=kabanero-cli,app.kubernetes.io/part-of=kabanero,app.kubernetes.io/version=0.9.0,app=kabanero-cli
kabanero-landing                          1/1     1            1           4m19s   app.kubernetes.io/component=kabanero-landing,app.kubernetes.io/instance=89d344df-6fdd-4beb-a6de-f17cf3b92bb0,app.kubernetes.io/managed-by=kabanero-operator,app.kubernetes.io/name=kabanero-landing,app.kubernetes.io/part-of=kabanero,app.kubernetes.io/version=0.9.0,app=kabanero-landing
kabanero-operator                         1/1     1            1           5m11s   olm.owner.kind=ClusterServiceVersion,olm.owner.namespace=kabanero,olm.owner=kabanero-operator.v0.9.0
kabanero-operator-admission-webhook       1/1     1            1           4m31s   app.kubernetes.io/component=admission-webhook,app.kubernetes.io/instance=89d344df-6fdd-4beb-a6de-f17cf3b92bb0,app.kubernetes.io/managed-by=kabanero-operator,app.kubernetes.io/name=kabanero-operator-admission-webhook,app.kubernetes.io/part-of=kabanero,app.kubernetes.io/version=0.9.0,name=kabanero-operator-admission-webhook
kabanero-operator-collection-controller   1/1     1            1           4m26s   app.kubernetes.io/component=collection-controller,app.kubernetes.io/instance=89d344df-6fdd-4beb-a6de-f17cf3b92bb0,app.kubernetes.io/managed-by=kabanero-operator,app.kubernetes.io/name=kabanero-operator-collection-controller,app.kubernetes.io/part-of=kabanero,app.kubernetes.io/version=0.9.0,app=kabanero-operator-collection-controller
kabanero-operator-stack-controller        1/1     1            1           4m26s   app.kubernetes.io/component=stack-controller,app.kubernetes.io/instance=89d344df-6fdd-4beb-a6de-f17cf3b92bb0,app.kubernetes.io/managed-by=kabanero-operator,app.kubernetes.io/name=kabanero-operator-stack-controller,app.kubernetes.io/part-of=kabanero,app.kubernetes.io/version=0.9.0,app=kabanero-operator-stack-controller
keycloak                                  1/1     1            1           3m41s   app=codeready,component=keycloak
plugin-registry                           1/1     1            1           2m8s    app=codeready,component=plugin-registry
postgres                                  1/1     1            1           4m17s   app=codeready,component=postgres

```