### PR TITLE
stack error state

### DIFF
--- a/pkg/apis/kabanero/v1alpha2/stack_types.go
+++ b/pkg/apis/kabanero/v1alpha2/stack_types.go
@@ -18,6 +18,10 @@ const (
 	// It indicates that the stack needs to be deactivated.
 	StackDesiredStateInactive = "inactive"
 
+	// StackStateError represents a stack status error state.
+	// It indicates that the stack did not complete an activation process
+	StackStateError = "error"
+
 	// Stack digest policy: strict.
 	StackPolicyStrictDigest = "strictDigest"
 


### PR DESCRIPTION
Add a new const error state kabanerov1alpha2.StackStateError

Change getStatusImageDigest to return err (in addition to setting err on status)

In reconcileActiveVersions if getStatusImageDigest returns err, set newStackVersionStatus.StackStateError

Nothing in cleanup appears use StackDesiredState to where the new error state might block cleanup

