### PR TITLE
add imagesignature role

### DIFF
--- a/deploy/kabanero-customresources.yaml
+++ b/deploy/kabanero-customresources.yaml
@@ -262,6 +262,7 @@ rules:
   verbs:
     - create
     - delete
+    - get
 - nonResourceURLs:
   - '/staging/*'
   verbs:

--- a/deploy/kabanero-customresources.yaml
+++ b/deploy/kabanero-customresources.yaml
@@ -254,6 +254,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ''
+  - image.openshift.io
+  resources:
+    - imagesignatures
+  verbs:
+    - create
+    - delete
+- nonResourceURLs:
+  - '/staging/*'
+  verbs:
+    - get
+    - put
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
To support pulling images which are signed from the internal image registry, imagesignature role needs to be granted to kabanero-pipeline-role.