### PR TITLE
Roll up imagestream fix to release-0.9

### DIFF
--- a/cmd/manager/stack/image.go
+++ b/cmd/manager/stack/image.go
@@ -1,0 +1,60 @@
+package main
+
+// Use pr to work around issue
+// https://github.com/kubernetes-sigs/controller-runtime/issues/362
+// https://github.com/openshift/api/issues/270
+// https://github.com/openshift/api/pull/461
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/openshift/api/image/docker10"
+	"github.com/openshift/api/image/dockerpre012"
+	imagev1 "github.com/openshift/api/image/v1"
+)
+
+var (
+	GroupName     = "image.openshift.io"
+	GroupVersion  = schema.GroupVersion{Group: GroupName, Version: "v1"}
+	schemeBuilder = runtime.NewSchemeBuilder(addKnownTypes, docker10.AddToScheme, dockerpre012.AddToScheme)
+	// Install is a function which adds this version to a scheme
+	Install = schemeBuilder.AddToScheme
+
+	// SchemeGroupVersion generated code relies on this name
+	// Deprecated
+	SchemeGroupVersion = GroupVersion
+	// AddToScheme exists solely to keep the old generators creating valid code
+	// DEPRECATED
+	AddToScheme = schemeBuilder.AddToScheme
+)
+
+// Resource generated code relies on this being here, but it logically belongs to the group
+// DEPRECATED
+func Resource(resource string) schema.GroupResource {
+	return schema.GroupResource{Group: GroupName, Resource: resource}
+}
+
+// Adds the list of known types to api.Scheme.
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(GroupVersion,
+		&imagev1.Image{},
+		&imagev1.ImageList{},
+		&imagev1.ImageSignature{},
+		&imagev1.ImageStream{},
+		&imagev1.ImageStreamList{},
+		&imagev1.ImageStreamMapping{},
+		&imagev1.ImageStreamTag{},
+		&imagev1.ImageStreamTagList{},
+		&imagev1.ImageStreamImage{},
+		&imagev1.ImageStreamLayers{},
+		&imagev1.ImageStreamImport{},
+		/* newer than our go.mod version
+		&imagev1.ImageTag{},
+		&imagev1.ImageTagList{},
+		*/
+	)
+	metav1.AddToGroupVersion(scheme, GroupVersion)
+	return nil
+}

--- a/cmd/manager/stack/main.go
+++ b/cmd/manager/stack/main.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	pipelinev1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	//imagev1 "github.com/openshift/api/image/v1"
 )
 
 // Change below variables to serve metrics on different host or port.
@@ -93,6 +94,22 @@ func main() {
 		log.Error(err, "")
 		os.Exit(1)
 	}
+
+	// Use pr to work around issue
+	// https://github.com/kubernetes-sigs/controller-runtime/issues/362
+	// https://github.com/openshift/api/issues/270
+	// https://github.com/openshift/api/pull/461
+	if err := AddToScheme(mgr.GetScheme()); err != nil {
+		log.Error(err, "")
+		os.Exit(1)
+	}
+
+	/*
+	if err := imagev1.AddToScheme(mgr.GetScheme()); err != nil {
+		log.Error(err, "")
+		os.Exit(1)
+	}
+  */
 
 	// Setup all Controllers
 	if err := stack.AddToManager(mgr); err != nil {

--- a/config/orchestrations/stack-controller/0.1/stack-controller.yaml
+++ b/config/orchestrations/stack-controller/0.1/stack-controller.yaml
@@ -97,6 +97,14 @@ rules:
   - '*'
   verbs:
   - '*'
+- apiGroups:
+  - image.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/pkg/controller/stack/stack_controller.go
+++ b/pkg/controller/stack/stack_controller.go
@@ -35,6 +35,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+	imagev1 "github.com/openshift/api/image/v1"
+	reference "github.com/docker/distribution/reference"
 )
 
 var log = logf.Log.WithName("controller_stack")
@@ -120,6 +122,14 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
+	// Index ImageStreams by status.publicDockerImageRepository
+	if err := mgr.GetFieldIndexer().IndexField(&imagev1.ImageStream{}, "status.publicDockerImageRepository", func(rawObj k8runtime.Object) []string {
+		imagestream := rawObj.(*imagev1.ImageStream)
+		return []string{imagestream.Status.PublicDockerImageRepository }
+	}); err != nil {
+		return err
+	}
+	
 	return nil
 }
 
@@ -430,6 +440,47 @@ func getStatusImageDigest(c client.Client, stackResource kabanerov1alpha2.Stack,
 
 // Retrieves the input image digest from the hosting repository.
 func retrieveImageDigest(c client.Client, namespace string, imgRegistry string, skipCertVerification bool, logr logr.Logger, image string) (string, error) {
+	// Check if the image is in the local registry - imagestream using the external route
+	iref, err := reference.ParseAnyReference(image)
+	if err != nil {
+		return "", err
+	}
+	named, err := reference.ParseNormalizedNamed(iref.String())
+	if err != nil {
+		return "", err
+	}
+
+	// ensure latest tag is added if not present
+	namedtagged := reference.TagNameOnly(named)
+
+	// domain & path (no tag/digest)
+	imagename := namedtagged.Name()
+
+	// tag
+	tagged, _ := namedtagged.(reference.Tagged)
+	imagetag := tagged.Tag()
+
+	imagestreamlist := &imagev1.ImageStreamList{}
+	err = c.List(context.TODO(), imagestreamlist, client.MatchingFields{"status.publicDockerImageRepository": imagename})
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			newError := fmt.Errorf("Unable to Get ImageStreamList while searching for image %v: %v", imagename, err)
+			return "", newError
+		}
+	}
+
+	// Should only have 1 ImageStream with a matching publicDockerImageRepository
+	// Get the Image sha256 for the tagged image
+	if len(imagestreamlist.Items) != 0 {
+		for _, tag := range imagestreamlist.Items[0].Status.Tags {
+			if tag.Tag == imagetag {
+				// The first TagEvent Item Image should be current, in form sha256:c19d8...
+				digesthex := tag.Items[0].Image[strings.LastIndex(tag.Items[0].Image, ":")+1:]
+				return digesthex, nil
+			}
+		}
+	}
+
 	// Search all secrets under the given namespace for the one containing the required hostname.
 	annotationKey := "kabanero.io/docker-"
 	secret, err := secret.GetMatchingSecret(c, namespace, sutils.SecretAnnotationFilter, imgRegistry, annotationKey)


### PR DESCRIPTION
Rolling the fix for #729 into release-0.9.  This was copied from PR #732 in the master branch.

Check to see if the stack image came from the internal registry.  If it did, get the image digest from the `ImageStream` and not by asking the internal registry for it.  this saves us the work of having to trust the internal registry's certificate, and authenticating.