### PR TITLE
v0.9.1-rc.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ IMAGE_SHA = $(lastword $(subst @, ,$(IMAGE_REPO_DIGEST)))
 REGISTRY_IMAGE_SHA = $(lastword $(subst @, ,$(REGISTRY_IMAGE_REPO_DIGEST)))
 
 # Current release (used for CSV management)
-CURRENT_RELEASE=0.9.0
+CURRENT_RELEASE=0.9.1
 
 # OS detection
 ifeq ($(OS),Windows_NT)

--- a/config/samples/default.yaml
+++ b/config/samples/default.yaml
@@ -3,7 +3,7 @@ kind: Kabanero
 metadata:
   name: kabanero
 spec:
-  version: "0.9.0"
+  version: "0.9.1"
   stacks:
     repositories:
     - name: central
@@ -11,6 +11,6 @@ spec:
         url: https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.9.0/kabanero-stack-hub-index.yaml
     pipelines:
     - id: default
-      sha256: 63b98242b60f6a1cf240b430d24659b9727d16013935553a798be1e6c122c479
+      sha256: 1348e90cc3269b6e65837f71011bef6f0dc662781a41442cb5ce3714cb91b890
       https:
-        url: https://github.com/kabanero-io/kabanero-pipelines/releases/download/0.9.0/default-kabanero-pipelines.tar.gz
+        url: https://github.com/kabanero-io/kabanero-pipelines/releases/download/0.9.1-rc.2/default-kabanero-pipelines.tar.gz

--- a/config/samples/full.yaml
+++ b/config/samples/full.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   # The platform version determines the desired version for all components, but those
   # can be overriden individually as well
-  version: "0.9.0"
+  version: "0.9.1"
 
   targetNamespaces:
   - kabanero
@@ -33,7 +33,7 @@ spec:
 
   collectionController:
     # Overrides the setting for version on this component
-    version: "0.9.0"
+    version: "0.9.1"
 
     # Overrides the image as a separate repository or tag
     repository: kabanero/kabanero-operator
@@ -44,7 +44,7 @@ spec:
 
   stackController:
     # Overrides the setting for version on this component
-    version: "0.9.0"
+    version: "0.9.1"
 
     # Overrides the image as a separate repository or tag
     repository: kabanero/kabanero-operator
@@ -69,7 +69,7 @@ spec:
 
   admissionControllerWebhook:
     # Overrides the setting for version on this component
-    version: "0.9.0"
+    version: "0.9.1"
 
     # Overrides the image as a separate repository or tag
     repository: kabanero/kabanero-operator
@@ -120,16 +120,16 @@ spec:
         url: https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.9.0/kabanero-stack-hub-index.yaml
     pipelines:
     - id: default
-      sha256: 63b98242b60f6a1cf240b430d24659b9727d16013935553a798be1e6c122c479
+      sha256: 1348e90cc3269b6e65837f71011bef6f0dc662781a41442cb5ce3714cb91b890
       https:
-        url: https://github.com/kabanero-io/kabanero-pipelines/releases/download/0.9.0/default-kabanero-pipelines.tar.gz
+        url: https://github.com/kabanero-io/kabanero-pipelines/releases/download/0.9.1-rc.2/default-kabanero-pipelines.tar.gz
 
   gitops:
     pipelines:
     - id: gitops
-      sha256: 683e8a05482a166ad4d76b6358227d3807a66e7edd8bc80483d6a88bca6c4095
+      sha256: 2b0f31cfb31f49454e68542deb301a98c409d8c2a233c6b8a32eb476090c2cd6
       https:
-        url: https://github.com/kabanero-io/kabanero-pipelines/releases/download/0.9.0/kabanero-gitops-pipelines.tar.gz
+        url: https://github.com/kabanero-io/kabanero-pipelines/releases/download/0.9.1-rc.2/kabanero-gitops-pipelines.tar.gz
 
   governancePolicy:
     # Provide governance configuration for all stacks managed by Kabanero. The allowed configuration policies are:

--- a/config/versions.yaml
+++ b/config/versions.yaml
@@ -9,10 +9,21 @@
 
 # When the Kabanero instance does not specify which version of Kabanero to use,
 # this is the value
-default: "0.9.0"
+default: "0.9.1"
 
 # Top level: relates Kabanero versions to software versions
 kabanero:
+- version: "0.9.1"
+  related-versions: 
+    cli-services: "0.9.0"
+    landing: "0.9.0"
+    events: "0.9.0"
+    collection-controller: "0.9.1"
+    stack-controller: "0.9.1"
+    admission-webhook: "0.9.1"
+    sso: "7.3.2"
+    codeready-workspaces: "0.9.0"
+
 - version: "0.9.0"
   related-versions: 
     cli-services: "0.9.0"
@@ -143,11 +154,16 @@ related-software:
       tag: "0.1"
 
   collection-controller: 
-  - version: "0.9.0"
+  - version: "0.9.1"
     orchestrations: "orchestrations/collection-controller/0.1"
     identifiers:
       repository: "FROM_POD"
       tag: "FROM_POD"
+  - version: "0.9.0"
+    orchestrations: "orchestrations/collection-controller/0.1"
+    identifiers:
+      repository: "kabanero/kabanero-operator"
+      tag: "0.9.0"
   - version: "0.8.0"
     orchestrations: "orchestrations/collection-controller/0.1"
     identifiers:
@@ -170,11 +186,16 @@ related-software:
       tag: "0.6.0"
 
   stack-controller: 
-  - version: "0.9.0"
+  - version: "0.9.1"
     orchestrations: "orchestrations/stack-controller/0.1"
     identifiers:
       repository: "FROM_POD"
       tag: "FROM_POD"
+  - version: "0.9.0"
+    orchestrations: "orchestrations/stack-controller/0.1"
+    identifiers:
+      repository: "kabanero/kabanero-operator"
+      tag: "0.9.0"
   - version: "0.8.0"
     orchestrations: "orchestrations/stack-controller/0.1"
     identifiers:
@@ -197,11 +218,16 @@ related-software:
       tag: "0.6.0"
 
   admission-webhook:
-  - version: "0.9.0"
+  - version: "0.9.1"
     orchestrations: "orchestrations/admission-webhook/0.2"
     identifiers:
       repository: "FROM_POD"
       tag: "FROM_POD"
+  - version: "0.9.0"
+    orchestrations: "orchestrations/admission-webhook/0.2"
+    identifiers:
+      repository: "kabanero/kabanero-operator"
+      tag: "0.9.0"
   - version: "0.8.0"
     orchestrations: "orchestrations/admission-webhook/0.2"
     identifiers:

--- a/registry/manifests/kabanero-operator/0.9.0/kabanero.io_collections_crd.yaml
+++ b/registry/manifests/kabanero-operator/0.9.0/kabanero.io_collections_crd.yaml
@@ -1,0 +1,207 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: collections.kabanero.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.creationTimestamp
+    description: CreationTimestamp is a timestamp representing the server time when
+      this object was created. It is not guaranteed to be set in happens-before order
+      across separate operations.
+    name: Age
+    type: date
+  - JSONPath: .status.status
+    description: Collection status.
+    name: Status
+    type: string
+  group: kabanero.io
+  names:
+    kind: Collection
+    listKind: CollectionList
+    plural: collections
+    singular: collection
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Collection is the Schema for the collections API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: CollectionSpec defines the desired composition of a Collection
+          properties:
+            desiredState:
+              type: string
+            name:
+              type: string
+            repositoryUrl:
+              type: string
+            skipCertVerification:
+              type: boolean
+            version:
+              type: string
+            versions:
+              items:
+                description: CollectionVersion defines the desired composition of
+                  a specific collection version.
+                properties:
+                  desiredState:
+                    type: string
+                  repositoryUrl:
+                    type: string
+                  skipCertVerification:
+                    type: boolean
+                  version:
+                    type: string
+                type: object
+              type: array
+          type: object
+        status:
+          description: CollectionStatus defines the observed state of a collection
+          properties:
+            activeLocation:
+              type: string
+            activePipelines:
+              items:
+                description: PipelineStatus defines the observed state of the assets
+                  located within a single pipeline .tar.gz.
+                properties:
+                  activeAssets:
+                    items:
+                      description: RepositoryAssetStatus defines the observed state
+                        of a single asset in a respository, in the collection.
+                      properties:
+                        assetDigest:
+                          type: string
+                        assetName:
+                          type: string
+                        group:
+                          type: string
+                        kind:
+                          type: string
+                        namespace:
+                          type: string
+                        status:
+                          type: string
+                        statusMessage:
+                          type: string
+                        version:
+                          type: string
+                      type: object
+                    type: array
+                  digest:
+                    type: string
+                  name:
+                    type: string
+                  url:
+                    type: string
+                required:
+                - digest
+                - name
+                - url
+                type: object
+              type: array
+            activeVersion:
+              type: string
+            availableLocation:
+              type: string
+            availableVersion:
+              type: string
+            images:
+              items:
+                description: Image defines a container image used by a collection
+                properties:
+                  id:
+                    type: string
+                  image:
+                    type: string
+                type: object
+              type: array
+            status:
+              type: string
+            statusMessage:
+              type: string
+            versions:
+              items:
+                description: CollectionVersionStatus defines the observed state of
+                  a specific collection version.
+                properties:
+                  images:
+                    items:
+                      description: Image defines a container image used by a collection
+                      properties:
+                        id:
+                          type: string
+                        image:
+                          type: string
+                      type: object
+                    type: array
+                  location:
+                    type: string
+                  pipelines:
+                    items:
+                      description: PipelineStatus defines the observed state of the
+                        assets located within a single pipeline .tar.gz.
+                      properties:
+                        activeAssets:
+                          items:
+                            description: RepositoryAssetStatus defines the observed
+                              state of a single asset in a respository, in the collection.
+                            properties:
+                              assetDigest:
+                                type: string
+                              assetName:
+                                type: string
+                              group:
+                                type: string
+                              kind:
+                                type: string
+                              namespace:
+                                type: string
+                              status:
+                                type: string
+                              statusMessage:
+                                type: string
+                              version:
+                                type: string
+                            type: object
+                          type: array
+                        digest:
+                          type: string
+                        name:
+                          type: string
+                        url:
+                          type: string
+                      required:
+                      - digest
+                      - name
+                      - url
+                      type: object
+                    type: array
+                  status:
+                    type: string
+                  statusMessage:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              type: array
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/registry/manifests/kabanero-operator/0.9.0/kabanero.io_kabaneros_crd.yaml
+++ b/registry/manifests/kabanero-operator/0.9.0/kabanero.io_kabaneros_crd.yaml
@@ -1,0 +1,977 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kabaneros.kabanero.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.creationTimestamp
+    description: CreationTimestamp is a timestamp representing the server time when
+      this object was created. It is not guaranteed to be set in happens-before order
+      across separate operations.
+    name: Age
+    type: date
+  - JSONPath: .status.kabaneroInstance.version
+    description: Kabanero operator instance version.
+    name: Version
+    type: string
+  - JSONPath: .status.kabaneroInstance.ready
+    description: Kabanero operator instance readiness status. The status is directly
+      correlated to the availability of the operator's resources dependencies.
+    name: Ready
+    type: string
+  group: kabanero.io
+  names:
+    kind: Kabanero
+    listKind: KabaneroList
+    plural: kabaneros
+    singular: kabanero
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KabaneroSpec defines the desired state of Kabanero
+            properties:
+              admissionControllerWebhook:
+                properties:
+                  image:
+                    type: string
+                  repository:
+                    type: string
+                  tag:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              che:
+                description: CheCustomizationSpec defines customization entries for
+                  Che.
+                properties:
+                  cheOperatorInstance:
+                    description: CheOperatorInstanceSpec defines customization entries
+                      for the Che operator instance.
+                    properties:
+                      cheWorkspaceClusterRole:
+                        type: string
+                    type: object
+                  enable:
+                    type: boolean
+                  kabaneroChe:
+                    description: KabaneroCheSpec defines customization entries for
+                      Kabanero Che.
+                    properties:
+                      image:
+                        type: string
+                      repository:
+                        type: string
+                      tag:
+                        type: string
+                      version:
+                        type: string
+                    type: object
+                type: object
+              cliServices:
+                description: KabaneroCliServicesCustomizationSpec defines customization
+                  entries for the Kabanero CLI.
+                properties:
+                  image:
+                    type: string
+                  repository:
+                    type: string
+                  sessionExpirationSeconds:
+                    type: string
+                  tag:
+                    type: string
+                  version:
+                    description: 'Future: Enable     bool   `json:"enable,omitempty"`'
+                    type: string
+                type: object
+              collectionController:
+                description: CollectionControllerSpec defines customization entried
+                  for the Kabanero collection controller.
+                properties:
+                  image:
+                    type: string
+                  repository:
+                    type: string
+                  tag:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              collections:
+                description: InstanceCollectionConfig defines the customization entries
+                  for a set of collections.
+                properties:
+                  repositories:
+                    items:
+                      description: RepositoryConfig defines customization entries
+                        for a collection.
+                      properties:
+                        activateDefaultCollections:
+                          type: boolean
+                        name:
+                          type: string
+                        skipCertVerification:
+                          type: boolean
+                        url:
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              events:
+                properties:
+                  enable:
+                    type: boolean
+                  image:
+                    type: string
+                  repository:
+                    type: string
+                  tag:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              github:
+                description: GithubConfig represents the Github information (public
+                  or GHE) where the organization and teams managing the collections
+                  live.  Members of the specified team in the specified organization
+                  will have admin authority in the Kabanero CLI.
+                properties:
+                  apiUrl:
+                    type: string
+                  organization:
+                    type: string
+                  teams:
+                    items:
+                      type: string
+                    type: array
+                type: object
+              landing:
+                description: KabaneroLandingCustomizationSpec defines customization
+                  entries for Kabanero landing page.
+                properties:
+                  enable:
+                    type: boolean
+                  version:
+                    type: string
+                type: object
+              targetNamespaces:
+                items:
+                  type: string
+                type: array
+              tekton:
+                description: TektonCustomizationSpec defines customization entries
+                  for Tekton
+                properties:
+                  disabled:
+                    type: boolean
+                  version:
+                    type: string
+                type: object
+              version:
+                type: string
+            type: object
+          status:
+            description: KabaneroStatus defines the observed state of the Kabanero
+              instance.
+            properties:
+              admissionControllerWebhook:
+                description: Admission webhook instance status
+                properties:
+                  errorMessage:
+                    type: string
+                  ready:
+                    type: string
+                type: object
+              appsody:
+                description: Appsody instance readiness status.
+                properties:
+                  errorMessage:
+                    type: string
+                  ready:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              che:
+                description: Che instance readiness status.
+                properties:
+                  cheOperator:
+                    description: CheOperatorStatus defines the observed status details
+                      of the Che operator.
+                    properties:
+                      version:
+                        type: string
+                    type: object
+                  errorMessage:
+                    type: string
+                  kabaneroChe:
+                    description: KabaneroCheStatus defines the observed status details
+                      of Kabanero Che.
+                    properties:
+                      version:
+                        type: string
+                    type: object
+                  kabaneroCheInstance:
+                    description: KabaneroCheInstanceStatus defines the observed status
+                      details of Che instance.
+                    properties:
+                      cheImage:
+                        type: string
+                      cheImageTag:
+                        type: string
+                      cheWorkspaceClusterRole:
+                        type: string
+                    type: object
+                  ready:
+                    type: string
+                type: object
+              cli:
+                description: CLI readiness status.
+                properties:
+                  errorMessage:
+                    type: string
+                  hostnames:
+                    items:
+                      type: string
+                    type: array
+                  ready:
+                    type: string
+                type: object
+              collectionController:
+                description: Kabanero collection controller readiness status.
+                properties:
+                  errorMessage:
+                    type: string
+                  ready:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              events:
+                description: Events instance status
+                properties:
+                  errorMessage:
+                    type: string
+                  hostnames:
+                    items:
+                      type: string
+                    type: array
+                  ready:
+                    type: string
+                type: object
+              kabaneroInstance:
+                description: Kabanero operator instance readiness status. The status
+                  is directly correlated to the availability of resources dependencies.
+                properties:
+                  errorMessage:
+                    type: string
+                  ready:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              kappnav:
+                description: Kabanero Application Navigator instance readiness status.
+                properties:
+                  apiLocations:
+                    items:
+                      type: string
+                    type: array
+                  errorMessage:
+                    type: string
+                  ready:
+                    type: string
+                  uiLocations:
+                    items:
+                      type: string
+                    type: array
+                type: object
+              knativeEventing:
+                description: Knative eventing instance readiness status.
+                properties:
+                  errorMessage:
+                    type: string
+                  ready:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              landing:
+                description: Kabanero Landing page readiness status.
+                properties:
+                  errorMessage:
+                    type: string
+                  ready:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              serverless:
+                description: OpenShift serverless operator status.
+                properties:
+                  errorMessage:
+                    type: string
+                  knativeServing:
+                    description: KnativeServingStatus defines the observed status
+                      details of Knative Serving.
+                    properties:
+                      errorMessage:
+                        type: string
+                      ready:
+                        type: string
+                      version:
+                        type: string
+                    type: object
+                  ready:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              tekton:
+                description: Tekton instance readiness status.
+                properties:
+                  errorMessage:
+                    type: string
+                  ready:
+                    type: string
+                  version:
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: false
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KabaneroSpec defines the desired state of Kabanero
+            properties:
+              admissionControllerWebhook:
+                properties:
+                  image:
+                    type: string
+                  repository:
+                    type: string
+                  tag:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              cliServices:
+                description: KabaneroCliServicesCustomizationSpec defines customization
+                  entries for the Kabanero CLI.
+                properties:
+                  image:
+                    type: string
+                  repository:
+                    type: string
+                  sessionExpirationSeconds:
+                    type: string
+                  tag:
+                    type: string
+                  version:
+                    description: 'Future: Enable     bool   `json:"enable,omitempty"`'
+                    type: string
+                type: object
+              codeReadyWorkspaces:
+                description: CRWCustomizationSpec defines customization entries for
+                  codeready-workspaces.
+                properties:
+                  enable:
+                    type: boolean
+                  operator:
+                    description: CRWOperatorSpec defines customization entries for
+                      the codeready-workspaces operator.
+                    properties:
+                      customResourceInstance:
+                        description: CRWOperatorCustomResourceSpec defines custom
+                          resource customization entries for the codeready-workspaces
+                          operator.
+                        properties:
+                          cheWorkspaceClusterRole:
+                            type: string
+                          devFileRegistryImage:
+                            description: CWRCustomResourceDevFileRegImage defines
+                              DevFileRegistryImage custom resource customization for
+                              the codeready-workspaces operator.
+                            properties:
+                              image:
+                                type: string
+                              repository:
+                                type: string
+                              tag:
+                                type: string
+                              version:
+                                type: string
+                            type: object
+                          openShiftOAuth:
+                            type: boolean
+                          selfSignedCert:
+                            type: boolean
+                          tlsSupport:
+                            type: boolean
+                        type: object
+                    type: object
+                type: object
+              collectionController:
+                description: CollectionControllerSpec defines customization entried
+                  for the Kabanero collection controller.
+                properties:
+                  image:
+                    type: string
+                  repository:
+                    type: string
+                  tag:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              events:
+                properties:
+                  enable:
+                    type: boolean
+                  image:
+                    type: string
+                  repository:
+                    type: string
+                  tag:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              github:
+                description: GithubConfig represents the Github information (public
+                  or GHE) where the organization and teams managing the stacks live.  Members
+                  of the specified team in the specified organization will have admin
+                  authority in the Kabanero CLI.
+                properties:
+                  apiUrl:
+                    type: string
+                  organization:
+                    type: string
+                  teams:
+                    items:
+                      type: string
+                    type: array
+                type: object
+              gitops:
+                properties:
+                  pipelines:
+                    items:
+                      description: PipelineSpec defines a set of pipelines and associated
+                        resources for a component.
+                      properties:
+                        gitRelease:
+                          description: GitReleaseSpec defines customization entries
+                            for a Git release.
+                          properties:
+                            assetName:
+                              type: string
+                            hostname:
+                              type: string
+                            organization:
+                              type: string
+                            project:
+                              type: string
+                            release:
+                              type: string
+                            skipCertVerification:
+                              type: boolean
+                          type: object
+                        https:
+                          description: HttpsProtocolFile defines how to retrieve a
+                            file over https
+                          properties:
+                            skipCertVerification:
+                              type: boolean
+                            url:
+                              type: string
+                          type: object
+                        id:
+                          type: string
+                        sha256:
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              governancePolicy:
+                description: GovernancePolicyConfig defines customization entries
+                  for governance policies.
+                properties:
+                  stackPolicy:
+                    type: string
+                type: object
+              landing:
+                description: KabaneroLandingCustomizationSpec defines customization
+                  entries for Kabanero landing page.
+                properties:
+                  enable:
+                    type: boolean
+                  image:
+                    type: string
+                  repository:
+                    type: string
+                  tag:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              sso:
+                properties:
+                  adminSecretName:
+                    type: string
+                  enable:
+                    type: boolean
+                  provider:
+                    type: string
+                type: object
+              stackController:
+                description: StackControllerSpec defines customization entried for
+                  the Kabanero stack controller.
+                properties:
+                  image:
+                    type: string
+                  repository:
+                    type: string
+                  tag:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              stacks:
+                description: InstanceStackConfig defines the customization entries
+                  for a set of stacks.
+                properties:
+                  pipelines:
+                    items:
+                      description: PipelineSpec defines a set of pipelines and associated
+                        resources for a component.
+                      properties:
+                        gitRelease:
+                          description: GitReleaseSpec defines customization entries
+                            for a Git release.
+                          properties:
+                            assetName:
+                              type: string
+                            hostname:
+                              type: string
+                            organization:
+                              type: string
+                            project:
+                              type: string
+                            release:
+                              type: string
+                            skipCertVerification:
+                              type: boolean
+                          type: object
+                        https:
+                          description: HttpsProtocolFile defines how to retrieve a
+                            file over https
+                          properties:
+                            skipCertVerification:
+                              type: boolean
+                            url:
+                              type: string
+                          type: object
+                        id:
+                          type: string
+                        sha256:
+                          type: string
+                      type: object
+                    type: array
+                  repositories:
+                    items:
+                      description: RepositoryConfig defines customization entries
+                        for a stack.
+                      properties:
+                        gitRelease:
+                          description: GitReleaseSpec defines customization entries
+                            for a Git release.
+                          properties:
+                            assetName:
+                              type: string
+                            hostname:
+                              type: string
+                            organization:
+                              type: string
+                            project:
+                              type: string
+                            release:
+                              type: string
+                            skipCertVerification:
+                              type: boolean
+                          type: object
+                        https:
+                          description: HttpsProtocolFile defines how to retrieve a
+                            file over https
+                          properties:
+                            skipCertVerification:
+                              type: boolean
+                            url:
+                              type: string
+                          type: object
+                        name:
+                          type: string
+                        pipelines:
+                          items:
+                            description: PipelineSpec defines a set of pipelines and
+                              associated resources for a component.
+                            properties:
+                              gitRelease:
+                                description: GitReleaseSpec defines customization
+                                  entries for a Git release.
+                                properties:
+                                  assetName:
+                                    type: string
+                                  hostname:
+                                    type: string
+                                  organization:
+                                    type: string
+                                  project:
+                                    type: string
+                                  release:
+                                    type: string
+                                  skipCertVerification:
+                                    type: boolean
+                                type: object
+                              https:
+                                description: HttpsProtocolFile defines how to retrieve
+                                  a file over https
+                                properties:
+                                  skipCertVerification:
+                                    type: boolean
+                                  url:
+                                    type: string
+                                type: object
+                              id:
+                                type: string
+                              sha256:
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    type: array
+                  skipRegistryCertVerification:
+                    type: boolean
+                type: object
+              targetNamespaces:
+                items:
+                  type: string
+                type: array
+              triggers:
+                items:
+                  description: TriggerSpec defines the sets of default triggers for
+                    the stacks
+                  properties:
+                    gitRelease:
+                      description: GitReleaseSpec defines customization entries for
+                        a Git release.
+                      properties:
+                        assetName:
+                          type: string
+                        hostname:
+                          type: string
+                        organization:
+                          type: string
+                        project:
+                          type: string
+                        release:
+                          type: string
+                        skipCertVerification:
+                          type: boolean
+                      type: object
+                    https:
+                      description: HttpsProtocolFile defines how to retrieve a file
+                        over https
+                      properties:
+                        skipCertVerification:
+                          type: boolean
+                        url:
+                          type: string
+                      type: object
+                    id:
+                      type: string
+                    sha256:
+                      type: string
+                  type: object
+                type: array
+              version:
+                type: string
+            type: object
+          status:
+            description: KabaneroStatus defines the observed state of the Kabanero
+              instance.
+            properties:
+              admissionControllerWebhook:
+                description: Admission webhook instance status
+                properties:
+                  message:
+                    type: string
+                  ready:
+                    type: string
+                type: object
+              appsody:
+                description: Appsody instance readiness status.
+                properties:
+                  message:
+                    type: string
+                  ready:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              cli:
+                description: CLI readiness status.
+                properties:
+                  hostnames:
+                    items:
+                      type: string
+                    type: array
+                  message:
+                    type: string
+                  ready:
+                    type: string
+                type: object
+              codereadyWorkspaces:
+                description: Codeready-workspaces instance readiness status.
+                properties:
+                  message:
+                    type: string
+                  operator:
+                    description: CRWOperatorStatus defines the observed status details
+                      of the codeready-workspaces operator.
+                    properties:
+                      instance:
+                        description: CRWInstanceStatus defines the observed status
+                          details of the codeready-workspaces operator custom resource.
+                        properties:
+                          cheWorkspaceClusterRole:
+                            type: string
+                          devfileRegistryImage:
+                            type: string
+                          openShiftOAuth:
+                            type: boolean
+                          selfSignedCert:
+                            type: boolean
+                          tlsSupport:
+                            type: boolean
+                        required:
+                        - cheWorkspaceClusterRole
+                        - devfileRegistryImage
+                        - openShiftOAuth
+                        - selfSignedCert
+                        - tlsSupport
+                        type: object
+                      version:
+                        type: string
+                    type: object
+                  ready:
+                    type: string
+                type: object
+              collectionController:
+                description: Kabanero collection controller readiness status.
+                properties:
+                  message:
+                    type: string
+                  ready:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              events:
+                description: Events instance status
+                properties:
+                  hostnames:
+                    items:
+                      type: string
+                    type: array
+                  message:
+                    type: string
+                  ready:
+                    type: string
+                type: object
+              gitops:
+                description: The status of the gitops pipelines
+                properties:
+                  message:
+                    type: string
+                  pipelines:
+                    items:
+                      description: PipelineStatus defines the observed state of the
+                        assets located within a single pipeline .tar.gz.
+                      properties:
+                        activeAssets:
+                          items:
+                            description: RepositoryAssetStatus defines the observed
+                              state of a single asset in a pipelines respository.
+                            properties:
+                              assetDigest:
+                                type: string
+                              assetName:
+                                type: string
+                              group:
+                                type: string
+                              kind:
+                                type: string
+                              namespace:
+                                type: string
+                              status:
+                                type: string
+                              statusMessage:
+                                type: string
+                              version:
+                                type: string
+                            type: object
+                          type: array
+                        digest:
+                          type: string
+                        gitRelease:
+                          description: GitReleaseInfo is all of the GitReleaseSpec
+                            information, minus the "skip cert verification" information,
+                            which is not relevant for status.
+                          properties:
+                            assetName:
+                              type: string
+                            hostname:
+                              type: string
+                            organization:
+                              type: string
+                            project:
+                              type: string
+                            release:
+                              type: string
+                          type: object
+                        name:
+                          type: string
+                        url:
+                          type: string
+                      type: object
+                    type: array
+                  ready:
+                    type: string
+                type: object
+              kabaneroInstance:
+                description: Kabanero operator instance readiness status. The status
+                  is directly correlated to the availability of resources dependencies.
+                properties:
+                  message:
+                    type: string
+                  ready:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              kappnav:
+                description: Kabanero Application Navigator instance readiness status.
+                properties:
+                  apiLocations:
+                    items:
+                      type: string
+                    type: array
+                  message:
+                    type: string
+                  ready:
+                    type: string
+                  uiLocations:
+                    items:
+                      type: string
+                    type: array
+                type: object
+              landing:
+                description: Kabanero Landing page readiness status.
+                properties:
+                  message:
+                    type: string
+                  ready:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              serverless:
+                description: OpenShift serverless operator status.
+                properties:
+                  knativeServing:
+                    description: KnativeServingStatus defines the observed status
+                      details of Knative Serving.
+                    properties:
+                      message:
+                        type: string
+                      ready:
+                        type: string
+                      version:
+                        type: string
+                    type: object
+                  message:
+                    type: string
+                  ready:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              sso:
+                description: SSO server status
+                properties:
+                  configured:
+                    type: string
+                  message:
+                    type: string
+                  ready:
+                    type: string
+                type: object
+              stackController:
+                description: Kabanero stack controller readiness status.
+                properties:
+                  message:
+                    type: string
+                  ready:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              tekton:
+                description: Tekton instance readiness status.
+                properties:
+                  message:
+                    type: string
+                  ready:
+                    type: string
+                  version:
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true

--- a/registry/manifests/kabanero-operator/0.9.0/kabanero.io_stacks_crd.yaml
+++ b/registry/manifests/kabanero-operator/0.9.0/kabanero.io_stacks_crd.yaml
@@ -1,0 +1,210 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: stacks.kabanero.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.creationTimestamp
+    description: CreationTimestamp is a timestamp representing the server time when
+      this object was created. It is not guaranteed to be set in happens-before order
+      across separate operations.
+    name: Age
+    type: date
+  - JSONPath: .status.summary
+    description: Stack summary.
+    name: Summary
+    type: string
+  group: kabanero.io
+  names:
+    kind: Stack
+    listKind: StackList
+    plural: stacks
+    singular: stack
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Stack is the Schema for the stack API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: StackSpec defines the desired composition of a Stack
+          properties:
+            name:
+              type: string
+            versions:
+              items:
+                description: StackVersion defines the desired composition of a specific
+                  stack version.
+                properties:
+                  desiredState:
+                    type: string
+                  images:
+                    items:
+                      description: Image defines a container image used by a stack
+                      properties:
+                        id:
+                          type: string
+                        image:
+                          type: string
+                      type: object
+                    type: array
+                  pipelines:
+                    items:
+                      description: PipelineSpec defines a set of pipelines and associated
+                        resources for a component.
+                      properties:
+                        gitRelease:
+                          description: GitReleaseSpec defines customization entries
+                            for a Git release.
+                          properties:
+                            assetName:
+                              type: string
+                            hostname:
+                              type: string
+                            organization:
+                              type: string
+                            project:
+                              type: string
+                            release:
+                              type: string
+                            skipCertVerification:
+                              type: boolean
+                          type: object
+                        https:
+                          description: HttpsProtocolFile defines how to retrieve a
+                            file over https
+                          properties:
+                            skipCertVerification:
+                              type: boolean
+                            url:
+                              type: string
+                          type: object
+                        id:
+                          type: string
+                        sha256:
+                          type: string
+                      type: object
+                    type: array
+                  skipCertVerification:
+                    type: boolean
+                  skipRegistryCertVerification:
+                    type: boolean
+                  version:
+                    type: string
+                type: object
+              type: array
+          type: object
+        status:
+          description: StackStatus defines the observed state of a stack
+          properties:
+            statusMessage:
+              type: string
+            summary:
+              type: string
+            versions:
+              items:
+                description: StackVersionStatus defines the observed state of a specific
+                  stack version.
+                properties:
+                  images:
+                    items:
+                      description: ImageStatus defines a container image status used
+                        by a stack
+                      properties:
+                        digest:
+                          description: ImageDigest defines a container image digest
+                            used by a stack
+                          properties:
+                            activation:
+                              type: string
+                            message:
+                              type: string
+                          type: object
+                        id:
+                          type: string
+                        image:
+                          type: string
+                      type: object
+                    type: array
+                  location:
+                    type: string
+                  pipelines:
+                    items:
+                      description: PipelineStatus defines the observed state of the
+                        assets located within a single pipeline .tar.gz.
+                      properties:
+                        activeAssets:
+                          items:
+                            description: RepositoryAssetStatus defines the observed
+                              state of a single asset in a pipelines respository.
+                            properties:
+                              assetDigest:
+                                type: string
+                              assetName:
+                                type: string
+                              group:
+                                type: string
+                              kind:
+                                type: string
+                              namespace:
+                                type: string
+                              status:
+                                type: string
+                              statusMessage:
+                                type: string
+                              version:
+                                type: string
+                            type: object
+                          type: array
+                        digest:
+                          type: string
+                        gitRelease:
+                          description: GitReleaseInfo is all of the GitReleaseSpec
+                            information, minus the "skip cert verification" information,
+                            which is not relevant for status.
+                          properties:
+                            assetName:
+                              type: string
+                            hostname:
+                              type: string
+                            organization:
+                              type: string
+                            project:
+                              type: string
+                            release:
+                              type: string
+                          type: object
+                        name:
+                          type: string
+                        url:
+                          type: string
+                      type: object
+                    type: array
+                  status:
+                    type: string
+                  statusMessage:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              type: array
+          type: object
+      type: object
+  version: v1alpha2
+  versions:
+  - name: v1alpha2
+    served: true
+    storage: true

--- a/registry/manifests/kabanero-operator/0.9.1/kabanero-operator.v0.9.1.clusterserviceversion.yaml
+++ b/registry/manifests/kabanero-operator/0.9.1/kabanero-operator.v0.9.1.clusterserviceversion.yaml
@@ -1,16 +1,16 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: kabanero-operator.v0.9.0
+  name: kabanero-operator.v0.9.1
   namespace: placeholder
   annotations:
     capabilities: Basic Install
     categories: "Integration & Delivery"
     certified: "false"
-    containerImage: kabanero/kabanero-operator@sha256:3ec321bb84127e108d4f65b6d2c97f102072b7622fa545ce1a78ef6935c2f3a8
+    containerImage: kabanero/kabanero-operator:latest
     createdAt: 2019-11-19T12:00:00.000-0500
     description: Bringings together foundational open source technologies into a modern microservices-based framework.
-    olm.skipRange: '>=0.6.1 <0.9.0'
+    olm.skipRange: '>=0.6.1 <0.9.1'
     repository: https://github.com/kabanero-io/kabanero-operator
     support: IBM
     alm-examples: |-
@@ -22,7 +22,7 @@ metadata:
             "name": "kabanero"
           },
           "spec": {
-            "version": "0.9.0",
+            "version": "0.9.1",
             "stacks": {
               "repositories": [
                 {
@@ -35,9 +35,9 @@ metadata:
               "pipelines": [
                 {
                   "id": "default",
-                  "sha256": "63b98242b60f6a1cf240b430d24659b9727d16013935553a798be1e6c122c479",
+                  "sha256": "1348e90cc3269b6e65837f71011bef6f0dc662781a41442cb5ce3714cb91b890",
                   "https": {
-                    "url": "https://github.com/kabanero-io/kabanero-pipelines/releases/download/0.9.0/default-kabanero-pipelines.tar.gz"
+                    "url": "https://github.com/kabanero-io/kabanero-pipelines/releases/download/0.9.1-rc.2/default-kabanero-pipelines.tar.gz"
                   }
                 }
               ]
@@ -68,9 +68,9 @@ metadata:
               { "version": "0.2.11",
                 "pipelines": [
                   { "id": "default",
-                    "sha256": "63b98242b60f6a1cf240b430d24659b9727d16013935553a798be1e6c122c479",
+                    "sha256": "1348e90cc3269b6e65837f71011bef6f0dc662781a41442cb5ce3714cb91b890",
                     "https": {
-                      "url": "https://github.com/kabanero-io/kabanero-pipelines/releases/download/0.9.0/default-kabanero-pipelines.tar.gz"
+                      "url": "https://github.com/kabanero-io/kabanero-pipelines/releases/download/0.9.1-rc.2/default-kabanero-pipelines.tar.gz"
                     }
                   }
                 ],
@@ -88,8 +88,8 @@ spec:
   minKubeVersion: 1.16.0
   apiservicedefinitions: {}
   maturity: alpha
-  version: 0.9.0
-  replaces: kabanero-operator.v0.8.0
+  version: 0.9.1
+  replaces: kabanero-operator.v0.9.0
   displayName: Kabanero Operator
   description: |
     The Kabanero operator is used to manage Kabanero Foundation instances on your Open Shift or Kubernetes cluster.
@@ -283,7 +283,7 @@ spec:
                 name: kabanero-operator
                 app.kubernetes.io/name: kabanero
                 app.kubernetes.io/instance:
-                app.kubernetes.io/version: '0.9.0'
+                app.kubernetes.io/version: '0.9.1'
                 app.kubernetes.io/component: operator
                 app.kubernetes.io/part-of: kabanero
                 app.kubernetes.io/managed-by: olm
@@ -302,7 +302,7 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: kabanero-operator
-                image: kabanero/kabanero-operator@sha256:3ec321bb84127e108d4f65b6d2c97f102072b7622fa545ce1a78ef6935c2f3a8
+                image: kabanero/kabanero-operator:latest
                 imagePullPolicy: Always
                 name: kabanero-operator
                 resources: {}
@@ -332,12 +332,3 @@ spec:
     type: AllNamespaces
   provider:
     name: IBM
-  relatedImages:
-  - image: kabanero/kabanero-command-line-services:0.9.0
-    name: cli-services-0.9.0
-  - image: kabanero/landing:0.9.0
-    name: landing-0.9.0
-  - image: kabanero/events-operator:0.1.0
-    name: events-0.9.0
-  - image: kabanero/che-devfile-registry:0.11.0
-    name: codeready-workspaces-0.9.0

--- a/registry/manifests/kabanero-operator/kabanero-operator-package.yaml
+++ b/registry/manifests/kabanero-operator/kabanero-operator-package.yaml
@@ -15,6 +15,6 @@ channels:
 - name: release-0.8
   currentCSV: kabanero-operator.v0.8.0
 - name: release-0.9
-  currentCSV: kabanero-operator.v0.9.0
+  currentCSV: kabanero-operator.v0.9.1
 defaultChannel: release-0.9
 


### PR DESCRIPTION
There were a couple new wrinkles this time around:
1) Had to manually generate `relatedImages` as the only place the previous version existed was inside the CSV inside the kabanero-operator-registry:0.9.0 image.  We should consider a more convenient place to stash this.  It wasn't a lot of trouble to re-generate it though.
2) Had to update the image in the 0.9.0 CSV using the digest as opposed to the tag as was done in previous releases.

