### PR TITLE
error state on bad pipeline sha

### DIFF
--- a/pkg/controller/stack/stack_controller.go
+++ b/pkg/controller/stack/stack_controller.go
@@ -344,6 +344,7 @@ func reconcileActiveVersions(stackResource *kabanerov1alpha2.Stack, c client.Cli
 					// If we had a problem loading the pipeline manifests, say so.
 					if value.ManifestError != nil {
 						newStackVersionStatus.StatusMessage = value.ManifestError.Error()
+						newStackVersionStatus.Status = kabanerov1alpha2.StackStateError
 					}
 				}
 			}


### PR DESCRIPTION
Fix produces state
@mtamboli 

```
status:
  summary: '[ 0.2.12: error ]'
  versions:
  - images:
    - digest:
        activation: d45808722cb8fe7f27280887e3c2e22faf19a24630fe428111280266bc15764f
      id: Open Liberty
      image: docker.io/appsody/java-openliberty
    pipelines:
    - digest: 63b98242b60f6a1cf240b430d24659b9727d16013935553a798be1e6c122c479
      gitRelease: {}
      name: default
      url: https://github.com/kabanero-io/kabanero-pipelines/releases/download/0.8.0/default-kabanero-pipelines.tar.gz
    status: error
    statusMessage: 'Index checksum: 63b98242b60f6a1cf240b430d24659b9727d16013935553a798be1e6c122c479
      not match download checksum: 3f3e440b3eed24273fd43c40208fdd95de6eadeb82b7bb461f52e1e5da7e239d
      for Pipeline Name default'
    version: 0.2.12
```