### PR TITLE
kabanero-pipeline-deploy-role: add kafkatopics

### DIFF
--- a/deploy/kabanero-customresources.yaml
+++ b/deploy/kabanero-customresources.yaml
@@ -332,6 +332,7 @@ rules:
   - kafka.strimzi.io
   resources:
   - kafkas
+  - kafkatopics
   verbs:
   - get
   - list


### PR DESCRIPTION
If it's possible to sneak this into 0.9.1 that would be great, but it's not stopship.