### PR TITLE
Revert "v1alpha1 served false"

### DIFF
--- a/deploy/crds/kabanero.io_collections_crd.yaml
+++ b/deploy/crds/kabanero.io_collections_crd.yaml
@@ -203,5 +203,5 @@ spec:
   version: v1alpha1
   versions:
   - name: v1alpha1
-    served: false
+    served: true
     storage: true

--- a/deploy/crds/kabanero.io_kabaneros_crd.yaml
+++ b/deploy/crds/kabanero.io_kabaneros_crd.yaml
@@ -358,7 +358,7 @@ spec:
                 type: object
             type: object
         type: object
-    served: false
+    served: true
     storage: false
   - name: v1alpha2
     schema:


### PR DESCRIPTION
Reverts kabanero-io/kabanero-operator#755
The collection controller pod doesn't start if the collection v1alpha1 CRD is not being served.